### PR TITLE
fix(release): pnpm publish pour résoudre workspace:*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,16 @@ jobs:
             version=$(jq -r '.version' packages/$pkg/package.json)
             echo "=== $name@$version ==="
             if npm view "$name@$version" version >/dev/null 2>&1; then
-              echo "Skip: $name@$version is already published."
+              echo "Skip: $name@$version est déjà publié."
               continue
             fi
-            (cd packages/$pkg && npm publish $DRY_RUN_FLAG --provenance --access public)
+            # On utilise `pnpm publish` (et non `npm publish`) parce que
+            # pnpm résout automatiquement les `workspace:*` en versions
+            # concrètes (ex: `0.1.0`) au moment du packaging du tarball.
+            # Avec `npm publish`, les `workspace:*` restent tels quels
+            # dans le `package.json` publié, ce qui rend le package non
+            # installable hors du monorepo (EUNSUPPORTEDPROTOCOL).
+            (cd packages/$pkg && pnpm publish $DRY_RUN_FLAG --provenance --access public --no-git-checks)
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # fallback si OIDC pas encore actif

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govpf/ori-css",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Bundle CSS statique Ori (drop-in pour sites statiques, GLPI, emails)",
   "main": "./dist/ori.css",

--- a/packages/tailwind-preset/package.json
+++ b/packages/tailwind-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@govpf/ori-tailwind-preset",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "description": "Preset Tailwind pour Ori (tokens + plugin composants)",
   "type": "module",


### PR DESCRIPTION
Les packages publiés en v0.1.0 et v0.1.1 ont des dépendances `workspace:*` non résolues, ce qui les rend non installables hors du monorepo (`npm install` échoue avec `EUNSUPPORTEDPROTOCOL Unsupported URL Type "workspace:": workspace:*`).

Cause : `npm publish` ne convertit pas les `workspace:*` en versions concrètes au packaging, contrairement à `pnpm publish`.

Correctifs :
- Workflow `release.yml` : remplace `npm publish` par `pnpm publish --no-git-checks` qui résout automatiquement les protocoles workspace
- `ori-css` : bump 0.1.0 -> 0.1.1 (la 0.1.0 est cassée)
- `ori-tailwind-preset` : bump 0.1.1 -> 0.1.2 (les 0.1.0 et 0.1.1 sont cassées)
- `ori-tokens`, `ori-react`, `ori-angular` restent en 0.1.0 (pas de dep workspace, donc déjà installables)

Le check skip-if-already-published du workflow garantit que les packages déjà bons ne sont pas re-publiés.
