### PR TITLE
fix: republish ori-tailwind-preset (0.1.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,11 @@ jobs:
         #   css (dep tailwind-preset + tokens)
         #   react (dep tokens)
         #   angular (dep tokens)
+        #
+        # Pour chaque package, on vérifie d'abord si la version courante
+        # n'est pas déjà publiée. Cela permet de republier partiellement
+        # (bumper un seul package en patch) sans que le workflow échoue
+        # sur les versions déjà publiées des autres.
         run: |
           set -euo pipefail
           DRY_RUN_FLAG=""
@@ -84,7 +89,13 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
           for pkg in tokens tailwind-preset css react angular; do
-            echo "=== Publishing @govpf/ori-$pkg ==="
+            name="@govpf/ori-$pkg"
+            version=$(jq -r '.version' packages/$pkg/package.json)
+            echo "=== $name@$version ==="
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "Skip: $name@$version is already published."
+              continue
+            fi
             (cd packages/$pkg && npm publish $DRY_RUN_FLAG --provenance --access public)
           done
         env:

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -43,5 +43,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/angular"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -30,5 +30,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/css"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,5 +38,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/react"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govpf/ori-tailwind-preset",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Preset Tailwind pour Ori (tokens + plugin composants)",
   "type": "module",

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -22,5 +22,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/tailwind-preset"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -33,5 +33,14 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/govpf/ori.git",
+    "directory": "packages/tokens"
+  },
+  "homepage": "https://ori.gov.pf",
+  "bugs": {
+    "url": "https://github.com/govpf/ori/issues"
   }
 }


### PR DESCRIPTION
Le tarball de @govpf/ori-tailwind-preset@0.1.0 a été uploadé en limbo (entrée visible côté org mais sans contenu utilisable). Bump à 0.1.1 pour republier proprement et ajout d'un check skip-if-already-published dans le workflow release pour que les futurs republish partiels ne fassent pas échouer le job sur les autres packages.
