### PR TITLE
ci: sync ruleset JSON (require_last_push_approval false)

### DIFF
--- a/.github/rulesets/protect-main.json
+++ b/.github/rulesets/protect-main.json
@@ -17,7 +17,7 @@
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,
-        "require_last_push_approval": true,
+        "require_last_push_approval": false,
         "required_review_thread_resolution": false,
         "allowed_merge_methods": ["merge", "squash", "rebase"]
       }


### PR DESCRIPTION
Aligne le fichier versionne du ruleset avec ce qui est deploye en prod sur GitHub. Le require_last_push_approval etait a true mais bloque le merge en single-mainteneur ; passe a false jusqu a ce qu un 2e admin nominatif rejoigne.