### PR TITLE
fix(packages): add repository field for npm provenance

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -43,5 +43,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/angular"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -30,5 +30,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/css"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,5 +38,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/react"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -22,5 +22,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/tailwind-preset"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -33,5 +33,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/tokens"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }


### PR DESCRIPTION
Premiere tentative de release a echoue avec '422 Unprocessable Entity - repository.url is empty, expected https://github.com/govpf/ori from provenance'. Ajoute les champs repository, homepage, bugs dans les 5 package.json publishables pour que le sigstore provenance bundle valide correctement.