### PR TITLE
chore(ci): gate strict sur les vulnérabilités des packages publiés

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,3 +262,51 @@ jobs:
         run: pnpm audit --prod --audit-level critical
       - name: Audit high (informational)
         run: pnpm audit --prod --audit-level high || true
+
+  # ─── Audit ciblé : packages publiés ───────────────────────────────────
+  # Garde stricte : tolérance zéro sur les paths qui commencent par
+  # `packages__` (= ce qui est installé chez les consommateurs des
+  # packages npm publiés `@govpf/*`). Les vulnérabilités dans les apps
+  # internes (`apps__*` : site doc, demos, playgrounds) restent gérées
+  # par le job `audit` ci-dessus.
+  #
+  # Ce gate formalise la posture documentée dans SECURITY.md : un service
+  # PF qui consomme @govpf/ori-react ne doit jamais hériter d'une CVE
+  # connue via la supply chain Ori.
+  audit-published:
+    name: Security audit (published packages)
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Fail on any vulnerability in published packages
+        run: |
+          # `pnpm audit --prod --json` renvoie un objet `advisories` quand
+          # il trouve quelque chose, ou rien sinon (exit 0). On capture le
+          # JSON et on filtre les paths qui touchent `packages/*`. Le
+          # filtre `// {}` rend la commande robuste même si le champ
+          # advisories est absent.
+          json=$(pnpm audit --prod --json 2>/dev/null || true)
+          paths=$(printf '%s' "$json" | jq -r '
+            [.advisories // {}
+             | to_entries[]
+             | .value
+             | {sev: .severity, pkg: .module_name, paths: .findings[].paths[]}
+             | select(.paths | startswith("packages__"))
+             | "\(.sev | ascii_upcase) - \(.pkg) via \(.paths)"
+            ] | .[]
+          ')
+          if [ -n "$paths" ]; then
+            echo "::error::Vulnérabilité détectée dans un package publié :"
+            echo "$paths"
+            exit 1
+          fi
+          echo "OK : aucune vulnérabilité dans les packages publiés."

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,47 @@ Sont **hors périmètre** :
   dépendances tierces (Angular, React, Tailwind, Lucide, etc.) - elles
   sont traitées via Dependabot
 
+## Posture de la supply chain
+
+Le dépôt contient deux familles de code aux exigences distinctes :
+
+- **Packages publiés** (`packages/{tokens,tailwind-preset,css,react,angular}`) :
+  c'est ce qui est installé chez les services consommateurs. Tolérance
+  zéro sur les vulnérabilités, quelle que soit la sévérité. La CI
+  applique cette garantie via le job
+  **Security audit (published packages)** qui échoue dès qu'un advisory
+  pnpm pointe vers un path `packages/*`.
+- **Apps internes** (`apps/{ori-site,demo-portail,playground-*,storybook-*}`) :
+  outils de documentation, démonstration et développement qui ne sont
+  pas publiés sur npm. Leurs vulnérabilités (Astro, Vite, esbuild, etc.)
+  ne se propagent pas aux consommateurs des packages. Elles sont
+  traitées en best-effort via le job **Security audit (pnpm audit)**
+  (bloquant sur `critical` uniquement), Dependabot et des bumps
+  périodiques.
+
+### Vérification côté consommateur
+
+Un service qui consomme Ori peut s'assurer que sa supply chain reste
+propre via les outils standards :
+
+```bash
+pnpm audit --prod        # ou npm audit --omit=dev / yarn audit
+```
+
+Aucune vulnérabilité connue ne devrait apparaître via les paths
+`@govpf/ori-*`. Si c'est le cas, ouvrir un advisory (cf. canaux
+ci-dessus) ou une issue publique selon la sévérité.
+
+### Principes côté Ori
+
+- Les `dependencies` runtime des packages publiés sont volontairement
+  **minimales** (Radix Dialog, clsx, lucide pour React ; rien pour
+  Angular hors peer deps). Chaque ajout est revu sous l'angle bundle
+  et surface d'attaque.
+- Les outils de build/dev (Vite, Astro, Storybook) restent confinés
+  aux `devDependencies` du monorepo. Ils ne sont jamais distribués
+  via npm.
+
 ## Divulgation responsable
 
 Ori suit une politique de **divulgation coordonnée** :


### PR DESCRIPTION
## Résumé

- Ajoute un job CI **Security audit (published packages)** : tolérance zéro sur tout advisory pnpm pointant vers un path `packages/*`
- Documente la posture supply chain dans **SECURITY.md** (séparation packages publiés vs apps internes, procédure de vérification consommateur)

## Pourquoi

Les 29 alertes Dependabot ouvertes concernent toutes des outils de build/dev (Astro, Vite, esbuild, postcss, picomatch, uuid) confinés à `apps/*`. `pnpm audit --prod` filtré sur les paths `packages__*` retourne un tableau vide aujourd'hui : aucun consommateur de `@govpf/ori-react` ou `@govpf/ori-angular` n'hérite de vulnérabilité connue.

Cette PR fige cette posture comme une **garantie automatique** : tout ajout futur d'une dépendance compromise dans un `packages/*` bloquera la CI.

## Détails

- Le job existant `Security audit (pnpm audit)` reste tel quel (bloquant sur `critical`, informational sur `high`) pour le monorepo entier.
- Le nouveau job `Security audit (published packages)` parse le JSON de `pnpm audit --prod` et filtre les paths `packages__*`. Émet une `::error::` GitHub Actions avec le détail (sévérité, package, path) si quelque chose remonte.
- `SECURITY.md` gagne une section "Posture de la supply chain" qui explique aux consommateurs externes comment vérifier que leur supply chain reste propre (`pnpm audit --prod`) et quels principes Ori applique pour minimiser la surface d'attaque (deps runtime minimales, outils de build en `devDependencies`).

## Test plan

- [x] Test local de la commande : `pnpm audit --prod --json | jq ...` -> exit 0 (zéro vuln en `packages/*`)
- [x] Test du chemin d'échec : input falsifié avec un path `packages__react>foo` -> exit 1 + message d'erreur lisible
- [x] `pnpm format:check` -> OK
- [ ] CI verte sur cette PR