### PR TITLE
feat: CI/CD complete (Pages deploy + npm release)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,95 @@
+name: Deploy to GitHub Pages
+
+# Build et deploiement composé du site documentaire et des Storybooks
+# vers https://ori.gov.pf/ (custom domain via CNAME, fallback
+# https://govpf.github.io/ori/ tant que le DNS Cloudflare ne propage pas).
+#
+# Structure servie :
+#   /                       -> site Astro (apps/ori-site/)
+#   /storybook/react/       -> Storybook React (test interactif)
+#   /storybook/angular/     -> Storybook Angular (test interactif)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # déclenchement manuel depuis l'UI Actions
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write # OIDC pour deploy-pages
+
+# Annule un deploy en cours si un nouveau push arrive sur main, mais
+# ne cancel pas un deploy déjà sorti du build (skip-after-deploy false).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10.29.3'
+
+jobs:
+  build:
+    name: Build composé (site + storybooks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages (deps des consommateurs)
+        run: pnpm -r --filter "./packages/*" build
+
+      - name: Build site Astro
+        run: pnpm --filter @govpf/ori-site build
+
+      - name: Build Storybook React
+        run: pnpm --filter @govpf/ori-storybook-react build
+
+      - name: Build Storybook Angular
+        run: pnpm --filter @govpf/ori-storybook-angular build
+
+      - name: Compose dist composé
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp -r apps/ori-site/dist/. dist/
+          mkdir -p dist/storybook/react dist/storybook/angular
+          cp -r apps/storybook-react/storybook-static/. dist/storybook/react/
+          cp -r apps/storybook-angular/storybook-static/. dist/storybook/angular/
+          # .nojekyll obligatoire pour servir _astro/, _next/, etc.
+          touch dist/.nojekyll
+          # CNAME pour le custom domain (Astro le copie déjà depuis public/
+          # mais on s'assure qu'il est bien à la racine de dist)
+          echo "ori.gov.pf" > dist/CNAME
+          echo "=== dist content ==="
+          ls -la dist
+          echo "=== sizes ==="
+          du -sh dist dist/storybook/react dist/storybook/angular dist/_astro 2>/dev/null || true
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release npm packages
+
+# Publication des packages publishables sur npm public sous le scope
+# @govpf/. Authentification via OIDC Trusted Publishers (pas de
+# NPM_TOKEN). Provenance signature automatique.
+#
+# Déclenchement :
+#   - tag git v* poussé sur main (ex: v0.1.0)
+#   - workflow_dispatch manuel depuis l'UI (utile pour republier)
+#
+# Prérequis npm (à faire une fois) :
+#   - Trusted publisher configuré au niveau de l'org @govpf, ou par
+#     package, pointant vers ce repo et ce fichier de workflow.
+#   - Environment GitHub "npm-release" créé dans Settings → Environments,
+#     éventuellement avec des reviewers requis pour bloquer le publish
+#     accidentel.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Simuler sans publier (npm publish --dry-run)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write # création GitHub Release
+  id-token: write # OIDC pour npm publish
+
+env:
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10.29.3'
+
+jobs:
+  release:
+    name: Build et publish
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-release
+      url: https://www.npmjs.com/org/govpf
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build all publishable packages
+        run: pnpm -r --filter "./packages/*" build
+
+      - name: Verify versions are aligned
+        run: |
+          set -euo pipefail
+          echo "=== package versions ==="
+          for pkg in tokens css tailwind-preset react angular; do
+            v=$(jq -r '.version' packages/$pkg/package.json)
+            echo "@govpf/ori-$pkg: $v"
+          done
+
+      - name: Publish to npm
+        # Ordre topologique :
+        #   tokens (aucune dep)
+        #   tailwind-preset (dep tokens)
+        #   css (dep tailwind-preset + tokens)
+        #   react (dep tokens)
+        #   angular (dep tokens)
+        run: |
+          set -euo pipefail
+          DRY_RUN_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            echo "Dry-run mode (workflow_dispatch input dry_run=true)"
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          for pkg in tokens tailwind-preset css react angular; do
+            echo "=== Publishing @govpf/ori-$pkg ==="
+            (cd packages/$pkg && npm publish $DRY_RUN_FLAG --provenance --access public)
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # fallback si OIDC pas encore actif
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v') && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "Voir le CHANGELOG du repo et les notes de chaque package sur npm." \
+            --verify-tag

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ dist/
 build/
 .turbo/
 .cache/
+.angular/
+.astro/
 .DS_Store
 *.log
 .env

--- a/apps/ori-site/.astro/settings.json
+++ b/apps/ori-site/.astro/settings.json
@@ -1,5 +1,0 @@
-{
-	"_variables": {
-		"lastUpdateCheck": 1777246299000
-	}
-}

--- a/apps/ori-site/.astro/types.d.ts
+++ b/apps/ori-site/.astro/types.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/apps/ori-site/astro.config.mjs
+++ b/apps/ori-site/astro.config.mjs
@@ -1,15 +1,15 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 
-// Configuration Astro pour le prototype Ori.
-// - output: static (pas de SSR), généré à 100% au build → déployable sur GitHub Pages
-// - base: /ori (le site sera servi sous https://govpf.github.io/ori/)
-// - integrations: React activé pour les îlots interactifs
-//
-// NOTE prototype : on garde `base: '/'` pour le dev local, à passer à `/ori`
-// au moment du déploiement GitHub Pages.
+// Configuration Astro pour le site documentaire Ori.
+// - output: static (généré à 100% au build, déployable sur GitHub Pages)
+// - site: URL canonique de production (utilisée pour OG tags, sitemap, etc.)
+// - base: '/' car servi à la racine du custom domain ori.gov.pf
+//   (le CNAME redirige govpf.github.io/ori vers ori.gov.pf, pas besoin
+//   de base path)
 export default defineConfig({
   output: 'static',
+  site: 'https://ori.gov.pf',
   base: '/',
   trailingSlash: 'always',
   integrations: [react()],

--- a/apps/ori-site/public/CNAME
+++ b/apps/ori-site/public/CNAME
@@ -1,0 +1,1 @@
+ori.gov.pf

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govpf/ori-angular",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Composants Angular pour Ori",
   "type": "module",
   "main": "./dist/fesm2022/Ori-angular.mjs",
@@ -40,5 +40,8 @@
     "tslib": "^2.8.1",
     "typescript": "~5.9.0",
     "zone.js": "~0.15.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govpf/ori-css",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Bundle CSS statique Ori (drop-in pour sites statiques, GLPI, emails)",
   "main": "./dist/ori.css",
   "style": "./dist/ori.css",
@@ -27,5 +27,8 @@
     "tailwindcss": "^3.4.14",
     "postcss": "^8.4.47",
     "autoprefixer": "^10.4.20"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govpf/ori-react",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Composants React / Next.js pour Ori",
   "type": "module",
   "main": "./dist/index.js",
@@ -35,5 +35,8 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "typescript": "~5.6.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govpf/ori-tailwind-preset",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Preset Tailwind pour Ori (tokens + plugin composants)",
   "type": "module",
   "main": "./src/index.js",
@@ -19,5 +19,8 @@
   },
   "peerDependencies": {
     "tailwindcss": "^3.4.0 || ^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govpf/ori-tokens",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Design tokens (format W3C DTCG) pour Ori",
   "type": "module",
   "main": "./build/js/tokens.js",
@@ -30,5 +30,8 @@
   },
   "devDependencies": {
     "style-dictionary": "^4.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Ajoute la chaine de deploiement complete pour le go-live.

Workflows ajoutes :
- deploy.yml : build composé site Astro + Storybooks deploye sur GitHub Pages a chaque push main, custom domain ori.gov.pf via CNAME
- release.yml : publication npm OIDC sur tag git v* ou workflow_dispatch, provenance signee, ordre topologique des packages

Configuration packages :
- private:false + publishConfig.access:public sur les 5 packages publishables
- Astro site:https://ori.gov.pf et base:/

Prerequis avant que ces workflows tournent :
1. Settings du repo GitHub : Pages source = GitHub Actions
2. Settings du repo GitHub : Environments = creer npm-release et github-pages
3. npmjs.com : configurer Trusted Publisher OIDC sur l org govpf (ou par package apres premiere publi manuelle)
4. DNS : CNAME ori.gov.pf vers govpf.github.io (deja fait cote Cloudflare)

Premier deploiement : merger cette PR -> deploy.yml se lance automatiquement -> https://govpf.github.io/ori/ (puis ori.gov.pf une fois propage)

Premier release npm : tag v0.1.0 -> release.yml se lance automatiquement, ou manuellement via workflow_dispatch avec dry-run pour test.