### PR TITLE
fix(storybook): migration restante des MDX Keycloak vers Patterns

### DIFF
--- a/packages/docs/src/Decisions-A-Prendre.mdx
+++ b/packages/docs/src/Decisions-A-Prendre.mdx
@@ -169,7 +169,7 @@ par un mécanisme manuel dans `preview.ts` :
 #### 3. Limite acceptée : MDX à JSX inline
 
 Pour les pages MDX qui contiennent du JSX inline rendant des classes
-`.ori-*` (typiquement les écrans `Composants fonctionnels/Keycloak/*`),
+`.ori-*` (typiquement les écrans `Patterns/Fonctionnels/Keycloak/*`),
 le toggle de la toolbar **ne bascule pas en live** le rendu. Cause :
 les decorators Storybook ne s'appliquent pas au JSX inline d'un MDX.
 

--- a/packages/docs/src/functional/AuthError.mdx
+++ b/packages/docs/src/functional/AuthError.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthError" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthError" />
 
 # AuthError - Erreur générique Keycloak
 

--- a/packages/docs/src/functional/AuthLogin.mdx
+++ b/packages/docs/src/functional/AuthLogin.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthLogin" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthLogin" />
 
 # AuthLogin - Mire d'authentification Keycloak
 

--- a/packages/docs/src/functional/AuthOtp.mdx
+++ b/packages/docs/src/functional/AuthOtp.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthOtp" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthOtp" />
 
 # AuthOtp - Saisie du code MFA
 

--- a/packages/docs/src/functional/AuthResetPassword.mdx
+++ b/packages/docs/src/functional/AuthResetPassword.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthResetPassword" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthResetPassword" />
 
 # AuthResetPassword - Mot de passe oublié
 

--- a/packages/docs/src/functional/AuthSessionExpired.mdx
+++ b/packages/docs/src/functional/AuthSessionExpired.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthSessionExpired" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthSessionExpired" />
 
 # AuthSessionExpired - Session expirée
 

--- a/packages/docs/src/functional/AuthUpdatePassword.mdx
+++ b/packages/docs/src/functional/AuthUpdatePassword.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Composants fonctionnels/Keycloak/AuthUpdatePassword" />
+<Meta title="Patterns/Fonctionnels/Keycloak/AuthUpdatePassword" />
 
 # AuthUpdatePassword - Définition d'un nouveau mot de passe
 


### PR DESCRIPTION
## Résumé

Suite à la PR #36, **6 des 7 MDX Keycloak** étaient restés sur l'ancien title `Composants fonctionnels/Keycloak/*` au lieu de `Patterns/Fonctionnels/Keycloak/*`. Seul `AuthRegister` avait migré.

Visible dans le Storybook : double catégorie côte à côte dans la sidebar.

## Cause

Effet de bord d'un `git checkout` pendant la mise au point de la PR #36 qui avait annulé les modifs sur ces 6 fichiers, et le re-run du script de renommage n'avait pas recouvert la 2e étape pour ces fichiers spécifiquement (`AuthRegister` avait été retouché à la main via le sed du fix-deep-links).

## Fix

- 6 titres `<Meta title="Composants fonctionnels/Keycloak/...">` -> `Patterns/Fonctionnels/Keycloak/...`
- Mention textuelle dans `Decisions-A-Prendre.mdx` (décision A.4, sous-section "MDX à JSX inline") alignée

## Test plan

- [x] `grep -h "Meta title" packages/docs/src/functional/*.mdx` : tous en `Patterns/Fonctionnels/Keycloak/`
- [x] `pnpm format:check` : OK
- [ ] CI verte sur cette PR
- [ ] Vérification visuelle : la catégorie `Composants fonctionnels` disparaît de la sidebar