### PR TITLE
chore: remove em-dashes from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ soumise.
 ### Prérequis
 
 - **Node.js 20.11+** (recommandé : Node 24 LTS, comme la CI)
-- **pnpm 10.29+** (gestionnaire de paquets — `corepack enable && corepack prepare pnpm@latest --activate`)
+- **pnpm 10.29+** (gestionnaire de paquets - `corepack enable && corepack prepare pnpm@latest --activate`)
 - **Git**
 - **Docker** (optionnel, pour tester la CI en local via `act`)
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ complète des composants disponibles et leurs API.
 ### Prérequis
 
 - **Node.js** ≥ 20.11 (la CI tourne en Node 24 LTS)
-- **pnpm** ≥ 9 (testé avec 10.29 — `corepack enable && corepack prepare pnpm@latest --activate`)
-- **just** (optionnel mais recommandé — alternative cross-platform à `make`)
+- **pnpm** ≥ 9 (testé avec 10.29 - `corepack enable && corepack prepare pnpm@latest --activate`)
+- **just** (optionnel mais recommandé - alternative cross-platform à `make`)
 
 ### Installer `just`
 
@@ -84,7 +84,7 @@ nativement sur Windows, macOS et Linux.
 | Linux (Arch)          | `pacman -S just`                                                |
 | Tous (via Rust)       | `cargo install just`                                            |
 
-> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` —
+> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` -
 > tu peux toujours utiliser les commandes `pnpm` équivalentes (colonne de
 > droite des tableaux ci-dessous).
 
@@ -150,14 +150,14 @@ Depuis la racine `ori/`. `just` liste les recettes disponibles avec un simple
 
 ### Tokens
 
-- Format **W3C Design Tokens Community Group** (DTCG) — fichiers `packages/tokens/src/*.json`.
-- Deux fichiers : `core.json` (primitives — palettes, échelles) et `semantic.json` (alias — `brand.primary`, `surface.base`…).
-- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) — toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
+- Format **W3C Design Tokens Community Group** (DTCG) - fichiers `packages/tokens/src/*.json`.
+- Deux fichiers : `core.json` (primitives - palettes, échelles) et `semantic.json` (alias - `brand.primary`, `surface.base`…).
+- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) - toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
 
 ### Composants
 
 - Stylés via **classes sémantiques** (`.ori-btn`, `.ori-card`…) définies dans `packages/tailwind-preset/src/plugin-components.js`.
-- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`) — bascule de thème dynamique sans recompilation.
+- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`) - bascule de thème dynamique sans recompilation.
 - **Aucun utilitaire Tailwind inline** dans le JSX/template du DS. Les utilitaires restent disponibles pour la mise en page applicative dans les projets consommateurs.
 - React : composants standards avec `forwardRef`, `clsx` pour les classes.
 - Angular : composants `standalone`, `ChangeDetectionStrategy.OnPush`, `ViewEncapsulation.None`.
@@ -212,4 +212,4 @@ transverses (accessibilité, performance, documentation, correctifs de bugs).
 
 ## Licence
 
-[MIT](./LICENSE) — Copyright © 2026 Gouvernement de la Polynésie française.
+[MIT](./LICENSE) - Copyright © 2026 Gouvernement de la Polynésie française.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,7 +72,7 @@ Sont **hors périmètre** :
 - la plateforme Keycloak du Gouvernement (les écrans documentés ici
   sont des spécifications, pas une instance en production)
 - les vulnérabilités déjà rapportées et publiées dans les CVE des
-  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) — elles
+  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) - elles
   sont traitées via Dependabot
 
 ## Divulgation responsable

--- a/packages/docs/src/Decisions-A-Prendre.mdx
+++ b/packages/docs/src/Decisions-A-Prendre.mdx
@@ -245,12 +245,12 @@ marine institutionnel PF). En light, ce bleu sombre sur fond `feedback-info-bg`
 (info-50, bleu très clair) contraste correctement. En dark, ce même bleu
 sombre est utilisé comme **couleur de texte** sur un fond `feedback-info-bg`
 qui est lui-même très sombre (mix 18 % de info-500 sur transparent ≈
-neutral-900) — d'où un bleu sombre sur bleu sombre, illisible.
+neutral-900) - d'où un bleu sombre sur bleu sombre, illisible.
 
 Le fix est analogue à ce qu'on fait déjà pour `--color-brand-primary` :
 on aligne `--color-feedback-info` sur `primary-400` (#5980ff) en dark.
 Cet alignement préserve l'invariant "info = primary" (vrai en light via
-`info-500 = primary-500`) — sans ce choix, l'item courant du SideMenu
+`info-500 = primary-500`) - sans ce choix, l'item courant du SideMenu
 (qui utilise `brand-primary`) et un bandeau Notification info, identiques
 en light, divergeraient en dark. Les tons saturés des autres feedbacks
 (success-500 vert vif, warning-500 orange vif, danger-500 rouge vif)

--- a/packages/docs/src/Strategie-Ouverture.mdx
+++ b/packages/docs/src/Strategie-Ouverture.mdx
@@ -86,7 +86,7 @@ dans les défenses citées plus haut est plus efficace.
   structures associatives à mission de service public peuvent partir de
   Ori plutôt que repartir de zéro.
 - **Documentation forcée** : un repo public oblige à écrire une doc
-  utilisable par un externe — ce qui sert aussi en interne.
+  utilisable par un externe - ce qui sert aussi en interne.
 
 ## Coût réel à anticiper
 
@@ -227,7 +227,7 @@ avant publication.
 - [ ] Préparer 5-10 issues "good first issue" pour amorcer la
       communauté
 - [ ] Surveiller le repo les 2 premières semaines (issues, PRs, stars,
-      forks) — adaptation possible
+      forks) - adaptation possible
 
 ## Après la publication : posture continue
 

--- a/packages/docs/src/components/FileCard.mdx
+++ b/packages/docs/src/components/FileCard.mdx
@@ -46,7 +46,7 @@ Le DS porte ces choix une fois pour toutes :
 | `archive` | `FileArchive` | Archive |
 | `other` | `File` | Fichier |
 
-Le `type` n'est **pas dérivé automatiquement** de l'extension du `name` —
+Le `type` n'est **pas dérivé automatiquement** de l'extension du `name` -
 c'est l'app qui doit le passer explicitement, pour éviter les surprises
 (un `.txt`, un `.json`, un type MIME exotique…). Si l'app dispose du
 type MIME, elle peut le mapper vers l'un des 6 `type` standardisés ; pour
@@ -80,7 +80,7 @@ Les actions sont des boutons icône **ghost / size sm** affichés en haut
 ## Bonnes pratiques
 
 - **3 actions max** dans `actions`. Au-delà, regrouper les actions secondaires dans un menu kebab côté app.
-- **Garder le nom du fichier exact** dans `name` — y compris l'extension. L'utilisateur a besoin de la voir pour reconnaître son fichier.
+- **Garder le nom du fichier exact** dans `name` - y compris l'extension. L'utilisateur a besoin de la voir pour reconnaître son fichier.
 - **`size` formaté humainement** (ex: `'1.2 Mo'`, `'850 Ko'`), pas en octets bruts. Le DS n'en fait pas le formatage : c'est du contenu applicatif.
 - **`meta` court**. Une date d'ajout, un auteur, un statut. Pas de phrase complète.
 - **`link` pour pointer vers le contexte**, pas pour une action sur le fichier. Le téléchargement ou l'aperçu vont dans `actions`.

--- a/tmp-npm-stubs/README.md
+++ b/tmp-npm-stubs/README.md
@@ -1,4 +1,4 @@
-# Stubs de réservation npm — @govpf/ori-*
+# Stubs de réservation npm - @govpf/ori-*
 
 Ce dossier contient des packages **vides** dont l'unique but est de
 réserver les noms de packages sur npm avant la publication réelle, pour
@@ -46,7 +46,7 @@ Devrait afficher la version 0.0.0 et la description "Reserved".
   stubs que si tu es **certain** des noms.
 - À la 1re vraie publication (V1), tu remplaceras la version 0.0.0 par
   une version 1.0.0 du package réel via les pipelines de release. Pas
-  besoin de "supprimer" le stub — un `npm publish` avec une version
+  besoin de "supprimer" le stub - un `npm publish` avec une version
   supérieure le remplace naturellement.
 - Une fois les stubs publiés, ce dossier `tmp-npm-stubs/` peut être
   supprimé du repo. Il n'a aucune utilité fonctionnelle.


### PR DESCRIPTION
Remplace tous les caracteres em-dash et en-dash par des tirets simples dans la doc. Regle elevee au niveau global dans ~/.claude/CLAUDE.md pour eviter de les reintroduire dans les futures sessions.