### PR TITLE
chore: add open source standards + refresh README

### DIFF
--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -1,0 +1,43 @@
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Install dependencies" },
+          { "context": "Format check (Prettier)" },
+          { "context": "Security audit (pnpm audit)" },
+          { "context": "Build packages" },
+          { "context": "Build Storybook React" },
+          { "context": "Build Storybook Angular" },
+          { "context": "Build site Astro" },
+          { "context": "Build demo-portail" }
+        ]
+      }
+    }
+  ]
+}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,149 @@
+# Code de conduite des contributeurs
+
+## Notre engagement
+
+En tant que membres, contributeurs et responsables de ce projet, nous
+nous engageons à faire de la participation à notre communauté une
+expérience exempte de harcèlement pour tous, indépendamment de l'âge,
+de la taille du corps, du handicap visible ou invisible, de
+l'appartenance ethnique, des caractéristiques sexuelles, de
+l'identité et de l'expression de genre, du niveau d'expérience, de
+l'éducation, du statut socio-économique, de la nationalité, de
+l'apparence personnelle, de la race, de la caste, de la couleur, de
+la religion, ou de l'identité et de l'orientation sexuelles.
+
+Nous nous engageons à agir et à interagir de manière à contribuer à
+une communauté ouverte, accueillante, diversifiée, inclusive et
+saine.
+
+## Nos standards
+
+Voici des exemples de comportements qui contribuent à un environnement
+positif pour notre communauté :
+
+- Faire preuve d'empathie et de bienveillance envers les autres
+- Respecter les opinions, points de vue et expériences différents
+- Donner et accepter avec grâce des retours constructifs
+- Assumer ses responsabilités et présenter des excuses aux personnes
+  affectées par nos erreurs, et apprendre de l'expérience
+- Se concentrer sur ce qui est le mieux non seulement pour nous en
+  tant qu'individus, mais aussi pour la communauté dans son ensemble
+
+Voici des exemples de comportements inacceptables :
+
+- L'utilisation de langage ou d'imagerie sexualisés, et l'attention
+  ou les avances sexuelles de toute nature
+- Les commentaires insultants ou désobligeants (« trolling »), et les
+  attaques personnelles ou politiques
+- Le harcèlement public ou privé
+- La publication d'informations privées d'autrui, telles qu'une
+  adresse physique ou électronique, sans leur autorisation explicite
+- Toute autre conduite qui pourrait raisonnablement être considérée
+  comme inappropriée dans un cadre professionnel
+
+## Responsabilités d'application
+
+Les responsables de la communauté sont chargés de clarifier et faire
+respecter nos standards de comportement acceptable et prendront des
+mesures correctives appropriées et équitables en réponse à tout
+comportement qu'ils jugent inapproprié, menaçant, offensant ou
+nuisible.
+
+Les responsables de la communauté ont le droit et la responsabilité
+de supprimer, modifier ou rejeter les commentaires, commits, code,
+modifications du wiki, issues et autres contributions qui ne sont pas
+alignés avec ce code de conduite, et communiqueront les raisons des
+décisions de modération lorsque cela est approprié.
+
+## Périmètre
+
+Ce code de conduite s'applique à tous les espaces communautaires, et
+s'applique également lorsqu'un individu représente officiellement la
+communauté dans des espaces publics. Des exemples de représentation
+de notre communauté incluent l'utilisation d'une adresse e-mail
+officielle, la publication via un compte de médias sociaux officiel,
+ou le fait d'agir en tant que représentant désigné lors d'un
+événement en ligne ou hors ligne.
+
+## Application
+
+Les cas de comportement abusif, harcelant ou autrement inacceptable
+peuvent être signalés aux responsables de la communauté chargés de
+l'application du code à l'adresse suivante :
+
+**leonard.tavae@administration.gov.pf**
+
+Toutes les plaintes seront examinées et étudiées rapidement et
+équitablement.
+
+Tous les responsables de la communauté sont tenus de respecter la vie
+privée et la sécurité du déclarant de tout incident.
+
+## Lignes directrices d'application
+
+Les responsables de la communauté suivront ces lignes directrices
+d'impact communautaire pour déterminer les conséquences de toute
+action qu'ils jugent contraire au présent code de conduite :
+
+### 1. Correction
+
+**Impact sur la communauté** : utilisation d'un langage inapproprié
+ou tout autre comportement jugé non professionnel ou indésirable
+dans la communauté.
+
+**Conséquence** : un avertissement écrit privé de la part des
+responsables de la communauté, clarifiant la nature de la violation
+et expliquant pourquoi le comportement était inapproprié. Des excuses
+publiques peuvent être demandées.
+
+### 2. Avertissement
+
+**Impact sur la communauté** : une violation par un seul incident ou
+une série d'actions.
+
+**Conséquence** : un avertissement avec des conséquences pour la
+poursuite du comportement. Aucune interaction avec les personnes
+concernées, y compris les interactions non sollicitées avec ceux qui
+appliquent le code de conduite, pendant une période déterminée. Cela
+inclut le fait d'éviter les interactions dans les espaces
+communautaires ainsi que les canaux externes comme les médias
+sociaux. La violation de ces conditions peut entraîner un
+bannissement temporaire ou permanent.
+
+### 3. Bannissement temporaire
+
+**Impact sur la communauté** : une violation grave des standards
+communautaires, y compris un comportement inapproprié soutenu.
+
+**Conséquence** : un bannissement temporaire de toute interaction ou
+communication publique avec la communauté pendant une période
+déterminée. Aucune interaction publique ou privée avec les personnes
+concernées, y compris les interactions non sollicitées avec ceux qui
+appliquent le code de conduite, n'est autorisée pendant cette
+période. La violation de ces conditions peut entraîner un
+bannissement permanent.
+
+### 4. Bannissement permanent
+
+**Impact sur la communauté** : démontrer un schéma de violation des
+standards de la communauté, y compris un comportement inapproprié
+soutenu, le harcèlement d'un individu ou l'agression ou le dénigrement
+de catégories d'individus.
+
+**Conséquence** : un bannissement permanent de toute forme
+d'interaction publique au sein de la communauté.
+
+## Attribution
+
+Ce code de conduite est adapté du
+[Contributor Covenant](https://www.contributor-covenant.org), version
+2.1, disponible à l'adresse
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Les lignes directrices d'impact communautaire ont été inspirées par
+[l'échelle d'application du code de conduite de Mozilla](https://github.com/mozilla/diversity).
+
+Pour des réponses aux questions courantes sur ce code de conduite,
+consultez la FAQ à
+<https://www.contributor-covenant.org/faq>. Des traductions sont
+disponibles à <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,208 @@
+# Contribuer à Ori
+
+Merci de l'intérêt porté à Ori, le design system des services
+administratifs de la Polynésie française.
+
+Ori est principalement développé par et pour l'administration PF, mais
+les contributions externes sont les bienvenues, en particulier sur les
+sujets transverses (accessibilité, performance, documentation,
+correctifs de bugs).
+
+## Avant de contribuer
+
+### Niveau de support
+
+Ori est maintenu en mode **best-effort, sans engagement de SLA**. Les
+contributions sont filtrées par les besoins des services PF qui
+consomment le DS. Une demande qui ne sert pas un usage administratif
+polynésien peut être refusée même si techniquement valide.
+
+### Avant d'ouvrir une PR significative
+
+Pour toute contribution autre qu'un correctif évident (typo, lien
+cassé, classe CSS oubliée), **ouvrir une issue d'abord** pour discuter
+du besoin. Cela évite de produire du code qui ne sera pas mergé pour
+des raisons de design ou de stratégie.
+
+### Code de conduite
+
+Ce projet suit le [Contributor Covenant](./CODE_OF_CONDUCT.md).
+Toute interaction avec le projet (issues, PR, discussions) y est
+soumise.
+
+## Mise en place de l'environnement
+
+### Prérequis
+
+- **Node.js 20.11+** (recommandé : Node 24 LTS, comme la CI)
+- **pnpm 10.29+** (gestionnaire de paquets — `corepack enable && corepack prepare pnpm@latest --activate`)
+- **Git**
+- **Docker** (optionnel, pour tester la CI en local via `act`)
+
+### Installation
+
+```bash
+git clone https://github.com/govpf/ori.git
+cd ori
+pnpm install
+```
+
+### Builds des packages
+
+Tous les packages doivent être buildés avant de pouvoir lancer les
+applications consommatrices (Storybooks, demo-portail, site Astro) :
+
+```bash
+pnpm -r --filter "./packages/*" build
+```
+
+### Lancer les apps en développement
+
+```bash
+pnpm storybook:react       # Storybook React, port 6006
+pnpm storybook:angular     # Storybook Angular, port 6008
+pnpm demo:portail          # Demo end-to-end portail usager, port 5174
+pnpm playground:static     # HTML pur consommant ori-css, port 4173
+```
+
+### Tester la CI en local
+
+Le repo embarque un wrapper Docker pour exécuter les workflows GitHub
+Actions sans les pousser :
+
+```bash
+./tools/act/run.sh push                  # tout le pipeline
+./tools/act/run.sh push -j format        # un job spécifique
+```
+
+Voir [tools/act/README.md](./tools/act/README.md) pour le détail.
+
+## Process de contribution
+
+### 1. Fork et branche
+
+```bash
+gh repo fork govpf/ori --clone
+cd ori
+git checkout -b feat/nom-court-explicite
+```
+
+Conventions de nommage de branche :
+
+- `feat/...` : nouvelle fonctionnalité
+- `fix/...` : correction de bug
+- `docs/...` : documentation seule
+- `refactor/...` : refactor sans changement de comportement
+- `chore/...` : maintenance, deps, build
+
+### 2. Coder en respectant les principes
+
+Ori suit quelques règles de fond, documentées dans la page
+**Décisions de design** du Storybook :
+
+- **RGAA AA est la baseline obligatoire** (a11y vérifiée à chaque PR)
+- **Préférer le HTML natif** quand il couvre le besoin
+- **Bundle minimal** : chaque dépendance ajoutée doit être justifiée
+- **Généricité institutionnelle** : pas de domaine métier hardcodé
+- **Aucun dark pattern**
+
+Pour toute modification d'un composant DS (`packages/react/`,
+`packages/angular/`, `packages/tailwind-preset/`) :
+
+- La modification doit être appliquée **en miroir** côté React et
+  côté Angular (sauf si volontairement single-framework, dans ce cas
+  justifier dans la PR)
+- Les classes CSS `.ori-*` doivent rester cohérentes entre les deux
+- Les stories doivent être mises à jour dans les deux Storybooks
+
+### 3. Vérifier localement avant push
+
+```bash
+# Format Prettier
+pnpm format:check
+
+# Build de tous les packages
+pnpm -r --filter "./packages/*" build
+
+# Build des apps consommatrices
+pnpm --filter @govpf/ori-storybook-react build
+pnpm --filter @govpf/ori-storybook-angular build
+pnpm --filter @govpf/ori-site build
+pnpm --filter @govpf/ori-demo-portail build
+```
+
+### 4. Conventions de commits
+
+Format **Conventional Commits** :
+
+```
+<type>(<scope optionnel>): <description courte>
+
+<corps optionnel>
+
+<footer optionnel>
+```
+
+Types courants :
+
+- `feat` : nouvelle fonctionnalité
+- `fix` : correction de bug
+- `docs` : documentation
+- `refactor` : refactor sans changement comportemental
+- `perf` : amélioration de performance
+- `test` : ajout ou modification de tests
+- `chore` : maintenance, build, deps
+- `ci` : workflows CI/CD
+
+Exemples :
+
+```
+feat(react): add FileCard component
+fix(angular): correct Tooltip aria-describedby on focus
+docs(storybook): document the Statistic.trend.positive prop
+```
+
+### 5. Ouvrir la pull request
+
+Le repo a un [template de PR](./.github/PULL_REQUEST_TEMPLATE.md)
+qui rappelle les checks attendus :
+
+- Cross-framework (React + Angular)
+- Accessibilité
+- Tests manuels (clair/sombre, mobile/desktop)
+- Documentation à jour
+
+La CI doit être verte sur tous les jobs avant qu'une PR puisse être
+mergée. Les status checks requis sont configurés dans le ruleset
+`protect-main` du repo.
+
+## Architecture du monorepo
+
+```
+ori/
+├── packages/
+│   ├── tokens/              # Source : design tokens (Style Dictionary)
+│   ├── tailwind-preset/     # Preset Tailwind généré depuis les tokens
+│   ├── css/                 # Bundle ori.css drop-in
+│   ├── react/               # Composants React (@govpf/ori-react)
+│   ├── angular/             # Composants Angular (@govpf/ori-angular)
+│   └── docs/                # MDX transverse partagé entre les Storybooks
+└── apps/
+    ├── ori-site/            # Site documentaire (Astro)
+    ├── storybook-react/     # Storybook test React
+    ├── storybook-angular/   # Storybook test Angular
+    ├── playground-static/   # Démo HTML pur du livrable CSS
+    ├── playground-react/    # Démo Vite + React
+    ├── playground-angular/  # Démo Angular CLI
+    └── demo-portail/        # Démo end-to-end portail usager
+```
+
+## Mainteneur principal
+
+- **Léonard Tavae** ([@sitle](https://github.com/sitle))
+- Contact : leonard.tavae@administration.gov.pf
+
+## Questions
+
+Pour toute question qui ne relève pas d'une issue, ouvrir une
+**Discussion** sur le repo, ou écrire au mainteneur principal.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gouvernement de la Polynésie française
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,30 +1,38 @@
 # Ori
 
-Design system de l'administration de la Polynésie française.
+[![CI](https://github.com/govpf/ori/actions/workflows/ci.yml/badge.svg)](https://github.com/govpf/ori/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-`Ori` est un design system **multi-framework** (React, Angular, HTML pur) bâti autour d'une source unique de design tokens. La même apparence visuelle est garantie sur toutes les cibles.
+Design system mutualisé des services administratifs de la Polynésie française.
+
+Ori est un design system **multi-framework** (React, Angular, HTML pur) bâti
+autour d'une source unique de design tokens. La même apparence visuelle est
+garantie sur toutes les cibles, quel que soit l'outil consommateur.
 
 ## Architecture
 
 Monorepo pnpm organisé autour de trois axes : **tokens**, **styles**, **composants**.
 
 ```
-Ori/
+ori/
 ├── packages/
-│   ├── tokens/              # Source de vérité : JSON DTCG (W3C)
+│   ├── tokens/              # Source : design tokens (W3C DTCG via Style Dictionary)
 │   ├── tailwind-preset/     # Preset Tailwind généré depuis les tokens
-│   ├── css/                 # ds.css statique (livrable drop-in)
+│   ├── css/                 # Bundle ori.css drop-in (statique)
 │   ├── react/               # Composants React / Next.js
-│   ├── angular/             # Composants Angular 20 standalone
-│   └── docs/                # Doc transverse MDX partagée par les 2 Storybooks
+│   ├── angular/             # Composants Angular standalone
+│   └── docs/                # MDX transverse partagé entre les Storybooks
 └── apps/
-    ├── storybook-react/     # Storybook React   (port 6006)
-    ├── storybook-angular/   # Storybook Angular (port 6008)
-    ├── playground-static/   # Démo HTML pur du ds.css (port 4173)
-    └── playground-angular/  # SPA Angular consommatrice (port 4200)
+    ├── ori-site/            # Site documentaire public (Astro)
+    ├── storybook-react/     # Storybook test interactif React
+    ├── storybook-angular/   # Storybook test interactif Angular
+    ├── playground-static/   # Démo HTML pur (intégration GLPI, emails)
+    ├── playground-react/    # Démo Vite + React
+    ├── playground-angular/  # Démo Angular CLI
+    └── demo-portail/        # Démo end-to-end portail usager
 ```
 
-## Chaîne de production
+### Chaîne de production
 
 ```
 tokens/*.json (DTCG)
@@ -33,42 +41,40 @@ tokens/*.json (DTCG)
         │                          │
         │                          ├──► react/       (composants TSX)
         │                          ├──► angular/     (composants ng-packagr)
-        │                          └──► css/         (ds.css statique)
+        │                          └──► css/         (ori.css statique)
         │
-        └──► CSS variables ──► tokens/build/css/tokens.css  + tokens/src/dark.css
+        └──► CSS variables ──► tokens/build/css/tokens.css  +  tokens/src/dark.css
 ```
 
-## Composants disponibles
-
-Parité totale React ↔ Angular pour les 5 composants fondateurs :
-
-| Composant |                React                |                     Angular                      | Description                                                  |
-| --------- | :---------------------------------: | :----------------------------------------------: | ------------------------------------------------------------ |
-| Button    |             ✓ `Button`              |                 ✓ `<ori-button>`                 | 4 variantes, 3 tailles, full width, disabled                 |
-| Input     |              ✓ `Input`              |                 ✓ `<ori-input>`                  | label / hint / error, ARIA complet, 3 tailles                |
-| Card      | ✓ `Card` + `CardHeader/Body/Footer` | ✓ `<ori-card>` + `<ori-card-header/body/footer>` | 3 variantes (default / elevated / flat)                      |
-| Alert     |              ✓ `Alert`              |                 ✓ `<ori-alert>`                  | 4 sévérités (info / success / warning / danger), dismissible |
-| Dialog    |         ✓ `Dialog` (Radix)          |                 ✓ `<ori-dialog>`                 | Modal avec backdrop, ESC, focus trap (React)                 |
-
-Le **thème sombre** est supporté nativement : un attribut `data-theme="dark"` sur `<html>` bascule automatiquement tous les composants.
-
-## Livrables
+## Livrables publishables
 
 | Cible                         | Package                                             | Comment ça se consomme                    |
 | ----------------------------- | --------------------------------------------------- | ----------------------------------------- |
-| Next.js / React               | `@govpf/ori-react` + `@govpf/ori-tailwind-preset`   | `npm install`, import composants + preset |
+| Next.js / React / Vite        | `@govpf/ori-react` + `@govpf/ori-tailwind-preset`   | `npm install`, import composants + preset |
 | Angular ≥ 20                  | `@govpf/ori-angular` + `@govpf/ori-tailwind-preset` | idem, composants standalone               |
-| Site statique / GLPI / emails | `@govpf/ori-css`                                    | `<link rel="stylesheet" href="ds.css">`   |
+| Site statique / GLPI / emails | `@govpf/ori-css`                                    | `<link rel="stylesheet" href="ori.css">`  |
 
-## Prérequis
+Tous publiés sous le scope `@govpf/`. Voir le site documentaire pour la liste
+complète des composants disponibles et leurs API.
 
-- **Node.js** ≥ 20.11
-- **pnpm** ≥ 9 (testé avec 10.29)
-- **just** (optionnel mais recommandé - alternative cross-platform à `make`)
+## Documentation
+
+- **Site documentaire** (à venir) : <https://ori.gov.pf>
+- **Storybooks de test interactif** : déployés en sous-chemins du site documentaire
+- **Décisions de design** et **stratégie d'ouverture** : pages MDX dans `packages/docs/`
+
+## Démarrer
+
+### Prérequis
+
+- **Node.js** ≥ 20.11 (la CI tourne en Node 24 LTS)
+- **pnpm** ≥ 9 (testé avec 10.29 — `corepack enable && corepack prepare pnpm@latest --activate`)
+- **just** (optionnel mais recommandé — alternative cross-platform à `make`)
 
 ### Installer `just`
 
-`just` est un runner de commandes simple qui remplace `make` et fonctionne nativement sur Windows, macOS et Linux.
+`just` est un runner de commandes simple qui remplace `make` et fonctionne
+nativement sur Windows, macOS et Linux.
 
 | OS                    | Commande                                                        |
 | --------------------- | --------------------------------------------------------------- |
@@ -78,44 +84,53 @@ Le **thème sombre** est supporté nativement : un attribut `data-theme="dark"` 
 | Linux (Arch)          | `pacman -S just`                                                |
 | Tous (via Rust)       | `cargo install just`                                            |
 
-Vérifier : `just --version`.
+> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` —
+> tu peux toujours utiliser les commandes `pnpm` équivalentes (colonne de
+> droite des tableaux ci-dessous).
 
-> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` - tu peux toujours utiliser les commandes `pnpm` équivalentes (colonne de droite du tableau ci-dessous).
+### Premier setup
+
+```bash
+git clone https://github.com/govpf/ori.git
+cd ori
+just setup        # ou : pnpm install && pnpm -r --filter "./packages/*" build
+```
+
+### Lancer les apps en développement
+
+```bash
+just storybook-react       # Storybook React,   http://localhost:6006
+just storybook-angular     # Storybook Angular, http://localhost:6008
+just demo-portail          # Demo portail end-to-end, http://localhost:5174
+just site                  # Site Astro, http://localhost:4321
+```
 
 ## Commandes
 
-Depuis la racine `Ori/`.
+Depuis la racine `ori/`. `just` liste les recettes disponibles avec un simple
+`just`. Référence concise :
 
-```bash
-just              # liste toutes les recettes disponibles
-just setup        # setup initial complet (install + build)
-just storybook-react    # Storybook React  : http://localhost:6006
-just storybook-angular  # Storybook Angular : http://localhost:6008
-```
+#### Installation et nettoyage
 
-### Référence complète
-
-#### Installation & nettoyage
-
-| Recette            | Équivalent pnpm              | Description                                                     |
-| ------------------ | ---------------------------- | --------------------------------------------------------------- |
-| `just install`     | `pnpm install`               | Installer toutes les dépendances                                |
-| `just clean`       | `pnpm clean`                 | Supprimer `node_modules`, `dist`, `build`, `.angular`           |
-| `just clean-cache` | `pnpm clean:cache`           | Purger les caches Vite / Webpack / Angular CLI (sans réinstall) |
-| `just fresh`       | `pnpm clean && pnpm install` | Réinstallation complète depuis zéro                             |
+| Recette            | Équivalent pnpm    | Description                                           |
+| ------------------ | ------------------ | ----------------------------------------------------- |
+| `just install`     | `pnpm install`     | Installer toutes les dépendances                      |
+| `just clean`       | `pnpm clean`       | Supprimer `node_modules`, `dist`, `build`, `.angular` |
+| `just clean-cache` | `pnpm clean:cache` | Purger les caches Vite / Webpack / Angular CLI        |
+| `just fresh`       |                    | Réinstallation complète depuis zéro                   |
 
 #### Builds
 
-| Recette               | Équivalent pnpm                                           | Description                                             |
-| --------------------- | --------------------------------------------------------- | ------------------------------------------------------- |
-| `just build`          | `pnpm build`                                              | Tout compiler (tokens → preset → css → react → angular) |
-| `just build-tokens`   | `pnpm build:tokens`                                       | Régénérer les tokens (CSS, SCSS, JS, preset Tailwind)   |
-| `just build-css`      | `pnpm build:css`                                          | Compiler `ds.css` + `ds.min.css` + `tokens.css`         |
-| `just build-react`    | `pnpm build:react`                                        | Compiler les composants React                           |
-| `just build-angular`  | `pnpm build:angular`                                      | Compiler la lib Angular (ng-packagr)                    |
-| `just rebuild-tokens` | `pnpm build:tokens && pnpm build:css && pnpm clean:cache` | Régénération + purge des caches après modif tokens      |
+| Recette               | Équivalent pnpm      | Description                                             |
+| --------------------- | -------------------- | ------------------------------------------------------- |
+| `just build`          | `pnpm build`         | Tout compiler (tokens → preset → css → react → angular) |
+| `just build-tokens`   | `pnpm build:tokens`  | Régénérer les tokens (CSS, SCSS, JS, preset Tailwind)   |
+| `just build-css`      | `pnpm build:css`     | Compiler `ori.css` + `ori.min.css` + `tokens.css`       |
+| `just build-react`    | `pnpm build:react`   | Compiler les composants React                           |
+| `just build-angular`  | `pnpm build:angular` | Compiler la lib Angular (ng-packagr)                    |
+| `just rebuild-tokens` |                      | Régénération + purge des caches après modif tokens      |
 
-#### Storybook
+#### Storybooks et démos
 
 | Recette                        | Équivalent pnpm                | Description                               |
 | ------------------------------ | ------------------------------ | ----------------------------------------- |
@@ -124,132 +139,77 @@ just storybook-angular  # Storybook Angular : http://localhost:6008
 | `just build-storybook-react`   | `pnpm build:storybook:react`   | Storybook React → site statique           |
 | `just build-storybook-angular` | `pnpm build:storybook:angular` | Storybook Angular → site statique         |
 
-#### Playgrounds
-
-| Recette                   | Équivalent pnpm           | Description                            |
-| ------------------------- | ------------------------- | -------------------------------------- |
-| `just playground-static`  | `pnpm playground:static`  | Démo HTML pure (http://localhost:4173) |
-| `just playground-angular` | `pnpm playground:angular` | SPA Angular (http://localhost:4200)    |
-
-#### Modes watch
-
-| Recette            | Description              |
-| ------------------ | ------------------------ |
-| `just watch-css`   | Rebuild CSS à la volée   |
-| `just watch-react` | Rebuild React à la volée |
-
 #### Qualité
 
-| Recette       | Description                      |
-| ------------- | -------------------------------- |
-| `just format` | Formater tout le code (prettier) |
-| `just lint`   | Linter tous les packages         |
-
-#### Raccourcis composés
-
-| Recette      | Description                               |
-| ------------ | ----------------------------------------- |
-| `just setup` | Setup initial : install + build           |
-| `just all`   | Cycle complet : fresh + build + storybook |
+| Recette             | Équivalent pnpm     | Description                      |
+| ------------------- | ------------------- | -------------------------------- |
+| `just format`       | `pnpm format`       | Formater tout le code (Prettier) |
+| `just format-check` | `pnpm format:check` | Vérifier le format sans modifier |
 
 ## Conventions
 
 ### Tokens
 
-- Format **W3C Design Tokens Community Group** (DTCG) - fichiers `packages/tokens/src/*.json`.
-- Deux fichiers : `core.json` (primitives - palettes, échelles) et `semantic.json` (alias - `brand.primary`, `surface.base`…).
-- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) : toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
+- Format **W3C Design Tokens Community Group** (DTCG) — fichiers `packages/tokens/src/*.json`.
+- Deux fichiers : `core.json` (primitives — palettes, échelles) et `semantic.json` (alias — `brand.primary`, `surface.base`…).
+- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) — toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
 
 ### Composants
 
 - Stylés via **classes sémantiques** (`.ori-btn`, `.ori-card`…) définies dans `packages/tailwind-preset/src/plugin-components.js`.
-- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`), pas des hex résolus → bascule de thème dynamique sans recompilation.
+- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`) — bascule de thème dynamique sans recompilation.
 - **Aucun utilitaire Tailwind inline** dans le JSX/template du DS. Les utilitaires restent disponibles pour la mise en page applicative dans les projets consommateurs.
 - React : composants standards avec `forwardRef`, `clsx` pour les classes.
-- Angular : composants `standalone`, `ChangeDetectionStrategy.OnPush`, `ViewEncapsulation.None`, `@Input()` (décorateur classique pour compatibilité large avec Storybook Angular).
+- Angular : composants `standalone`, `ChangeDetectionStrategy.OnPush`, `ViewEncapsulation.None`.
 
 ### Versions Angular
 
-Toutes les dépendances `@angular/*` sont **forcées sur une version unique** via `pnpm.overrides` dans le `package.json` racine. Sans cette règle, pnpm peut installer plusieurs versions mineures côte à côte (ex: 20.3.18 + 20.3.19), ce qui provoque des erreurs runtime cryptiques (`Cannot read properties of null` dans `ɵɵprojectionDef`) parce que les composants sont compilés contre une version et exécutés contre une autre.
-
-## Structure d'un composant
-
-### React
-
-```
-packages/react/src/components/Button/
-├── Button.tsx           # implémentation React
-├── Button.stories.tsx   # story Storybook
-└── index.ts             # ré-export
-```
-
-### Angular
-
-```
-packages/angular/src/components/button/
-├── button.component.ts  # composant standalone + ChangeDetection.OnPush
-├── button.stories.ts    # story Storybook Angular
-└── index.ts             # ré-export
-```
-
-Les classes CSS associées (`.ori-btn`, `.ori-btn--primary`…) sont définies **une seule fois** dans `packages/tailwind-preset/src/plugin-components.js`. Les implémentations React et Angular les appliquent identiquement → **parité visuelle garantie**.
-
-## Ajouter un nouveau composant
-
-1. Définir les classes `.ori-<composant>` dans `packages/tailwind-preset/src/plugin-components.js`
-2. Implémentation React : `packages/react/src/components/<Name>/<Name>.tsx` + story + export
-3. Implémentation Angular : `packages/angular/src/components/<name>/<name>.component.ts` + story + export
-4. Ajouter aux barrels `packages/{react,angular}/src/index.ts` (ou `public-api.ts`)
-5. `just rebuild-tokens` pour régénérer les CSS, puis `just storybook` / `just storybook-angular` pour valider
-
-## Workflow typique
-
-```bash
-# Premier clone
-just setup
-
-# Développement courant - choisir la cible
-just storybook-react        # React
-just storybook-angular      # Angular
-just playground-static      # HTML pur (démo intégrateur)
-just playground-angular     # SPA Angular (démo consommateur)
-
-# Mode watch en parallèle (terminal séparé) si tu modifies le plugin CSS
-just watch-css
-
-# Après avoir modifié un token
-just rebuild-tokens
-# (relancer Storybook s'il tournait - le cache a été purgé)
-
-# Avant de committer
-just format
-just build
-```
+Toutes les dépendances `@angular/*` sont **forcées sur une version unique**
+via `pnpm.overrides` dans le `package.json` racine. Sans cette règle, pnpm
+peut installer plusieurs versions mineures côte à côte, ce qui provoque des
+erreurs runtime cryptiques parce que les composants sont compilés contre une
+version et exécutés contre une autre.
 
 ## Thème sombre
 
-Le DS supporte light/dark via une seule règle CSS : ajouter `data-theme="dark"` (ou la classe `.dark-theme`) sur `<html>`. Compatible aussi avec `prefers-color-scheme: dark` automatiquement.
+Le DS supporte light/dark via une seule règle CSS : ajouter `data-theme="dark"`
+(ou la classe `.dark-theme`) sur `<html>`.
 
 ```html
-<!-- Light (par défaut) -->
 <html data-theme="light">
-  …
+  ...
 </html>
-
-<!-- Dark -->
+<!-- clair (défaut) -->
 <html data-theme="dark">
-  …
+  ...
 </html>
+<!-- sombre -->
 ```
 
-Côté Storybook, un toggle dans la barre d'outils bascule en live grâce à `@storybook/addon-themes`. Côté playgrounds, un bouton `(click)="toggleTheme()"` switche l'attribut.
+Côté Storybook, un toggle dans la barre d'outils bascule en live. Côté
+playgrounds et demo-portail, un bouton dédié switche l'attribut.
 
-## Pièges connus
+## Tester la CI localement
 
-| Symptôme                                                                    | Cause                                                        | Fix                                                                                                                             |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| Storybook affiche les anciens tokens après modif                            | Cache Vite / Webpack / Angular CLI persistant                | `just clean-cache`, puis relancer Storybook                                                                                     |
-| Storybook Angular : `Cannot read properties of null` dans `ɵɵprojectionDef` | Plusieurs versions d'`@angular/core` co-installées           | Vérifier `pnpm.overrides` dans `package.json` racine ; réinstaller fresh (`rm -rf node_modules pnpm-lock.yaml && pnpm install`) |
-| Storybook Angular : NG0203 sur `input()`                                    | `useDefineForClassFields` non explicite                      | Forcer `false` dans `tsconfig.json`                                                                                             |
-| `serve` choisit un port aléatoire                                           | Mauvaise option CLI                                          | Utiliser `http-server -p 4173` plutôt que `serve -p 4173`                                                                       |
-| Tailwind n'émet pas les classes `.ori-*` dynamiques (template literals)     | Le scanner de Tailwind ne détecte que les classes littérales | `safelist: [{ pattern: /^ds-/ }]` dans la config Tailwind                                                                       |
+Le repo embarque un wrapper Docker pour exécuter les workflows GitHub Actions
+sans les pousser :
+
+```bash
+./tools/act/run.sh push                  # tout le pipeline CI
+./tools/act/run.sh push -j format        # un seul job
+```
+
+Voir [tools/act/README.md](./tools/act/README.md) pour les détails.
+
+## Contribuer
+
+Les contributions sont les bienvenues, en particulier sur les sujets
+transverses (accessibilité, performance, documentation, correctifs de bugs).
+
+- [Guide du contributeur](./CONTRIBUTING.md)
+- [Code de conduite](./CODE_OF_CONDUCT.md)
+- [Politique de sécurité](./SECURITY.md)
+
+## Licence
+
+[MIT](./LICENSE) — Copyright © 2026 Gouvernement de la Polynésie française.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Politique de sécurité
+
+Ori est utilisé dans les services administratifs de la Polynésie française.
+La sécurité est traitée comme une priorité, et les rapports de
+vulnérabilités sont les bienvenus.
+
+## Versions supportées
+
+Ori est en **phase de bootstrap** (versions 0.x). Toutes les versions
+publiées reçoivent les correctifs de sécurité jusqu'à la sortie d'une
+version stable 1.0, après quoi cette section sera mise à jour pour
+refléter une politique de support semver classique.
+
+| Version | Support |
+| ------- | ------- |
+| 0.x     | ✓       |
+
+## Signaler une vulnérabilité
+
+**Ne pas ouvrir d'issue publique sur GitHub** pour rapporter une faille
+de sécurité. Utiliser à la place l'un des canaux ci-dessous :
+
+### 1. GitHub Security Advisories (recommandé)
+
+C'est le canal préféré : il permet une discussion confidentielle avec
+les mainteneurs et la création d'un advisory public au moment opportun.
+
+1. Aller sur <https://github.com/govpf/ori/security/advisories/new>
+2. Décrire la vulnérabilité, son impact et les conditions de
+   reproduction
+3. Préciser si une CVE est souhaitée
+
+### 2. Courriel
+
+Pour les rapports qui ne passent pas par GitHub, écrire à :
+
+- **leonard.tavae@administration.gov.pf** (mainteneur principal)
+
+Préciser dans l'objet : `[security] Ori - <résumé court>`.
+
+## Délais d'engagement
+
+| Étape                                   | Délai                                      |
+| --------------------------------------- | ------------------------------------------ |
+| Accusé de réception                     | sous **5 jours ouvrés**                    |
+| Premier diagnostic et niveau de gravité | sous **15 jours ouvrés**                   |
+| Correctif ou plan d'atténuation         | dépend de la gravité (cf. ci-dessous)      |
+| Publication coordonnée de l'advisory    | au plus tard **90 jours** après le rapport |
+
+## Niveaux de gravité
+
+Échelle CVSS 3.1 utilisée comme référence :
+
+- **Critical (9.0 - 10.0)** : correctif visé sous **7 jours**
+- **High (7.0 - 8.9)** : correctif visé sous **30 jours**
+- **Medium (4.0 - 6.9)** : correctif visé sous **60 jours**
+- **Low (0.1 - 3.9)** : intégré dans la prochaine version mineure
+
+## Périmètre
+
+Sont **dans le périmètre** :
+
+- les composants publiés (`@govpf/ori-*`) et leur code source
+- le site documentaire (https://ori.gov.pf une fois en ligne)
+- les workflows GitHub Actions du dépôt
+- les pipelines de publication npm
+
+Sont **hors périmètre** :
+
+- les services administratifs polynésiens qui consomment Ori (à
+  signaler à l'éditeur du service concerné)
+- la plateforme Keycloak du Gouvernement (les écrans documentés ici
+  sont des spécifications, pas une instance en production)
+- les vulnérabilités déjà rapportées et publiées dans les CVE des
+  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) — elles
+  sont traitées via Dependabot
+
+## Divulgation responsable
+
+Ori suit une politique de **divulgation coordonnée** :
+
+1. Le rapport est traité de manière confidentielle
+2. Un correctif est préparé en privé via un GitHub Security Advisory
+3. La version corrigée est publiée
+4. Les services consommateurs sont notifiés
+5. L'advisory est rendu public, avec mention du rapporteur (sauf
+   demande contraire)
+
+## Reconnaissance
+
+Les rapporteurs de vulnérabilités sont mentionnés dans le CHANGELOG et
+dans l'advisory public, sauf demande explicite d'anonymat. Aucun
+programme de bug bounty n'est en place actuellement.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Ori - design system de l'administration de la Polynésie française",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "packageManager": "pnpm@10.29.3",
   "engines": {
     "node": ">=20.11.0",


### PR DESCRIPTION
Ajoute les fichiers standards attendus pour un repo open source publié, et met à jour le README pour refléter l'état actuel du projet (Ori, scope @govpf/, ori-site, ori.css).

## Contenu

- **LICENSE** : MIT, copyright Gouvernement de la Polynésie française
- **SECURITY.md** : politique de divulgation responsable, contact mainteneur, délais d'engagement par niveau de gravité CVSS
- **CONTRIBUTING.md** : guide complet (prérequis, setup, conventions, process PR, conventions de commit)
- **CODE_OF_CONDUCT.md** : Contributor Covenant 2.1, contact pour signalement
- **README.md** : refonte (badges CI + license, architecture monorepo à jour avec ori-site, demo-portail, playground-react, livrables packages \, lien vers le futur site documentaire, tokens / composants / thème sombre, intégration tools/act, sections Contribuer & Licence)
- **package.json** : license passée de UNLICENSED à MIT
- **.github/rulesets/protect-main.json** : ruleset versionné (déjà déployé sur main)

## Validation

- \undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "format:check\" not found

Did you mean "pnpm format:check"? ✓
- Cross-framework : pas de modification de composant
- Tous les fichiers passés en revue, aucune référence à pf-ds, ds-, pf- restante