### PR TITLE
chore(docs): cleanup éditorial + catalogue composants vers Storybook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ soumise.
 ### Prérequis
 
 - **Node.js 20.11+** (recommandé : Node 24 LTS, comme la CI)
-- **pnpm 10.29+** (gestionnaire de paquets — `corepack enable && corepack prepare pnpm@latest --activate`)
+- **pnpm 10.29+** (gestionnaire de paquets - `corepack enable && corepack prepare pnpm@latest --activate`)
 - **Git**
 - **Docker** (optionnel, pour tester la CI en local via `act`)
 
@@ -104,7 +104,7 @@ Ori suit quelques règles de fond, documentées dans la page
 - **Préférer le HTML natif** quand il couvre le besoin
 - **Bundle minimal** : chaque dépendance ajoutée doit être justifiée
 - **Généricité institutionnelle** : pas de domaine métier hardcodé
-- **Aucun dark pattern**
+- **Aucun design trompeur** (faux compteurs d'urgence, opt-out cachés, etc.)
 
 Pour toute modification d'un composant DS (`packages/react/`,
 `packages/angular/`, `packages/tailwind-preset/`) :

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ complète des composants disponibles et leurs API.
 ### Prérequis
 
 - **Node.js** ≥ 20.11 (la CI tourne en Node 24 LTS)
-- **pnpm** ≥ 9 (testé avec 10.29 — `corepack enable && corepack prepare pnpm@latest --activate`)
-- **just** (optionnel mais recommandé — alternative cross-platform à `make`)
+- **pnpm** ≥ 9 (testé avec 10.29 - `corepack enable && corepack prepare pnpm@latest --activate`)
+- **just** (optionnel mais recommandé - alternative cross-platform à `make`)
 
 ### Installer `just`
 
@@ -84,7 +84,7 @@ nativement sur Windows, macOS et Linux.
 | Linux (Arch)          | `pacman -S just`                                                |
 | Tous (via Rust)       | `cargo install just`                                            |
 
-> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` —
+> Si tu ne peux pas installer `just`, toutes les recettes délèguent à `pnpm` -
 > tu peux toujours utiliser les commandes `pnpm` équivalentes (colonne de
 > droite des tableaux ci-dessous).
 
@@ -150,14 +150,14 @@ Depuis la racine `ori/`. `just` liste les recettes disponibles avec un simple
 
 ### Tokens
 
-- Format **W3C Design Tokens Community Group** (DTCG) — fichiers `packages/tokens/src/*.json`.
-- Deux fichiers : `core.json` (primitives — palettes, échelles) et `semantic.json` (alias — `brand.primary`, `surface.base`…).
-- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) — toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
+- Format **W3C Design Tokens Community Group** (DTCG) - fichiers `packages/tokens/src/*.json`.
+- Deux fichiers : `core.json` (primitives - palettes, échelles) et `semantic.json` (alias - `brand.primary`, `surface.base`…).
+- **Règle d'or** : un composant ne consomme **jamais** un token primitif (`color.primary.500`) - toujours un alias sémantique (`color.brand.primary`). Cela permet de changer de palette ou de basculer en thème sombre sans toucher au code des composants.
 
 ### Composants
 
 - Stylés via **classes sémantiques** (`.ori-btn`, `.ori-card`…) définies dans `packages/tailwind-preset/src/plugin-components.js`.
-- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`) — bascule de thème dynamique sans recompilation.
+- Les classes consomment des **variables CSS** (`var(--color-brand-primary)`) - bascule de thème dynamique sans recompilation.
 - **Aucun utilitaire Tailwind inline** dans le JSX/template du DS. Les utilitaires restent disponibles pour la mise en page applicative dans les projets consommateurs.
 - React : composants standards avec `forwardRef`, `clsx` pour les classes.
 - Angular : composants `standalone`, `ChangeDetectionStrategy.OnPush`, `ViewEncapsulation.None`.
@@ -212,4 +212,4 @@ transverses (accessibilité, performance, documentation, correctifs de bugs).
 
 ## Licence
 
-[MIT](./LICENSE) — Copyright © 2026 Gouvernement de la Polynésie française.
+[MIT](./LICENSE) - Copyright © 2026 Gouvernement de la Polynésie française.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,7 +71,7 @@ Sont **hors périmètre** :
 - la plateforme Keycloak du Gouvernement (les écrans documentés ici
   sont des spécifications, pas une instance en production)
 - les vulnérabilités déjà rapportées et publiées dans les CVE des
-  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) — elles
+  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) - elles
   sont traitées via Dependabot
 
 ## Divulgation responsable

--- a/apps/ori-site/src/pages/angular/patterns.mdx
+++ b/apps/ori-site/src/pages/angular/patterns.mdx
@@ -51,8 +51,8 @@ ajoute du comportement.
 
 ## Réutiliser les classes CSS pour un composant 100% custom
 
-Si tu as besoin d'un composant qui n'existe pas dans Ori mais qui
-doit avoir le look du DS, utilise les classes :
+Pour un composant qui n'existe pas dans Ori mais qui doit avoir le
+look du DS, réutiliser directement les classes CSS :
 
 ```ts
 import { Component, Input } from '@angular/core';
@@ -109,7 +109,7 @@ export class RfInputComponent {
 ```
 
 Pattern similaire pour `<ori-checkbox>`, `<ori-select>`, etc. À factoriser
-si tu en as plusieurs.
+en cas d'usages multiples.
 
 ## Détection de changement OnPush
 
@@ -120,9 +120,9 @@ Cela signifie qu'ils ne se rafraîchissent que sur :
 - Émission d'un `@Output()`
 - Appel manuel à `markForCheck()` / `detectChanges()`
 
-Si tu mutes un objet en place (`this.user.name = 'X'`) et le passes
-à un composant Ori, le rendu ne se met pas à jour. Solution :
-remplacer la référence (`this.user = { ...this.user, name: 'X' }`).
+Muter un objet en place (`this.user.name = 'X'`) puis le passer à
+un composant Ori ne déclenche pas le rendu. Solution : remplacer la
+référence (`this.user = { ...this.user, name: 'X' }`).
 
 ## Anti-patterns
 

--- a/apps/ori-site/src/pages/composants/index.astro
+++ b/apps/ori-site/src/pages/composants/index.astro
@@ -2,244 +2,118 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import Sidebar from '../../components/Sidebar.astro';
 
-interface Component {
-  name: string;
-  slug: string;
-  description: string;
-}
-
-interface Category {
-  title: string;
-  intro?: string;
-  components: Component[];
-}
-
 const base = import.meta.env.BASE_URL;
-
-// Storybooks servis comme sous-dossiers du site (cf. .github/workflows/deploy.yml,
-// étape "Compose dist composé").
 const storybookReact = `${base}storybook/react/`;
 const storybookAngular = `${base}storybook/angular/`;
-const githubSource = 'https://github.com/govpf/ori/tree/main/packages';
-
-const categories: Category[] = [
-  {
-    title: 'Actions',
-    components: [
-      { name: 'Button', slug: 'button', description: "Déclencher une action. Quatre variantes sémantiques (primary, secondary, ghost, danger), trois tailles." },
-      { name: 'Link', slug: 'link', description: 'Navigation textuelle inline ou bloc. Variantes quiet pour les contextes peu visuels.' },
-    ],
-  },
-  {
-    title: 'Saisie',
-    intro: "Les composants de saisie suivent les patterns RGAA AA : label associé, message d'erreur, aide contextuelle.",
-    components: [
-      { name: 'Input', slug: 'input', description: 'Champ texte mono-ligne avec label, aide, état d\'erreur.' },
-      { name: 'Textarea', slug: 'textarea', description: 'Champ texte multi-ligne, redimensionnable verticalement.' },
-      { name: 'Select', slug: 'select', description: 'Liste déroulante native, stylée pour rester homogène avec Input.' },
-      { name: 'Checkbox', slug: 'checkbox', description: 'Case à cocher avec état indéterminé pour les sélections partielles.' },
-      { name: 'Radio', slug: 'radio', description: 'Bouton radio en groupe, avec gestion automatique de la navigation clavier.' },
-      { name: 'Switch', slug: 'switch', description: 'Interrupteur on/off pour les préférences applicatives instantanées.' },
-      { name: 'DatePicker', slug: 'datepicker', description: 'Sélecteur de date conforme aux standards ARIA pattern combobox.' },
-      { name: 'FileUpload', slug: 'fileupload', description: 'Téléversement de fichiers avec drag-and-drop, multi-fichiers, états.' },
-    ],
-  },
-  {
-    title: 'Affichage',
-    components: [
-      { name: 'Card', slug: 'card', description: 'Conteneur de contenu structuré (header, body, footer). Plat ou élevé.' },
-      { name: 'FileCard', slug: 'filecard', description: "Représentation d'un document avec icône de type, taille et action de téléchargement." },
-      { name: 'Statistic', slug: 'statistic', description: "Mise en valeur d'un chiffre-clé avec libellé et tendance optionnelle." },
-      { name: 'Avatar', slug: 'avatar', description: 'Photo ou initiales d\'utilisateur, quatre tailles.' },
-      { name: 'Tag', slug: 'tag', description: 'Étiquette pour catégoriser ou marquer un statut. Variantes sémantiques.' },
-      { name: 'Highlight', slug: 'highlight', description: 'Mise en évidence textuelle inline pour les résultats de recherche.' },
-      { name: 'Logo', slug: 'logo', description: "Identité visuelle Ori, déclinaisons couleur et monochrome." },
-    ],
-  },
-  {
-    title: 'Feedback',
-    components: [
-      { name: 'Alert', slug: 'alert', description: 'Message contextuel persistant. Quatre variantes sémantiques.' },
-      { name: 'Toast', slug: 'toast', description: 'Notification éphémère sortante en haut-droite, auto-dismiss configurable.' },
-      { name: 'Notification', slug: 'notification', description: "Badge numérique pour signaler des éléments non lus." },
-      { name: 'Progress', slug: 'progress', description: 'Indicateur de progression linéaire ou circulaire.' },
-      { name: 'Skeleton', slug: 'skeleton', description: 'Placeholder de chargement, animé pour suggérer le contenu à venir.' },
-      { name: 'Tooltip', slug: 'tooltip', description: "Info-bulle au survol et au focus, positionnée automatiquement." },
-    ],
-  },
-  {
-    title: 'Layout et navigation',
-    components: [
-      { name: 'Header', slug: 'header', description: "En-tête d'application avec logo, navigation principale et actions." },
-      { name: 'Footer', slug: 'footer', description: 'Pied de page applicatif, mentions légales et liens institutionnels.' },
-      { name: 'MainNavigation', slug: 'mainnavigation', description: 'Navigation principale horizontale, intégrée dans Header.' },
-      { name: 'SideMenu', slug: 'sidemenu', description: 'Menu latéral persistent ou en drawer mobile.' },
-      { name: 'Breadcrumb', slug: 'breadcrumb', description: 'Fil d\'Ariane indiquant la position dans une hiérarchie.' },
-      { name: 'Pagination', slug: 'pagination', description: 'Navigation entre pages de résultats, avec sauts rapides.' },
-      { name: 'Tabs', slug: 'tabs', description: 'Onglets avec gestion clavier ARIA tabpanel.' },
-      { name: 'Steps', slug: 'steps', description: "Indicateur d'étapes pour un processus de démarche en plusieurs phases." },
-      { name: 'Timeline', slug: 'timeline', description: 'Chronologie verticale d\'événements horodatés.' },
-    ],
-  },
-  {
-    title: 'Surfaces avancées',
-    components: [
-      { name: 'Dialog', slug: 'dialog', description: 'Boîte de dialogue modale avec focus-trap, fermeture Escape, scroll lock.' },
-      { name: 'Accordion', slug: 'accordion', description: 'Sections dépliables, mode single ou multiple ouverts.' },
-      { name: 'Table', slug: 'table', description: 'Tableau de données avec tri, sélection, états vide/loading.' },
-    ],
-  },
-  {
-    title: 'Utilitaires',
-    components: [
-      { name: 'LanguageSwitcher', slug: 'languageswitcher', description: 'Sélecteur de langue pour les sites multilingues (français, tahitien, anglais).' },
-    ],
-  },
-];
-
-const total = categories.reduce((sum, c) => sum + c.components.length, 0);
 ---
 
 <BaseLayout
   title="Composants"
   current="components"
-  description="Catalogue des composants Ori avec liens vers la documentation interactive (Storybook) pour React et Angular"
+  description="Bibliothèque de composants Ori : doc interactive dans les Storybook React et Angular"
 >
   <Sidebar current="components-index" />
 
-  <article class="site-content site-content--wide">
+  <article class="site-content">
     <h1>Composants</h1>
     <p>
-      Ori expose <strong>{total} composants</strong> couvrant les besoins courants
-      des portails usagers, espaces agents et sites institutionnels. La documentation
-      interactive de chaque composant - props, variantes, états, exemples vivants -
-      est disponible dans les Storybook React et Angular.
+      La documentation détaillée des composants Ori vit dans les Storybook
+      React et Angular : props, variantes, états, exemples interactifs et
+      vérifications d'accessibilité y sont auto-générés à partir des
+      sources et restent toujours alignés sur la dernière version
+      publiée.
     </p>
 
-    <aside class="ori-callout ori-callout--note" role="note" style="margin-block: 1.5rem;">
-      <svg
-        class="ori-callout__icon"
-        aria-hidden="true"
-        focusable="false"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 4a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm1 12h-2v-7h2v7z" />
-      </svg>
-      <div class="ori-callout__body">
-        <strong class="ori-callout__title">Pourquoi Storybook plutôt qu'Astro ?</strong>
-        <p style="margin: 0;">
-          La documentation des composants est isolée par composant, interactive
-          (Controls, Args), et auto-générée à partir des types TypeScript. Astro
-          reste le canal pour les guides éditoriaux, fondations et patterns d'usage.
-        </p>
-      </div>
-    </aside>
+    <p>
+      Le site Astro reste le canal pour les fondations, les patterns
+      d'usage et les guides de démarrage. Pour explorer un composant
+      donné, ouvrir le Storybook correspondant à votre framework.
+    </p>
 
-    {
-      categories.map((category) => (
-        <section class="components-category">
-          <h2>{category.title}</h2>
-          {category.intro && <p class="components-category__intro">{category.intro}</p>}
-          <ul class="components-grid" role="list">
-            {category.components.map((component) => (
-              <li class="components-grid__item">
-                <article class="component-card">
-                  <h3 class="component-card__name">{component.name}</h3>
-                  <p class="component-card__description">{component.description}</p>
-                  <div class="component-card__links">
-                    <a
-                      class="ori-link"
-                      href={`${storybookReact}?path=/docs/composants-${component.slug}--docs`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Storybook React
-                      <span class="ori-link__external" aria-hidden="true">↗</span>
-                    </a>
-                    <a
-                      class="ori-link"
-                      href={`${storybookAngular}?path=/docs/composants-${component.slug}--docs`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Storybook Angular
-                      <span class="ori-link__external" aria-hidden="true">↗</span>
-                    </a>
-                    <a
-                      class="ori-link ori-link--quiet"
-                      href={`${githubSource}/react/src/components/${component.name}`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Source
-                      <span class="ori-link__external" aria-hidden="true">↗</span>
-                    </a>
-                  </div>
-                </article>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))
-    }
+    <div class="components-cta-grid">
+      <a class="components-cta" href={storybookReact}>
+        <span class="components-cta__eyebrow">Documentation interactive</span>
+        <h2 class="components-cta__title">Storybook React</h2>
+        <p class="components-cta__description">
+          Tous les composants React du package <code>@govpf/ori-react</code>,
+          avec Controls et stories de variantes.
+        </p>
+        <span class="components-cta__action">Ouvrir le Storybook React →</span>
+      </a>
+
+      <a class="components-cta" href={storybookAngular}>
+        <span class="components-cta__eyebrow">Documentation interactive</span>
+        <h2 class="components-cta__title">Storybook Angular</h2>
+        <p class="components-cta__description">
+          Tous les composants Angular du package <code>@govpf/ori-angular</code>,
+          avec Controls et stories de variantes.
+        </p>
+        <span class="components-cta__action">Ouvrir le Storybook Angular →</span>
+      </a>
+    </div>
+
+    <h2>Source du code</h2>
+    <p>
+      Le code des composants est versionné dans le monorepo
+      <a href="https://github.com/govpf/ori" target="_blank" rel="noreferrer">github.com/govpf/ori</a>
+      sous <code>packages/react/src/components/</code> et
+      <code>packages/angular/src/components/</code>. Les tokens et
+      conventions visuelles sont décrits dans la section
+      <a href={`${base}fondations/palette/`}>Fondations</a>.
+    </p>
   </article>
 </BaseLayout>
 
 <style>
-  .components-category {
-    margin-block: 2.5rem;
-  }
-  .components-category__intro {
-    color: var(--color-text-secondary);
-    margin: 0 0 1rem;
-    line-height: 1.6;
-  }
-  .components-grid {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+  .components-cta-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
     gap: 1rem;
+    margin: 1.5rem 0 2.5rem;
   }
-  .component-card {
+  .components-cta {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding: 1rem 1.25rem;
-    border: 1px solid var(--color-border-subtle);
+    padding: 1.5rem;
+    border: 1px solid var(--color-border-default);
     border-radius: 0.5rem;
     background-color: var(--color-surface-base);
-    height: 100%;
-    transition: border-color 150ms, box-shadow 150ms;
+    color: var(--color-text-primary);
+    text-decoration: none;
+    transition:
+      border-color 150ms,
+      box-shadow 150ms,
+      transform 150ms;
   }
-  .component-card:hover {
-    border-color: var(--color-border-default);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  .components-cta:hover {
+    border-color: var(--color-brand-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   }
-  .component-card__name {
+  .components-cta__eyebrow {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-brand-primary);
+  }
+  .components-cta__title {
     margin: 0;
-    font-size: 1rem;
+    font-size: 1.25rem;
     font-weight: 600;
     color: var(--color-text-primary);
   }
-  .component-card__description {
+  .components-cta__description {
     margin: 0;
-    font-size: 0.875rem;
+    font-size: 0.9375rem;
     line-height: 1.55;
     color: var(--color-text-secondary);
     flex: 1 1 auto;
   }
-  .component-card__links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.875rem;
+  .components-cta__action {
     margin-top: 0.5rem;
-    font-size: 0.8125rem;
-  }
-  .site-content--wide {
-    max-width: 100%;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-brand-primary);
   }
 </style>

--- a/apps/ori-site/src/pages/react/patterns.mdx
+++ b/apps/ori-site/src/pages/react/patterns.mdx
@@ -51,8 +51,8 @@ wrapper qui ajoute du comportement.
 
 ## Réutiliser les classes CSS pour un composant 100% custom
 
-Si tu as besoin d'un composant qui n'existe pas dans Ori mais qui
-doit avoir le look du DS, utilise les classes :
+Pour un composant qui n'existe pas dans Ori mais qui doit avoir le
+look du DS, réutiliser directement les classes CSS :
 
 ```tsx
 export function ResultCard({ title, count }: { title: string; count: number }) {

--- a/apps/ori-site/src/pages/ressources/contribuer.mdx
+++ b/apps/ori-site/src/pages/ressources/contribuer.mdx
@@ -42,7 +42,7 @@ soumise.
 ### Prérequis
 
 - **Node.js 20.11+** (recommandé : Node 24 LTS, comme la CI)
-- **pnpm 10.29+** (gestionnaire de paquets — `corepack enable && corepack prepare pnpm@latest --activate`)
+- **pnpm 10.29+** (gestionnaire de paquets - `corepack enable && corepack prepare pnpm@latest --activate`)
 - **Git**
 - **Docker** (optionnel, pour tester la CI en local via `act`)
 
@@ -111,7 +111,7 @@ Ori suit quelques règles de fond, documentées dans la page
 - **Préférer le HTML natif** quand il couvre le besoin
 - **Bundle minimal** : chaque dépendance ajoutée doit être justifiée
 - **Généricité institutionnelle** : pas de domaine métier hardcodé
-- **Aucun dark pattern**
+- **Aucun design trompeur** (faux compteurs d'urgence, opt-out cachés, etc.)
 
 Pour toute modification d'un composant DS (`packages/react/`,
 `packages/angular/`, `packages/tailwind-preset/`) :

--- a/apps/ori-site/src/pages/ressources/securite.mdx
+++ b/apps/ori-site/src/pages/ressources/securite.mdx
@@ -78,7 +78,7 @@ Sont **hors périmètre** :
 - la plateforme Keycloak du Gouvernement (les écrans documentés ici
   sont des spécifications, pas une instance en production)
 - les vulnérabilités déjà rapportées et publiées dans les CVE des
-  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) — elles
+  dépendances tierces (Angular, React, Tailwind, Lucide, etc.) - elles
   sont traitées via Dependabot
 
 ## Divulgation responsable

--- a/packages/docs/src/Decisions-A-Prendre.mdx
+++ b/packages/docs/src/Decisions-A-Prendre.mdx
@@ -48,7 +48,7 @@ tranchées au fil de l'implémentation.
   mobile en zone à faible débit). Chaque dépendance ajoutée doit se
   justifier par un besoin réel, pas par une hypothèse "on en aura
   peut-être besoin".
-- **Pas de dark patterns**. Les boutons doivent être clairs, les
+- **Pas de design trompeur**. Les boutons doivent être clairs, les
   validations explicites, les actions destructives confirmées. C'est de
   la base mais ça oriente certains choix d'API (cf. B.5 sur la
   composition Button, B.4 sur le `dismissible` boolean explicite).
@@ -245,12 +245,12 @@ marine institutionnel PF). En light, ce bleu sombre sur fond `feedback-info-bg`
 (info-50, bleu très clair) contraste correctement. En dark, ce même bleu
 sombre est utilisé comme **couleur de texte** sur un fond `feedback-info-bg`
 qui est lui-même très sombre (mix 18 % de info-500 sur transparent ≈
-neutral-900) — d'où un bleu sombre sur bleu sombre, illisible.
+neutral-900) - d'où un bleu sombre sur bleu sombre, illisible.
 
 Le fix est analogue à ce qu'on fait déjà pour `--color-brand-primary` :
 on aligne `--color-feedback-info` sur `primary-400` (#5980ff) en dark.
 Cet alignement préserve l'invariant "info = primary" (vrai en light via
-`info-500 = primary-500`) — sans ce choix, l'item courant du SideMenu
+`info-500 = primary-500`) - sans ce choix, l'item courant du SideMenu
 (qui utilise `brand-primary`) et un bandeau Notification info, identiques
 en light, divergeraient en dark. Les tons saturés des autres feedbacks
 (success-500 vert vif, warning-500 orange vif, danger-500 rouge vif)

--- a/packages/docs/src/Iconography.mdx
+++ b/packages/docs/src/Iconography.mdx
@@ -238,6 +238,6 @@ les apps consommatrices.
 
 ## Décision
 
-À acter par l'équipe ou en mode solo dev par toi-même. Une fois validée,
-mettre à jour cette page pour la transformer de "page de décision" en
-"page de référence d'usage".
+À acter par l'équipe DS. Une fois la décision validée, mettre à jour
+cette page pour la transformer de "page de décision" en "page de
+référence d'usage".

--- a/packages/docs/src/Strategie-Ouverture.mdx
+++ b/packages/docs/src/Strategie-Ouverture.mdx
@@ -30,7 +30,7 @@ repo n'est pas privé sur le réseau.
 
 ## Les vrais sujets de sécurité ne sont pas dans le DS
 
-Aucune décision UI ne doit être *load-bearing* pour la sécurité. Les
+Aucune décision UI ne doit être _load-bearing_ pour la sécurité. Les
 contrôles vivent côté serveur :
 
 - authentification et fédération d'identité (Keycloak)
@@ -47,14 +47,14 @@ classe `.ori-form` ou la structure d'un écran Keycloak, c'est une faille
 
 Toutes les administrations comparables publient leur DS :
 
-| Administration | Design system | Licence |
-|---|---|---|
-| France | DSFR | MIT |
-| Royaume-Uni | GOV.UK Design System | MIT |
-| États-Unis | USWDS | Domaine public (CC0 / public.gov.uk) |
-| Canada | Canada.ca / GC Design System | MIT |
-| Australie | Australian GOV Design System | MIT |
-| Belgique | DS BOSA | EUPL |
+| Administration | Design system                | Licence                              |
+| -------------- | ---------------------------- | ------------------------------------ |
+| France         | DSFR                         | MIT                                  |
+| Royaume-Uni    | GOV.UK Design System         | MIT                                  |
+| États-Unis     | USWDS                        | Domaine public (CC0 / public.gov.uk) |
+| Canada         | Canada.ca / GC Design System | MIT                                  |
+| Australie      | Australian GOV Design System | MIT                                  |
+| Belgique       | DS BOSA                      | EUPL                                 |
 
 C'est un signal fort : en service public, le bénéfice (transparence,
 contributions externes, audits a11y/sécu communautaires, crédibilité,
@@ -86,7 +86,7 @@ dans les défenses citées plus haut est plus efficace.
   structures associatives à mission de service public peuvent partir de
   Ori plutôt que repartir de zéro.
 - **Documentation forcée** : un repo public oblige à écrire une doc
-  utilisable par un externe — ce qui sert aussi en interne.
+  utilisable par un externe - ce qui sert aussi en interne.
 
 ## Coût réel à anticiper
 
@@ -108,18 +108,21 @@ Politique claire à afficher dès le début, par exemple dans le README :
 Trois zones à garder strictement internes même quand le DS est open source :
 
 ### 1. Secrets et configurations d'infra
+
 - Fichiers `.env*`, credentials, certificats, clés privées, tokens d'API
 - IPs internes, hostnames intranet, URLs d'admin Keycloak
 - Configurations Keycloak réelles (au-delà des templates FTL publics
   documentés ici)
 
 ### 2. Cartographie des consommateurs
-- Ne pas publier la liste exhaustive *"service A utilise Ori@1.2.3,
-  service B utilise Ori@1.4.0"*
+
+- Ne pas publier la liste exhaustive _"service A utilise Ori@1.2.3,
+  service B utilise Ori@1.4.0"_
 - Cela faciliterait le fingerprinting et le ciblage de campagnes
 - Le DS est public ; l'inventaire d'usage reste interne
 
 ### 3. Stratégie supply chain
+
 - Mesures de protection du compte npm (2FA, restrictions IP, audit logs)
 - Plan de réponse en cas de compromission de package
 - Liste des mainteneurs autorisés à publier
@@ -135,10 +138,10 @@ L'historique git garde tout. Un secret committé puis supprimé par un
 commit suivant **reste visible** dans l'historique. Doit être traité
 avant publication.
 
-- [ ] Lancer `gitleaks detect --source . --no-git` (HEAD courant)
-- [ ] Lancer `gitleaks detect --source .` (historique complet)
+- [x] Lancer `gitleaks detect --source . --no-git` (HEAD courant)
+- [x] Lancer `gitleaks detect --source .` (historique complet)
 - [ ] Alternative : `trufflehog filesystem .` ou `trufflehog git file://.`
-- [ ] Vérifier qu'il n'y a pas de fichiers `.env*`, `*.key`, `*.pem`,
+- [x] Vérifier qu'il n'y a pas de fichiers `.env*`, `*.key`, `*.pem`,
       `id_rsa`, `credentials.json`, `secrets.yaml` dans aucun commit
 - [ ] Si un secret est trouvé : ne **jamais** se contenter d'un commit de
       suppression. Utiliser `git-filter-repo --path xxx --invert-paths`
@@ -146,78 +149,79 @@ avant publication.
 
 ### B. Audit des dépendances
 
-- [ ] `pnpm audit --prod` : zéro vulnérabilité critical/high non résolue
+- [x] `pnpm audit --prod` : zéro vulnérabilité critical/high non résolue
+      (vérifié en CI sur chaque PR via le job "Security audit (pnpm audit)")
 - [ ] Vérifier que toutes les licences des deps sont compatibles avec la
       licence du DS (MIT, Apache, ISC, BSD : OK ; GPL : à éviter pour un
       DS sous MIT)
-- [ ] Activer **Dependabot** (ou Renovate) sur le repo, avec security
+- [x] Activer **Dependabot** (ou Renovate) sur le repo, avec security
       updates activés
-- [ ] Pinner les versions critiques dans `pnpm-lock.yaml` (committed)
-- [ ] Vérifier qu'il n'y a pas de scripts `postinstall` dans nos
+- [x] Pinner les versions critiques dans `pnpm-lock.yaml` (committed)
+- [x] Vérifier qu'il n'y a pas de scripts `postinstall` dans nos
       `package.json` (vecteur classique de supply chain attack)
 
 ### C. Configuration GitHub
 
-- [ ] **Branch protection** sur `main` :
+- [x] **Branch protection** sur `main` :
   - PR obligatoire avant merge
   - 1 review requise (2 sur les changements sensibles)
   - CI verte requise
   - Pas de force push, pas de suppression de branche
 - [ ] **CODEOWNERS** : un mainteneur référent par dossier critique
 - [ ] **Required signed commits** activé si l'équipe est setup pour
-- [ ] **2FA obligatoire** pour tous les utilisateurs ayant write access
+- [x] **2FA obligatoire** pour tous les utilisateurs ayant write access
       sur l'organisation GitHub
-- [ ] **Secret scanning + push protection** activés (Settings → Code
+- [x] **Secret scanning + push protection** activés (Settings → Code
       security)
-- [ ] **Dependabot security updates** activés
-- [ ] Pas de variables `secrets.*` exposées dans les workflows publics
+- [x] **Dependabot security updates** activés
+- [x] Pas de variables `secrets.*` exposées dans les workflows publics
 
 ### D. Supply chain npm
 
-- [ ] **2FA obligatoire** sur le compte npm utilisé pour publier
-- [ ] **npm provenance** activée (signatures via GitHub Actions OIDC) :
+- [x] **2FA obligatoire** sur le compte npm utilisé pour publier
+- [x] **npm provenance** activée (signatures via GitHub Actions OIDC) :
       `npm publish --provenance`
-- [ ] Publication explicite en `--access public` (sinon les packages
+- [x] Publication explicite en `--access public` (sinon les packages
       privés ne sont visibles que par l'organisation)
-- [ ] Lockfile `pnpm-lock.yaml` committé et utilisé en CI (`pnpm install
-      --frozen-lockfile`)
-- [ ] Désigner les **mainteneurs autorisés à publier** (limite la
+- [x] Lockfile `pnpm-lock.yaml` committé et utilisé en CI (`pnpm install
+--frozen-lockfile`)
+- [x] Désigner les **mainteneurs autorisés à publier** (limite la
       surface d'attaque)
 - [ ] Plan de réponse documenté en cas de compromission de package
       (yank, rotation, communication)
 
 ### E. Documents légaux
 
-- [ ] **LICENSE** à la racine (recommandé : MIT pour la simplicité ; EUPL
+- [x] **LICENSE** à la racine (recommandé : MIT pour la simplicité ; EUPL
       pour aligner avec d'autres DS européens de service public)
-- [ ] **CONTRIBUTING.md** : règles de contribution, conventions de
+- [x] **CONTRIBUTING.md** : règles de contribution, conventions de
       commit, comment tester localement
-- [ ] **CODE_OF_CONDUCT.md** : standard Contributor Covenant 2.1
-- [ ] **SECURITY.md** : comment signaler une faille (email dédié,
+- [x] **CODE_OF_CONDUCT.md** : standard Contributor Covenant 2.1
+- [x] **SECURITY.md** : comment signaler une faille (email dédié,
       éventuellement clé PGP, délai de réponse promis ex 5 jours
       ouvrés, processus de divulgation responsable)
-- [ ] **README.md** cohérent avec un public externe (pas de jargon
+- [x] **README.md** cohérent avec un public externe (pas de jargon
       interne, lien vers la doc Storybook publique)
 
 ### F. Documentation publique nettoyée
 
-- [ ] Pas de mention de service administratif spécifique (DPAM, etc.) si
+- [x] Pas de mention de service administratif spécifique (DPAM, etc.) si
       la décision projet est de rester générique (cf. décision projet :
       ne pas mentionner DPAM ni l'historique legacy dans la doc)
-- [ ] Pas de captures d'écran avec données réelles d'usagers ou d'agents
-- [ ] Pas de noms d'agents PF dans les exemples
-- [ ] Pas d'IPs internes ou d'URLs `intranet.gov.pf` dans la doc ou les
+- [x] Pas de captures d'écran avec données réelles d'usagers ou d'agents
+- [x] Pas de noms d'agents PF dans les exemples
+- [x] Pas d'IPs internes ou d'URLs `intranet.gov.pf` dans la doc ou les
       stories
-- [ ] Pas de numéros de dossier ou identifiants réels dans les mocks
+- [x] Pas de numéros de dossier ou identifiants réels dans les mocks
 
 ### G. CI/CD
 
-- [ ] Pas de secrets en clair dans `.github/workflows/*.yml`
-- [ ] Permissions GITHUB_TOKEN minimales (`permissions: contents: read`
+- [x] Pas de secrets en clair dans `.github/workflows/*.yml`
+- [x] Permissions GITHUB_TOKEN minimales (`permissions: contents: read`
       par défaut, élargir au cas par cas)
-- [ ] OIDC pour les déploiements (pas de long-lived tokens)
-- [ ] Si un workflow publie sur npm : isolé, avec `environment:
-      production` pour ajouter une review manuelle
+- [x] OIDC pour les déploiements (pas de long-lived tokens)
+- [x] Si un workflow publie sur npm : isolé, avec `environment:
+production` pour ajouter une review manuelle
 
 ### H. Communication et lancement
 
@@ -227,7 +231,7 @@ avant publication.
 - [ ] Préparer 5-10 issues "good first issue" pour amorcer la
       communauté
 - [ ] Surveiller le repo les 2 premières semaines (issues, PRs, stars,
-      forks) — adaptation possible
+      forks) - adaptation possible
 
 ## Après la publication : posture continue
 

--- a/packages/docs/src/angular/Patterns.mdx
+++ b/packages/docs/src/angular/Patterns.mdx
@@ -48,8 +48,8 @@ ajoute du comportement.
 
 ## Réutiliser les classes CSS pour un composant 100% custom
 
-Si tu as besoin d'un composant qui n'existe pas dans Ori mais qui
-doit avoir le look du DS, utilise les classes :
+Pour un composant qui n'existe pas dans Ori mais qui doit avoir le
+look du DS, réutiliser directement les classes CSS :
 
 ```ts
 import { Component, Input } from '@angular/core';
@@ -106,7 +106,7 @@ export class RfInputComponent {
 ```
 
 Pattern similaire pour `<ori-checkbox>`, `<ori-select>`, etc. À factoriser
-si tu en as plusieurs.
+en cas d'usages multiples.
 
 ## Détection de changement OnPush
 
@@ -117,9 +117,9 @@ Cela signifie qu'ils ne se rafraîchissent que sur :
 - Émission d'un `@Output()`
 - Appel manuel à `markForCheck()` / `detectChanges()`
 
-Si tu mutes un objet en place (`this.user.name = 'X'`) et le passes
-à un composant Ori, le rendu ne se met pas à jour. Solution :
-remplacer la référence (`this.user = { ...this.user, name: 'X' }`).
+Muter un objet en place (`this.user.name = 'X'`) puis le passer à
+un composant Ori ne déclenche pas le rendu. Solution : remplacer la
+référence (`this.user = { ...this.user, name: 'X' }`).
 
 ## Anti-patterns
 

--- a/packages/docs/src/components/FileCard.mdx
+++ b/packages/docs/src/components/FileCard.mdx
@@ -46,7 +46,7 @@ Le DS porte ces choix une fois pour toutes :
 | `archive` | `FileArchive` | Archive |
 | `other` | `File` | Fichier |
 
-Le `type` n'est **pas dérivé automatiquement** de l'extension du `name` —
+Le `type` n'est **pas dérivé automatiquement** de l'extension du `name` -
 c'est l'app qui doit le passer explicitement, pour éviter les surprises
 (un `.txt`, un `.json`, un type MIME exotique…). Si l'app dispose du
 type MIME, elle peut le mapper vers l'un des 6 `type` standardisés ; pour
@@ -80,7 +80,7 @@ Les actions sont des boutons icône **ghost / size sm** affichés en haut
 ## Bonnes pratiques
 
 - **3 actions max** dans `actions`. Au-delà, regrouper les actions secondaires dans un menu kebab côté app.
-- **Garder le nom du fichier exact** dans `name` — y compris l'extension. L'utilisateur a besoin de la voir pour reconnaître son fichier.
+- **Garder le nom du fichier exact** dans `name` - y compris l'extension. L'utilisateur a besoin de la voir pour reconnaître son fichier.
 - **`size` formaté humainement** (ex: `'1.2 Mo'`, `'850 Ko'`), pas en octets bruts. Le DS n'en fait pas le formatage : c'est du contenu applicatif.
 - **`meta` court**. Une date d'ajout, un auteur, un statut. Pas de phrase complète.
 - **`link` pour pointer vers le contexte**, pas pour une action sur le fichier. Le téléchargement ou l'aperçu vont dans `actions`.

--- a/packages/docs/src/react/Patterns.mdx
+++ b/packages/docs/src/react/Patterns.mdx
@@ -48,8 +48,8 @@ wrapper qui ajoute du comportement.
 
 ## Réutiliser les classes CSS pour un composant 100% custom
 
-Si tu as besoin d'un composant qui n'existe pas dans Ori mais qui
-doit avoir le look du DS, utilise les classes :
+Pour un composant qui n'existe pas dans Ori mais qui doit avoir le
+look du DS, réutiliser directement les classes CSS :
 
 ```tsx
 export function ResultCard({ title, count }: { title: string; count: number }) {

--- a/tmp-npm-stubs/README.md
+++ b/tmp-npm-stubs/README.md
@@ -1,4 +1,4 @@
-# Stubs de réservation npm — @govpf/ori-*
+# Stubs de réservation npm - @govpf/ori-*
 
 Ce dossier contient des packages **vides** dont l'unique but est de
 réserver les noms de packages sur npm avant la publication réelle, pour
@@ -46,7 +46,7 @@ Devrait afficher la version 0.0.0 et la description "Reserved".
   stubs que si tu es **certain** des noms.
 - À la 1re vraie publication (V1), tu remplaceras la version 0.0.0 par
   une version 1.0.0 du package réel via les pipelines de release. Pas
-  besoin de "supprimer" le stub — un `npm publish` avec une version
+  besoin de "supprimer" le stub - un `npm publish` avec une version
   supérieure le remplace naturellement.
 - Une fois les stubs publiés, ce dossier `tmp-npm-stubs/` peut être
   supprimé du repo. Il n'a aucune utilité fonctionnelle.


### PR DESCRIPTION
## Résumé

Trois nettoyages éditoriaux + simplification du catalogue composants.

## Catalogue composants

La page \`/composants/\` ne maintient plus une liste manuelle dérivée du Storybook (qui devenait obsolète). Remplacée par **2 cartes CTA** pointant vers Storybook React et Angular, seuls index auto-générés et toujours à jour.

Pattern adopté par Material UI, Chakra, Radix : la doc publique curate les fondations et patterns, le Storybook curate les composants.

## Style éditorial

- **Tutoiement → forme impersonnelle** dans toute la doc (6 fichiers, Storybook + site Astro). Le ton institutionnel s'adresse à une équipe, pas à un dev seul.
- **\"dark patterns\" → \"design trompeur\"** (terme officiel CNIL/UE) + exemples pour éviter la collision visuelle avec \"dark mode\" (3 fichiers).
- **Em-dash typographiques → hyphen** dans 9 fichiers (README, SECURITY, CONTRIBUTING, MDX Storybook et copies Astro).

## Sync checklist sécurité

\`packages/docs/src/Strategie-Ouverture.mdx\` (consommé par les 2 Storybooks) resynchronisé avec \`docs/architecture/strategie-ouverture.md\` : **31 cases cochées sur 41** reflètent l'état réel du repo (branch protection, Dependabot, npm provenance, docs légaux, etc.).

## Test plan

- [ ] Site Astro local : vérifier la page \`/composants/\` (2 cartes CTA + lien GitHub)
- [ ] Storybook local : vérifier la page \"Documentation générale / Stratégie d'ouverture\" (cases cochées visibles)
- [ ] CI verte