### PR TITLE
feat(tests): tests unitaires Vitest sur 5 composants React

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,29 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  # ─── Tests unitaires ──────────────────────────────────────────────────
+  # Vitest + @testing-library/react : couvre la logique des composants
+  # React (callbacks, états, branches conditionnelles, navigation
+  # clavier). Complémentaire des tests a11y axe-core (qui couvrent le
+  # rendu DOM accessible des stories) et des stories Storybook elles-
+  # mêmes (galerie visuelle).
+  unit-tests-react:
+    name: Unit tests React
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Run Vitest
+        run: pnpm --filter @govpf/ori-react test
+
   # ─── Build apps consommatrices ────────────────────────────────────────
   # Validation que tous les consommateurs (storybooks, site Astro, demo)
   # buildent correctement avec les packages publiés.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,9 @@ pnpm --filter @govpf/ori-storybook-angular build
 pnpm --filter @govpf/ori-site build
 pnpm --filter @govpf/ori-demo-portail build
 
+# Tests unitaires (Vitest sur les composants React à logique non triviale)
+pnpm --filter @govpf/ori-react test
+
 # Tests d'accessibilité automatisés (axe-core sur chaque story)
 pnpm --filter @govpf/ori-storybook-react test:a11y:ci
 pnpm --filter @govpf/ori-storybook-angular test:a11y:ci
@@ -174,6 +177,50 @@ Conséquences pratiques pour qui ajoute ou modifie un composant :
 Pour exécuter contre un Storybook qui tourne déjà en local
 (`pnpm --filter ... storybook`), utiliser `test:a11y` au lieu de
 `test:a11y:ci`.
+
+#### Tests unitaires (Vitest)
+
+Côté React, **Vitest + @testing-library/react** sont configurés dans
+`packages/react`. Le runner couvre la **logique** des composants
+(callbacks, transitions d'état, navigation clavier, validations) que
+les tests a11y et les stories ne couvrent pas.
+
+```bash
+pnpm --filter @govpf/ori-react test           # CI : run + exit
+pnpm --filter @govpf/ori-react test:watch     # dev : re-run on change
+```
+
+Convention : un fichier de test par composant, à côté du composant.
+
+```
+packages/react/src/components/Button/
+├── Button.tsx
+├── Button.stories.tsx
+├── Button.test.tsx          ← ici
+└── index.ts
+```
+
+Cibles prioritaires (ce qui mérite un test unitaire) :
+
+- **logique métier** : calcul de pages dans Pagination, validation
+  type/taille dans FileUpload, timer auto-dismiss du Toast
+- **transitions d'état** : ouverture/fermeture, sélection, focus
+- **navigation clavier** : Arrow keys dans Tabs, Home/End
+- **branches conditionnelles** : disabled, loading, error
+- **régressions identifiées** : tout bug corrigé devrait gagner un
+  test pour empêcher le retour (cf. cas Highlight `query=""` qui
+  surlignait tout)
+
+Ce qui **n'a pas besoin** d'un test unitaire :
+
+- composants de présentation pure (Tag, Card, Avatar, Skeleton...) :
+  les stories suffisent comme galerie + a11y
+- wrapping triviaux d'une lib externe (Dialog → Radix) : tester la
+  lib externe est hors-scope ; couvrir les stories suffit
+
+Côté Angular, **Jest** sera configuré dans une PR ultérieure (le
+runner natif Karma est en fin de vie ; on attend la stabilisation de
+`@angular/build` avec Jest avant de migrer).
 
 ### 4. Conventions de commits
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,7 +28,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "dev": "tsc -p tsconfig.build.json --watch",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
@@ -40,9 +42,15 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "typescript": "~5.6.2"
+    "@vitejs/plugin-react": "^5.2.0",
+    "jsdom": "^29.1.0",
+    "typescript": "~5.6.2",
+    "vitest": "^4.1.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/FileUpload/FileUpload.test.tsx
+++ b/packages/react/src/components/FileUpload/FileUpload.test.tsx
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FileUpload } from './FileUpload';
+
+function makeFile(name: string, type: string, size = 100): File {
+  const f = new File(['x'.repeat(size)], name, { type });
+  // Vérification : la taille du blob est respectée
+  Object.defineProperty(f, 'size', { value: size });
+  return f;
+}
+
+function getInput(): HTMLInputElement {
+  // L'input file est <input type="file"> avec class ori-file__input
+  // Il n'a pas de role accessible standard, on le récupère par sélecteur.
+  const input = document.querySelector('input[type="file"]');
+  if (!input) throw new Error('input file not found');
+  return input as HTMLInputElement;
+}
+
+async function uploadFiles(input: HTMLInputElement, files: File[]) {
+  // On utilise fireEvent.change plutôt que userEvent.upload pour
+  // bypasser la validation HTML `accept` de l'input. C'est notre
+  // composant qui doit faire la validation et émettre `onReject` ;
+  // on veut couvrir ce code, donc on lui passe les fichiers tels quels.
+  Object.defineProperty(input, 'files', { value: files, configurable: true });
+  fireEvent.change(input);
+}
+// userEvent reste utilisé ailleurs (clics sur boutons) ; on garde son import
+void userEvent;
+
+describe('FileUpload', () => {
+  describe('sélection de fichier', () => {
+    it('appelle onFilesChange quand un fichier est sélectionné', async () => {
+      const onFilesChange = vi.fn();
+      render(<FileUpload onFilesChange={onFilesChange} />);
+      await uploadFiles(getInput(), [makeFile('cv.pdf', 'application/pdf')]);
+      expect(onFilesChange).toHaveBeenCalledTimes(1);
+      expect(onFilesChange.mock.calls[0][0]).toHaveLength(1);
+      expect(onFilesChange.mock.calls[0][0][0].name).toBe('cv.pdf');
+    });
+
+    it('en mode incontrôlé, garde un seul fichier par défaut (multiple=false)', async () => {
+      render(<FileUpload />);
+      await uploadFiles(getInput(), [
+        makeFile('a.pdf', 'application/pdf'),
+        makeFile('b.pdf', 'application/pdf'),
+      ]);
+      // multiple=false → un seul fichier conservé
+      expect(screen.getAllByText(/\.pdf$/)).toHaveLength(1);
+    });
+
+    it('en mode multiple, accumule les fichiers à chaque sélection', async () => {
+      const onFilesChange = vi.fn();
+      const { rerender } = render(<FileUpload multiple onFilesChange={onFilesChange} />);
+      await uploadFiles(getInput(), [makeFile('a.pdf', 'application/pdf')]);
+      // simuler un re-render après la 1ère sélection (le state interne est mis à jour
+      // automatiquement, on doit juste laisser React refléter)
+      rerender(<FileUpload multiple onFilesChange={onFilesChange} />);
+      await uploadFiles(getInput(), [makeFile('b.pdf', 'application/pdf')]);
+      expect(onFilesChange).toHaveBeenLastCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'a.pdf' }),
+          expect.objectContaining({ name: 'b.pdf' }),
+        ]),
+      );
+    });
+  });
+
+  describe('validation par type (accept)', () => {
+    it('accepte un fichier qui matche un MIME exact', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(
+        <FileUpload accept="application/pdf" onFilesChange={onFilesChange} onReject={onReject} />,
+      );
+      await uploadFiles(getInput(), [makeFile('cv.pdf', 'application/pdf')]);
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('accepte un fichier qui matche un wildcard MIME (image/*)', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(<FileUpload accept="image/*" onFilesChange={onFilesChange} onReject={onReject} />);
+      await uploadFiles(getInput(), [makeFile('photo.png', 'image/png')]);
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('accepte un fichier qui matche une extension (.pdf)', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(<FileUpload accept=".pdf" onFilesChange={onFilesChange} onReject={onReject} />);
+      // Type MIME bidon, mais l'extension matche → accepté
+      await uploadFiles(getInput(), [makeFile('cv.pdf', '')]);
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('rejette un fichier dont le type ne matche pas', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(
+        <FileUpload accept="application/pdf" onFilesChange={onFilesChange} onReject={onReject} />,
+      );
+      await uploadFiles(getInput(), [makeFile('photo.png', 'image/png')]);
+      expect(onReject).toHaveBeenCalledTimes(1);
+      expect(onReject.mock.calls[0][0]).toEqual([
+        expect.objectContaining({
+          file: expect.objectContaining({ name: 'photo.png' }),
+          reason: 'type',
+        }),
+      ]);
+      expect(onFilesChange).not.toHaveBeenCalled();
+    });
+
+    it("ne valide rien quand accept n'est pas fourni", async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(<FileUpload onFilesChange={onFilesChange} onReject={onReject} />);
+      await uploadFiles(getInput(), [makeFile('foo.xyz', 'application/octet-stream')]);
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onReject).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation par taille (maxSize)', () => {
+    it('accepte un fichier sous la limite', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(<FileUpload maxSize={1024} onFilesChange={onFilesChange} onReject={onReject} />);
+      await uploadFiles(getInput(), [makeFile('small.pdf', 'application/pdf', 500)]);
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onReject).not.toHaveBeenCalled();
+    });
+
+    it('rejette un fichier au-dessus de la limite', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(<FileUpload maxSize={1024} onFilesChange={onFilesChange} onReject={onReject} />);
+      await uploadFiles(getInput(), [makeFile('big.pdf', 'application/pdf', 2048)]);
+      expect(onReject).toHaveBeenCalledTimes(1);
+      expect(onReject.mock.calls[0][0][0].reason).toBe('size');
+      expect(onFilesChange).not.toHaveBeenCalled();
+    });
+
+    it('mélange : remonte les acceptés via onFilesChange et les rejetés via onReject', async () => {
+      const onReject = vi.fn();
+      const onFilesChange = vi.fn();
+      render(
+        <FileUpload
+          multiple
+          maxSize={1024}
+          accept="application/pdf"
+          onFilesChange={onFilesChange}
+          onReject={onReject}
+        />,
+      );
+      await uploadFiles(getInput(), [
+        makeFile('ok.pdf', 'application/pdf', 500),
+        makeFile('too-big.pdf', 'application/pdf', 2048),
+        makeFile('wrong.png', 'image/png', 500),
+      ]);
+      expect(onFilesChange.mock.calls[0][0]).toEqual([expect.objectContaining({ name: 'ok.pdf' })]);
+      expect(onReject.mock.calls[0][0]).toEqual([
+        expect.objectContaining({ reason: 'size' }),
+        expect.objectContaining({ reason: 'type' }),
+      ]);
+    });
+  });
+
+  describe('drag & drop', () => {
+    it('ajoute la classe --dragging pendant le drag over', () => {
+      const { container } = render(<FileUpload />);
+      const dropzone = container.querySelector('.ori-file__dropzone')!;
+      fireEvent.dragOver(dropzone);
+      expect(dropzone).toHaveClass('ori-file__dropzone--dragging');
+      fireEvent.dragLeave(dropzone);
+      expect(dropzone).not.toHaveClass('ori-file__dropzone--dragging');
+    });
+
+    it('appelle handleIncoming au drop', () => {
+      const onFilesChange = vi.fn();
+      const { container } = render(<FileUpload onFilesChange={onFilesChange} />);
+      const dropzone = container.querySelector('.ori-file__dropzone')!;
+      const file = makeFile('drop.pdf', 'application/pdf');
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [file] },
+      });
+      expect(onFilesChange).toHaveBeenCalled();
+      expect(onFilesChange.mock.calls[0][0][0].name).toBe('drop.pdf');
+    });
+
+    it('disabled : le drop ne déclenche aucun callback', () => {
+      const onFilesChange = vi.fn();
+      const { container } = render(<FileUpload disabled onFilesChange={onFilesChange} />);
+      const dropzone = container.querySelector('.ori-file__dropzone')!;
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [makeFile('x.pdf', 'application/pdf')] },
+      });
+      expect(onFilesChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('liste affichée et suppression', () => {
+    it('affiche la liste des fichiers sélectionnés avec leur taille formatée', async () => {
+      render(<FileUpload multiple />);
+      await uploadFiles(getInput(), [
+        makeFile('petit.pdf', 'application/pdf', 500),
+        makeFile('moyen.pdf', 'application/pdf', 50_000),
+      ]);
+      expect(screen.getByText('petit.pdf')).toBeInTheDocument();
+      expect(screen.getByText('500 o')).toBeInTheDocument();
+      expect(screen.getByText('moyen.pdf')).toBeInTheDocument();
+      expect(screen.getByText('48.8 Ko')).toBeInTheDocument();
+    });
+
+    it('retire un fichier au clic sur "Retirer"', async () => {
+      const user = userEvent.setup();
+      render(<FileUpload />);
+      await uploadFiles(getInput(), [makeFile('cv.pdf', 'application/pdf')]);
+      expect(screen.getByText('cv.pdf')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Retirer cv.pdf' }));
+      expect(screen.queryByText('cv.pdf')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibilité', () => {
+    it("lie hint et error à l'input via aria-describedby", () => {
+      render(<FileUpload hint="PDF uniquement" error="Champ requis" id="cv" />);
+      const input = getInput();
+      const describedBy = input.getAttribute('aria-describedby');
+      expect(describedBy).toContain('cv-error');
+      // hint est masqué quand error est présent (cf. JSX), mais l'ID
+      // dans aria-describedby couvre les deux pour la robustesse
+    });
+
+    it('marque aria-invalid quand error est fourni', () => {
+      render(<FileUpload error="Trop gros" />);
+      expect(getInput()).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it("rend l'erreur avec role=alert", () => {
+      render(<FileUpload error="Type non accepté" />);
+      expect(screen.getByRole('alert')).toHaveTextContent('Type non accepté');
+    });
+  });
+});

--- a/packages/react/src/components/Highlight/Highlight.test.tsx
+++ b/packages/react/src/components/Highlight/Highlight.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Highlight } from './Highlight';
+
+describe('Highlight', () => {
+  describe('mode 1 : sans prop query', () => {
+    it('surligne tout le contenu dans un <mark>', () => {
+      render(<Highlight>important</Highlight>);
+      const mark = screen.getByText('important');
+      expect(mark.tagName).toBe('MARK');
+      expect(mark).toHaveClass('ori-highlight');
+    });
+
+    it('accepte du JSX comme children', () => {
+      render(
+        <Highlight>
+          <span data-testid="inner">contenu</span>
+        </Highlight>,
+      );
+      expect(screen.getByTestId('inner').parentElement?.tagName).toBe('MARK');
+    });
+  });
+
+  describe('mode 2 : recherche inactive (query="")', () => {
+    it('rend les children tels quels sans <mark>', () => {
+      const { container } = render(<Highlight query="">titre</Highlight>);
+      expect(container.querySelector('mark')).toBeNull();
+      expect(container.textContent).toBe('titre');
+    });
+
+    // Régression : avant le fix, query="" était traité comme "pas de
+    // query" et surlignait tout le contenu. C'est le bug qui surlignait
+    // les descriptions des cards quand l'input de recherche était vide.
+    it("ne surligne rien quand l'input de recherche est vide (régression)", () => {
+      const { container } = render(<Highlight query="">Description complète</Highlight>);
+      expect(container.querySelectorAll('mark')).toHaveLength(0);
+    });
+
+    it('rend les children tels quels même si non-string', () => {
+      render(
+        <Highlight query="ti">
+          <span data-testid="inner">titre</span>
+        </Highlight>,
+      );
+      // children non-string + query non-vide → impossible de matcher,
+      // donc pas de surlignage
+      expect(screen.getByTestId('inner').closest('mark')).toBeNull();
+    });
+  });
+
+  describe('mode 2 : recherche active', () => {
+    it('surligne une seule occurrence', () => {
+      const { container } = render(<Highlight query="ti">titre</Highlight>);
+      const marks = container.querySelectorAll('mark');
+      expect(marks).toHaveLength(1);
+      expect(marks[0]).toHaveTextContent('ti');
+    });
+
+    it('surligne plusieurs occurrences', () => {
+      const { container } = render(<Highlight query="a">papa banane</Highlight>);
+      const marks = container.querySelectorAll('mark');
+      expect(marks).toHaveLength(4);
+      marks.forEach((m) => expect(m).toHaveTextContent('a'));
+    });
+
+    it('match insensible à la casse', () => {
+      const { container } = render(<Highlight query="LICE">Licence professionnelle</Highlight>);
+      const marks = container.querySelectorAll('mark');
+      expect(marks).toHaveLength(1);
+      // Le texte affiché conserve la casse d'origine, pas celle de query
+      expect(marks[0]).toHaveTextContent('Lice');
+    });
+
+    it('ne surligne rien quand le query ne match pas', () => {
+      const { container } = render(<Highlight query="xyz">titre</Highlight>);
+      expect(container.querySelectorAll('mark')).toHaveLength(0);
+      expect(container.textContent).toBe('titre');
+    });
+
+    it('préserve le texte non-matché entre les surlignages', () => {
+      const { container } = render(<Highlight query="b">abcabc</Highlight>);
+      // Texte rendu : a + <mark>b</mark> + ca + <mark>b</mark> + c
+      expect(container.textContent).toBe('abcabc');
+      expect(container.querySelectorAll('mark')).toHaveLength(2);
+    });
+
+    it('applique className sur les <mark> générés', () => {
+      const { container } = render(
+        <Highlight query="a" className="custom">
+          banane
+        </Highlight>,
+      );
+      const marks = container.querySelectorAll('mark');
+      expect(marks.length).toBeGreaterThan(0);
+      marks.forEach((m) => {
+        expect(m).toHaveClass('ori-highlight');
+        expect(m).toHaveClass('custom');
+      });
+    });
+  });
+});

--- a/packages/react/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Pagination } from './Pagination';
+
+function renderPag(page: number, totalPages: number, siblings = 1) {
+  const onPageChange = vi.fn();
+  const result = render(
+    <Pagination
+      page={page}
+      totalPages={totalPages}
+      onPageChange={onPageChange}
+      siblings={siblings}
+    />,
+  );
+  return { ...result, onPageChange };
+}
+
+function visiblePages(): (number | '…')[] {
+  const items = Array.from(document.querySelectorAll('ol > li'));
+  // On ignore les boutons prev/next (1er et dernier)
+  return items.slice(1, -1).map((li) => {
+    const txt = li.textContent?.trim();
+    if (txt === '…') return '…';
+    return Number(txt);
+  });
+}
+
+describe('Pagination', () => {
+  describe('rendu compact (peu de pages)', () => {
+    it('ne rend rien si totalPages <= 1 (rien à paginer)', () => {
+      const { container } = render(<Pagination page={1} totalPages={1} onPageChange={vi.fn()} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('affiche toutes les pages sans ellipse quand totalPages <= 2*siblings+5', () => {
+      // siblings=1 → seuil = 7
+      renderPag(3, 7, 1);
+      expect(visiblePages()).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    });
+  });
+
+  describe('rendu avec ellipses', () => {
+    // Ex de la JSDoc : page=5, total=10, siblings=1 → [1, '...', 4, 5, 6, '...', 10]
+    it('insère une ellipse à gauche et à droite quand la page est au milieu', () => {
+      renderPag(5, 10, 1);
+      expect(visiblePages()).toEqual([1, '…', 4, 5, 6, '…', 10]);
+    });
+
+    it("pas d'ellipse à gauche quand la page est proche du début", () => {
+      renderPag(2, 10, 1);
+      expect(visiblePages()).toEqual([1, 2, 3, '…', 10]);
+    });
+
+    it("pas d'ellipse à droite quand la page est proche de la fin", () => {
+      renderPag(9, 10, 1);
+      expect(visiblePages()).toEqual([1, '…', 8, 9, 10]);
+    });
+
+    it('siblings=2 élargit la fenêtre autour de la courante', () => {
+      renderPag(6, 12, 2);
+      expect(visiblePages()).toEqual([1, '…', 4, 5, 6, 7, 8, '…', 12]);
+    });
+  });
+
+  describe('marquage de la page courante', () => {
+    it('met aria-current="page" sur la page courante uniquement', () => {
+      renderPag(3, 7);
+      expect(screen.getByRole('button', { name: /Page 3, page courante/ })).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(screen.getByRole('button', { name: 'Page 1' })).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  describe('boutons précédent / suivant', () => {
+    it('disable Précédent en page 1', () => {
+      renderPag(1, 5);
+      expect(screen.getByRole('button', { name: 'Page précédente' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Page suivante' })).toBeEnabled();
+    });
+
+    it('disable Suivant en dernière page', () => {
+      renderPag(5, 5);
+      expect(screen.getByRole('button', { name: 'Page précédente' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Page suivante' })).toBeDisabled();
+    });
+
+    it('appelle onPageChange(page-1) au clic sur Précédent', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPag(3, 5);
+      await user.click(screen.getByRole('button', { name: 'Page précédente' }));
+      expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('appelle onPageChange(page+1) au clic sur Suivant', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPag(3, 5);
+      await user.click(screen.getByRole('button', { name: 'Page suivante' }));
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+  });
+
+  describe('clic sur une page', () => {
+    it('appelle onPageChange(p) au clic sur une autre page', async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPag(2, 5);
+      await user.click(screen.getByRole('button', { name: 'Page 4' }));
+      expect(onPageChange).toHaveBeenCalledWith(4);
+    });
+
+    it("n'appelle pas onPageChange au clic sur la page courante", async () => {
+      const user = userEvent.setup();
+      const { onPageChange } = renderPag(3, 5);
+      await user.click(screen.getByRole('button', { name: /Page 3, page courante/ }));
+      expect(onPageChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accessibilité', () => {
+    it('rend un <nav> avec aria-label par défaut "Pagination"', () => {
+      renderPag(1, 5);
+      expect(screen.getByRole('navigation', { name: 'Pagination' })).toBeInTheDocument();
+    });
+
+    it("permet d'override aria-label", () => {
+      render(
+        <Pagination
+          page={1}
+          totalPages={3}
+          onPageChange={vi.fn()}
+          aria-label="Pagination des résultats"
+        />,
+      );
+      expect(
+        screen.getByRole('navigation', { name: 'Pagination des résultats' }),
+      ).toBeInTheDocument();
+    });
+
+    it("marque les ellipses aria-hidden (lecteurs d'écran)", () => {
+      renderPag(5, 10);
+      const ellipses = document.querySelectorAll('.ori-pagination__ellipsis');
+      expect(ellipses.length).toBeGreaterThan(0);
+      ellipses.forEach((e) => expect(e).toHaveAttribute('aria-hidden', 'true'));
+    });
+  });
+});

--- a/packages/react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs } from './Tabs';
+
+function setup(extra: { value?: string; onValueChange?: (v: string) => void } = {}) {
+  return render(
+    <Tabs defaultValue={extra.value === undefined ? 'profile' : undefined} {...extra}>
+      <Tabs.List aria-label="Réglages">
+        <Tabs.Tab value="profile">Profil</Tabs.Tab>
+        <Tabs.Tab value="notifications">Notifications</Tabs.Tab>
+        <Tabs.Tab value="security" disabled>
+          Sécurité
+        </Tabs.Tab>
+        <Tabs.Tab value="preferences">Préférences</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel value="profile">contenu profil</Tabs.Panel>
+      <Tabs.Panel value="notifications">contenu notifications</Tabs.Panel>
+      <Tabs.Panel value="security">contenu sécurité</Tabs.Panel>
+      <Tabs.Panel value="preferences">contenu préférences</Tabs.Panel>
+    </Tabs>,
+  );
+}
+
+describe('Tabs', () => {
+  describe('rendu', () => {
+    it('rend un role="tablist" avec les boutons en role="tab"', () => {
+      setup();
+      expect(screen.getByRole('tablist', { name: 'Réglages' })).toBeInTheDocument();
+      expect(screen.getAllByRole('tab')).toHaveLength(4);
+    });
+
+    it('marque le tab par défaut comme aria-selected="true"', () => {
+      setup();
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+    });
+
+    it('rend uniquement le panel actif (les autres en hidden)', () => {
+      setup();
+      expect(screen.getByRole('tabpanel', { hidden: false })).toHaveTextContent('contenu profil');
+      // Les autres panels sont en hidden, on ne peut pas les voir avec getByRole
+      // sauf en passant hidden: true.
+      const allPanels = screen.getAllByRole('tabpanel', { hidden: true });
+      expect(allPanels).toHaveLength(4);
+    });
+
+    it('lie chaque tab à son panel via aria-controls / aria-labelledby', () => {
+      setup();
+      const tab = screen.getByRole('tab', { name: 'Profil' });
+      const ariaControls = tab.getAttribute('aria-controls');
+      expect(ariaControls).toBeTruthy();
+      const panel = document.getElementById(ariaControls!);
+      expect(panel).toHaveAttribute('aria-labelledby', tab.id);
+    });
+  });
+
+  describe('sélection', () => {
+    it('change le tab actif au clic (incontrôlé)', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('tab', { name: 'Notifications' }));
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('appelle onValueChange en mode incontrôlé', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <Tabs defaultValue="a" onValueChange={onValueChange}>
+          <Tabs.List>
+            <Tabs.Tab value="a">A</Tabs.Tab>
+            <Tabs.Tab value="b">B</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="a">A</Tabs.Panel>
+          <Tabs.Panel value="b">B</Tabs.Panel>
+        </Tabs>,
+      );
+      await user.click(screen.getByRole('tab', { name: 'B' }));
+      expect(onValueChange).toHaveBeenCalledWith('b');
+    });
+
+    it('en mode contrôlé, le clic ne change pas le tab actif sans rerender parent', async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <Tabs value="a" onValueChange={onValueChange}>
+          <Tabs.List>
+            <Tabs.Tab value="a">A</Tabs.Tab>
+            <Tabs.Tab value="b">B</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="a">A</Tabs.Panel>
+          <Tabs.Panel value="b">B</Tabs.Panel>
+        </Tabs>,
+      );
+      await user.click(screen.getByRole('tab', { name: 'B' }));
+      // onValueChange est notifié mais l'état affiché reste "a" tant que
+      // le parent ne pousse pas value="b"
+      expect(onValueChange).toHaveBeenCalledWith('b');
+      expect(screen.getByRole('tab', { name: 'A' })).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('navigation clavier', () => {
+    it('ArrowRight déplace le focus au tab suivant (et saute les disabled)', async () => {
+      const user = userEvent.setup();
+      setup();
+      const profil = screen.getByRole('tab', { name: 'Profil' });
+      profil.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveFocus();
+      await user.keyboard('{ArrowRight}');
+      // "Sécurité" est disabled donc on saute à "Préférences"
+      expect(screen.getByRole('tab', { name: 'Préférences' })).toHaveFocus();
+    });
+
+    it('ArrowLeft déplace le focus au tab précédent', async () => {
+      const user = userEvent.setup();
+      setup();
+      const notif = screen.getByRole('tab', { name: 'Notifications' });
+      notif.focus();
+      await user.keyboard('{ArrowLeft}');
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveFocus();
+    });
+
+    it('ArrowRight depuis le dernier tab boucle au premier', async () => {
+      const user = userEvent.setup();
+      setup();
+      const last = screen.getByRole('tab', { name: 'Préférences' });
+      last.focus();
+      await user.keyboard('{ArrowRight}');
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveFocus();
+    });
+
+    it('Home déplace le focus au premier tab', async () => {
+      const user = userEvent.setup();
+      setup();
+      const last = screen.getByRole('tab', { name: 'Préférences' });
+      last.focus();
+      await user.keyboard('{Home}');
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveFocus();
+    });
+
+    it('End déplace le focus au dernier tab', async () => {
+      const user = userEvent.setup();
+      setup();
+      const profil = screen.getByRole('tab', { name: 'Profil' });
+      profil.focus();
+      await user.keyboard('{End}');
+      expect(screen.getByRole('tab', { name: 'Préférences' })).toHaveFocus();
+    });
+  });
+
+  describe('roving tabindex', () => {
+    it('seul le tab actif a tabIndex=0, les autres ont tabIndex=-1', () => {
+      setup();
+      expect(screen.getByRole('tab', { name: 'Profil' })).toHaveAttribute('tabindex', '0');
+      expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute('tabindex', '-1');
+    });
+  });
+});

--- a/packages/react/src/components/Toast/Toast.test.tsx
+++ b/packages/react/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { ToastProvider, ToastViewport, useToast } from './Toast';
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <ToastProvider>
+      <ToastViewport />
+      {children}
+    </ToastProvider>
+  );
+}
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('useToast hors provider lève une erreur explicite', () => {
+    expect(() => renderHook(() => useToast())).toThrow(/ToastProvider/);
+  });
+
+  describe('création de toasts', () => {
+    it('toast({ description }) ajoute un toast avec variant info par défaut', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      act(() => {
+        result.current.toast({ description: 'Bonjour' });
+      });
+      expect(result.current.toasts).toHaveLength(1);
+      expect(result.current.toasts[0]).toMatchObject({
+        description: 'Bonjour',
+        variant: 'info',
+      });
+    });
+
+    it('toast.success(description) crée un toast variant success', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      act(() => {
+        result.current.toast.success('OK !');
+      });
+      expect(result.current.toasts[0].variant).toBe('success');
+      expect(result.current.toasts[0].description).toBe('OK !');
+    });
+
+    it('toast.danger émet un toast danger (et la viewport le rend en role=alert)', () => {
+      render(<Wrapper>{null}</Wrapper>);
+      // Note : on ne peut pas re-utiliser renderHook + render dans le même wrapper,
+      // donc on accède au context via un composant temporaire
+      function Trigger() {
+        const { toast } = useToast();
+        return (
+          <button onClick={() => toast.danger('Erreur grave')} type="button">
+            crash
+          </button>
+        );
+      }
+      render(
+        <ToastProvider>
+          <ToastViewport />
+          <Trigger />
+        </ToastProvider>,
+      );
+      act(() => {
+        screen.getByRole('button', { name: 'crash' }).click();
+      });
+      // role=alert pour danger, role=status pour les autres
+      expect(screen.getByRole('alert')).toHaveTextContent('Erreur grave');
+    });
+
+    it('toast retourne un id unique par toast', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      let id1 = 0;
+      let id2 = 0;
+      act(() => {
+        id1 = result.current.toast({ description: 'a' });
+        id2 = result.current.toast({ description: 'b' });
+      });
+      expect(id1).not.toBe(id2);
+      expect(result.current.toasts).toHaveLength(2);
+    });
+  });
+
+  describe('auto-dismiss', () => {
+    it('dismiss après duration ms', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      act(() => {
+        result.current.toast({ description: 'Bonjour', duration: 1000 });
+      });
+      expect(result.current.toasts).toHaveLength(1);
+      act(() => {
+        vi.advanceTimersByTime(999);
+      });
+      expect(result.current.toasts).toHaveLength(1);
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.toasts).toHaveLength(0);
+    });
+
+    it('duration par défaut = 5000ms', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      act(() => {
+        result.current.toast({ description: 'défaut' });
+      });
+      act(() => {
+        vi.advanceTimersByTime(4999);
+      });
+      expect(result.current.toasts).toHaveLength(1);
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(result.current.toasts).toHaveLength(0);
+    });
+
+    it("duration: 0 désactive l'auto-dismiss (toast persistant)", () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      act(() => {
+        result.current.toast({ description: 'persistant', duration: 0 });
+      });
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(result.current.toasts).toHaveLength(1);
+    });
+  });
+
+  describe('dismiss programmatique', () => {
+    it('dismiss(id) retire le toast immédiatement', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      let id = 0;
+      act(() => {
+        id = result.current.toast({ description: 'Bonjour', duration: 0 });
+      });
+      expect(result.current.toasts).toHaveLength(1);
+      act(() => {
+        result.current.dismiss(id);
+      });
+      expect(result.current.toasts).toHaveLength(0);
+    });
+
+    it('dismiss(id) annule le timer (pas de double-dismiss qui plante)', () => {
+      const { result } = renderHook(() => useToast(), { wrapper: Wrapper });
+      let id = 0;
+      act(() => {
+        id = result.current.toast({ description: 'Bonjour', duration: 1000 });
+      });
+      act(() => {
+        result.current.dismiss(id);
+      });
+      // Le timer aurait expiré ici, mais comme on a dismissé manuellement,
+      // pas de crash et le state reste vide
+      expect(() => {
+        act(() => {
+          vi.advanceTimersByTime(2000);
+        });
+      }).not.toThrow();
+      expect(result.current.toasts).toHaveLength(0);
+    });
+  });
+
+  describe('UI viewport', () => {
+    it('rend un <ol role="region" aria-live="polite">', () => {
+      render(<Wrapper>{null}</Wrapper>);
+      const region = screen.getByRole('region', { name: 'Notifications' });
+      expect(region.tagName).toBe('OL');
+      expect(region).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('clic sur le bouton Fermer dismiss le toast', async () => {
+      // userEvent ne fonctionne pas avec fakeTimers de base ; on utilise
+      // un advanceTimers shim.
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      function Trigger() {
+        const { toast } = useToast();
+        return (
+          <button onClick={() => toast({ description: 'Bonjour', duration: 0 })} type="button">
+            spawn
+          </button>
+        );
+      }
+      render(
+        <ToastProvider>
+          <ToastViewport />
+          <Trigger />
+        </ToastProvider>,
+      );
+      await user.click(screen.getByRole('button', { name: 'spawn' }));
+      expect(screen.getByText('Bonjour')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Fermer' }));
+      expect(screen.queryByText('Bonjour')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+// Vitest est utilisé pour les tests unitaires de logique des composants
+// React (callbacks, états, transitions, branches conditionnelles). Les
+// tests d'accessibilité (axe-core) tournent ailleurs, dans les Storybooks
+// via @storybook/test-runner. Voir CONTRIBUTING.md pour le partage des
+// rôles entre les deux couches.
+//
+// L'environnement jsdom suffit ici : les composants Ori ne dépendent pas
+// d'API navigateur exotiques (canvas, IntersectionObserver custom, etc.).
+// Si un composant à venir en a besoin, basculer ce composant en
+// happy-dom ou ajouter le polyfill au setup.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/packages/react/vitest.setup.ts
+++ b/packages/react/vitest.setup.ts
@@ -1,0 +1,3 @@
+// Étend les matchers Vitest avec ceux de @testing-library/jest-dom
+// (toBeInTheDocument, toHaveAttribute, toHaveClass, etc.).
+import '@testing-library/jest-dom/vitest';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,15 +541,33 @@ importers:
         specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.28
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))
+      jsdom:
+        specifier: ^29.1.0
+        version: 29.1.0
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))
 
   packages/tailwind-preset:
     dependencies:
@@ -836,6 +854,21 @@ packages:
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/compiler@3.0.1':
     resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
@@ -1486,6 +1519,10 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@bundled-es-modules/deepmerge@4.3.1':
     resolution: {integrity: sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==}
 
@@ -1640,6 +1677,42 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@discoveryjs/json-ext@0.6.3':
     resolution: {integrity: sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==}
@@ -1959,6 +2032,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
@@ -3810,8 +3892,33 @@ packages:
     resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -3845,6 +3952,9 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect-history-api-fallback@1.5.4':
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
 
@@ -3853,6 +3963,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -4024,20 +4137,49 @@ packages:
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^7.3.2
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4418,6 +4560,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -4529,6 +4674,10 @@ packages:
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@2.4.2:
@@ -4931,6 +5080,10 @@ packages:
     resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -4951,6 +5104,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -5376,6 +5532,10 @@ packages:
     resolution: {integrity: sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==}
     deprecated: ⚠️ The 'expect-playwright' package is deprecated. The Playwright core assertions (via @playwright/test) now cover the same functionality. Please migrate to built-in expect. See https://playwright.dev/docs/test-assertions for migration.
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5790,6 +5950,10 @@ packages:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
     engines: {node: '>=12'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -6106,6 +6270,9 @@ packages:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -6410,6 +6577,15 @@ packages:
   jsdoc-type-pratt-parser@4.8.0:
     resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
     engines: {node: '>=12.0.0'}
+
+  jsdom@29.1.0:
+    resolution: {integrity: sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -7416,6 +7592,9 @@ packages:
   path@0.12.7:
     resolution: {integrity: sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
@@ -8036,6 +8215,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -8148,6 +8331,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -8270,6 +8456,9 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -8277,6 +8466,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -8406,6 +8598,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -8478,6 +8673,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -8501,9 +8699,20 @@ packages:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -8519,6 +8728,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-dump@1.1.0:
     resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
@@ -8623,6 +8840,10 @@ packages:
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -8918,6 +9139,51 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^7.3.2
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wait-on@7.2.0:
     resolution: {integrity: sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==}
     engines: {node: '>=12.0.0'}
@@ -8955,6 +9221,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-dev-middleware@6.1.3:
     resolution: {integrity: sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==}
@@ -9044,6 +9314,14 @@ packages:
     engines: {node: '>=12'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -9067,6 +9345,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wildcard@2.0.1:
@@ -9114,12 +9397,19 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -9757,6 +10047,26 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@angular/animations': 20.3.19(@angular/core@20.3.19(@angular/compiler@20.3.19)(rxjs@7.8.2)(zone.js@0.16.1))
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/compiler@3.0.1': {}
 
@@ -10653,6 +10963,10 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@bundled-es-modules/deepmerge@4.3.1':
     dependencies:
       deepmerge: 4.3.1
@@ -10961,6 +11275,30 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@discoveryjs/json-ext@0.6.3': {}
 
   '@emnapi/runtime@1.10.0':
@@ -11123,6 +11461,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.9':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@gar/promise-retry@1.0.3': {}
 
@@ -13033,7 +13373,30 @@ snapshots:
       lodash: 4.18.1
       redent: 3.0.0
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -13076,6 +13439,11 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
@@ -13088,6 +13456,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
@@ -13282,6 +13652,23 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -13290,9 +13677,27 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@2.0.5':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/spy@4.1.5': {}
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -13306,6 +13711,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -13841,6 +14252,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big.js@5.2.2: {}
 
   binary-extensions@2.3.0: {}
@@ -13990,6 +14405,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -14428,6 +14845,13 @@ snapshots:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -14437,6 +14861,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -14859,6 +15285,8 @@ snapshots:
       os-homedir: 1.0.2
 
   expect-playwright@0.8.0: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -15478,6 +15906,12 @@ snapshots:
     dependencies:
       whatwg-encoding: 2.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
@@ -15802,6 +16236,8 @@ snapshots:
       isobject: 3.0.1
 
   is-plain-object@5.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -16329,6 +16765,32 @@ snapshots:
       argparse: 2.0.1
 
   jsdoc-type-pratt-parser@4.8.0: {}
+
+  jsdom@29.1.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -17733,6 +18195,8 @@ snapshots:
       process: 0.11.10
       util: 0.10.4
 
+  pathe@2.0.3: {}
+
   pathval@2.0.1: {}
 
   piccolore@0.1.3: {}
@@ -18466,6 +18930,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -18663,6 +19131,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -18817,9 +19287,13 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -18975,6 +19449,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@3.4.19(yaml@2.8.3):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -19105,6 +19581,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinycolor2@1.6.0: {}
@@ -19123,7 +19601,15 @@ snapshots:
 
   tinyrainbow@1.2.0: {}
 
+  tinyrainbow@3.1.0: {}
+
   tinyspy@3.0.2: {}
+
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
 
   tmp@0.2.5: {}
 
@@ -19134,6 +19620,14 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
@@ -19214,6 +19708,8 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici@6.25.0: {}
+
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -19443,6 +19939,38 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
 
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@29.1.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(less@4.6.4)(sass@1.99.0)(terser@5.46.2)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      jsdom: 29.1.0
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wait-on@7.2.0:
     dependencies:
       axios: 1.15.2
@@ -19495,6 +20023,8 @@ snapshots:
     optional: true
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-dev-middleware@6.1.3(webpack@5.106.2(@swc/core@1.15.32)(esbuild@0.25.12)):
     dependencies:
@@ -19827,6 +20357,16 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which-module@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
@@ -19852,6 +20392,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wildcard@2.0.1: {}
 
@@ -19899,9 +20444,13 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  xml-name-validator@5.0.0: {}
+
   xml@1.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
## Résumé

Ajoute **Vitest + @testing-library/react** dans `packages/react` et écrit des tests unitaires pour les 5 composants à logique non triviale du DS.

**Couche complémentaire** des deux autres en place : tests a11y axe-core (rendu DOM accessible) et stories Storybook (galerie visuelle). Les tests unitaires couvrent la **logique** (callbacks, transitions d'état, navigation clavier, validation) qui n'est pas testée par les autres couches.

## Composants couverts (71 tests)

| Composant | Tests | Couvre |
| --- | --- | --- |
| `Highlight` | 11 | 3 modes (sans query, `query=""`, query actif), insensibilité à la casse, multiples occurrences, className. **Couvre la régression du bug PR #30** (`query=""` surlignait tout). |
| `Tabs` | 13 | sélection contrôlée/incontrôlée, nav clavier (← → Home End), saute les disabled, boucle, roving tabindex, aria-selected, aria-controls / aria-labelledby |
| `Pagination` | 16 | rendu compact vs ellipses, fenêtre `siblings`, page courante (aria-current), prev/next disabled aux bornes, callbacks, aria-label override |
| `FileUpload` | 19 | upload simple/multiple, validation MIME exact / wildcard / extension, rejet type, rejet taille, mélange accept/reject, drag-drop, disabled, format taille, suppression, aria-invalid, role=alert |
| `Toast` | 12 | useToast hors provider lève, helpers `toast.{info,success,danger,warning}`, ids uniques, auto-dismiss après `duration`, `duration=0` persistant, dismiss programmatique (annule le timer), viewport role=region aria-live=polite, clic Fermer |

## Critères de sélection

Composants à logique non triviale uniquement. **Pas testé** :

- composants de présentation pure (Tag, Card, Avatar, Skeleton...) → couverts par les stories
- wrappers triviaux de libs externes (Dialog → Radix) → tester Radix est hors-scope

Cf. CONTRIBUTING.md pour les critères détaillés.

## Setup

- `packages/react/vitest.config.ts` (env jsdom, plugin React, glob `src/**/*.test.{ts,tsx}`)
- `packages/react/vitest.setup.ts` (matchers `@testing-library/jest-dom`)
- DevDeps : vitest, @testing-library/react, @testing-library/user-event, @testing-library/jest-dom, jsdom, @vitejs/plugin-react
- Scripts pnpm `test` (CI) et `test:watch` (dev) dans `packages/react/package.json`
- `tsconfig.build.json` exclut déjà `**/*.test.tsx` → aucune fuite de tests dans le bundle publié sur npm

## CI

Nouveau job **Unit tests React** dans `.github/workflows/ci.yml` qui lance `pnpm --filter @govpf/ori-react test`.

## Doc

Section `#### Tests unitaires (Vitest)` ajoutée dans CONTRIBUTING.md :

- commandes locales (`pnpm --filter @govpf/ori-react test` et `test:watch`)
- convention de nommage (un fichier `<Composant>.test.tsx` à côté du composant)
- cibles prioritaires et ce qui n'a pas besoin de tests
- mention que Jest pour Angular suivra dans une PR séparée

## Tests Angular

**Hors-scope** de cette PR. Le runner natif Angular (Karma) est en fin de vie ; on attend la stabilisation de `@angular/build` avec Jest avant de migrer.

## Test plan

- [x] `pnpm --filter @govpf/ori-react test` : **71/71 OK** en ~5s
- [x] `pnpm --filter @govpf/ori-react build` : OK (pas de fuite de `.test.tsx` dans `dist/`)
- [x] `pnpm format:check` : OK
- [ ] CI verte sur cette PR