### PR TITLE
fix(demo-portail): polynésianisation, démarches Pays, espacement form, bandeau démo

### DIFF
--- a/apps/demo-portail/src/data/mock.ts
+++ b/apps/demo-portail/src/data/mock.ts
@@ -313,7 +313,6 @@ export const notificationsInitiales: NotificationItem[] = [
 // ─── Annuaire des services administratifs (mock) ──────────────────────
 
 export type ServiceSecteur =
-  | 'etat-civil'
   | 'economie'
   | 'logement'
   | 'famille'
@@ -324,7 +323,8 @@ export type ServiceSecteur =
   | 'culture'
   | 'sante'
   | 'education'
-  | 'emploi';
+  | 'emploi'
+  | 'support';
 
 export interface ServiceAdministratif {
   id: string;
@@ -339,78 +339,93 @@ export interface ServiceAdministratif {
 }
 
 export const SERVICE_SECTEUR_LABEL: Record<ServiceSecteur, string> = {
-  'etat-civil': 'État civil & identité',
   economie: 'Activité économique',
-  logement: 'Logement & urbanisme',
+  logement: 'Logement & foncier',
   famille: 'Famille & enfance',
   social: 'Solidarité & aides sociales',
-  fiscalite: 'Fiscalité',
+  fiscalite: 'Fiscalité & finances',
   mobilite: 'Mobilité & transport',
-  environnement: 'Environnement',
+  environnement: 'Environnement & agriculture',
   culture: 'Culture & sport',
   sante: 'Santé',
   education: 'Éducation',
   emploi: 'Emploi & formation',
+  support: 'Support & ressources',
 };
 
+// Vraies directions et services du gouvernement de la Polynésie française
+// (le "Pays"), tels que listés dans l'annuaire net.pf. Volontairement
+// limité au périmètre Pays : pas d'État civil (compétence communale),
+// pas de Haut-Commissariat (État), pas d'urbanisme (Communes).
+//
+// Sigle entre parenthèses pour faciliter l'identification quand l'app
+// affiche le nom complet.
 const SERVICE_TEMPLATES: { name: string; secteur: ServiceSecteur }[] = [
-  { name: "Direction de l'état civil", secteur: 'etat-civil' },
-  { name: "Bureau des cartes d'identité", secteur: 'etat-civil' },
-  { name: 'Service des passeports', secteur: 'etat-civil' },
-  { name: 'Bureau de la nationalité', secteur: 'etat-civil' },
-  { name: 'Service des actes notariés', secteur: 'etat-civil' },
-  { name: 'Direction des activités économiques', secteur: 'economie' },
-  { name: 'Registre du commerce', secteur: 'economie' },
-  { name: 'Bureau des licences professionnelles', secteur: 'economie' },
-  { name: "Service des autorisations d'exercice", secteur: 'economie' },
-  { name: 'Cellule développement entrepreneurial', secteur: 'economie' },
-  { name: "Direction de l'urbanisme", secteur: 'logement' },
-  { name: 'Bureau des permis de construire', secteur: 'logement' },
-  { name: 'Service du logement social', secteur: 'logement' },
-  { name: 'Cadastre et foncier', secteur: 'logement' },
-  { name: "Bureau de l'aménagement du territoire", secteur: 'logement' },
-  { name: 'Direction de la famille', secteur: 'famille' },
-  { name: "Bureau de la protection de l'enfance", secteur: 'famille' },
-  { name: "Service d'accueil des jeunes enfants", secteur: 'famille' },
-  { name: 'Cellule médiation familiale', secteur: 'famille' },
-  { name: 'Direction de la solidarité', secteur: 'social' },
-  { name: 'Bureau des aides sociales', secteur: 'social' },
-  { name: 'Service des allocations familiales', secteur: 'social' },
-  { name: "Bureau d'accompagnement des seniors", secteur: 'social' },
-  { name: "Service du handicap et de l'autonomie", secteur: 'social' },
-  { name: 'Direction des contributions', secteur: 'fiscalite' },
-  { name: 'Bureau de la déclaration des revenus', secteur: 'fiscalite' },
-  { name: 'Service du recouvrement', secteur: 'fiscalite' },
-  { name: 'Cellule fiscalité des entreprises', secteur: 'fiscalite' },
-  { name: 'Direction des transports terrestres', secteur: 'mobilite' },
-  { name: 'Bureau du permis de conduire', secteur: 'mobilite' },
-  { name: 'Service des immatriculations', secteur: 'mobilite' },
-  { name: 'Affaires maritimes', secteur: 'mobilite' },
-  { name: 'Aviation civile', secteur: 'mobilite' },
-  { name: "Direction de l'environnement", secteur: 'environnement' },
-  { name: 'Bureau de la protection des espaces naturels', secteur: 'environnement' },
-  { name: "Service des déchets et de l'assainissement", secteur: 'environnement' },
-  { name: 'Cellule transition énergétique', secteur: 'environnement' },
-  { name: 'Direction de la culture et du patrimoine', secteur: 'culture' },
-  { name: 'Bureau des archives', secteur: 'culture' },
-  { name: 'Service du sport et de la jeunesse', secteur: 'culture' },
-  { name: 'Cellule événementiel culturel', secteur: 'culture' },
-  { name: 'Direction de la santé publique', secteur: 'sante' },
-  { name: 'Bureau de la protection sanitaire', secteur: 'sante' },
-  { name: 'Service de la prévention santé', secteur: 'sante' },
-  { name: 'Cellule veille épidémiologique', secteur: 'sante' },
-  { name: "Direction générale de l'éducation", secteur: 'education' },
-  { name: 'Bureau de la scolarité', secteur: 'education' },
-  { name: "Service de l'orientation", secteur: 'education' },
-  { name: 'Cellule enseignement supérieur', secteur: 'education' },
-  { name: "Direction du travail et de l'emploi", secteur: 'emploi' },
-  { name: 'Bureau de la formation professionnelle', secteur: 'emploi' },
-  { name: "Service de l'apprentissage", secteur: 'emploi' },
-  { name: 'Cellule insertion professionnelle', secteur: 'emploi' },
-  { name: "Bureau d'accueil unique des entreprises", secteur: 'economie' },
+  // Économie
+  { name: 'Direction Générale des Affaires Économiques (DGAE)', secteur: 'economie' },
+  { name: 'Agence pour le Développement Économique (ADE)', secteur: 'economie' },
+  { name: 'Institut de la Statistique de la Polynésie française (ISPF)', secteur: 'economie' },
+  {
+    name: "Chambre de Commerce, d'Industrie, des Services et des Métiers (CCISM)",
+    secteur: 'economie',
+  },
+  { name: 'Service du Tourisme (SDT)', secteur: 'economie' },
+
+  // Emploi
+  { name: 'Direction du Travail (DTRT)', secteur: 'emploi' },
+  {
+    name: "Service de l'Emploi, de la Formation et de l'Insertion professionnelle (SEFI)",
+    secteur: 'emploi',
+  },
+  { name: 'Centre de Formation Professionnelle des Adultes (CFPA)', secteur: 'emploi' },
+
+  // Éducation
+  {
+    name: "Direction Générale de l'Éducation et des Enseignements (DGEE)",
+    secteur: 'education',
+  },
+
+  // Santé
+  { name: 'Direction de la Santé (DSP)', secteur: 'sante' },
+  { name: 'Centre Hospitalier de la Polynésie française (CHPF)', secteur: 'sante' },
+  { name: 'Caisse de Prévoyance Sociale (CPS)', secteur: 'sante' },
+
+  // Famille / Solidarité
+  {
+    name: "Direction des Solidarités, de la Famille et de l'Égalité (DSFE)",
+    secteur: 'famille',
+  },
+  { name: 'Institut de la Jeunesse et des Sports (IJSPF)', secteur: 'famille' },
+
+  // Logement / Foncier
+  { name: "Office Polynésien de l'Habitat (OPH)", secteur: 'logement' },
+  { name: 'Direction des Affaires Foncières (DAF)', secteur: 'logement' },
+
+  // Mobilité
+  { name: 'Direction des Transports Terrestres (DTT)', secteur: 'mobilite' },
+  {
+    name: 'Direction des Ressources Marines et Minières (DRMM)',
+    secteur: 'mobilite',
+  },
+
+  // Environnement / Agriculture
+  { name: "Direction de l'Environnement (DIREN)", secteur: 'environnement' },
+  { name: "Direction de l'Agriculture (DAG)", secteur: 'environnement' },
+
+  // Fiscalité / Finances
+  { name: 'Direction des Impôts et des Contributions Publiques (DICP)', secteur: 'fiscalite' },
+  { name: 'Direction du Budget et des Finances (DBF)', secteur: 'fiscalite' },
+
+  // Culture
+  { name: 'Service de la Culture et du Patrimoine (SCP)', secteur: 'culture' },
+  { name: 'Tahiti Nui Télévision (TNTV)', secteur: 'culture' },
+
+  // Support transverse
+  { name: 'Direction Générale des Ressources Humaines (DGRH)', secteur: 'support' },
+  { name: "Direction du Système d'Information (DSI)", secteur: 'support' },
+  { name: 'Secrétariat Général du Gouvernement (SGG)', secteur: 'support' },
 ];
 
-const ILES = ['Tahiti', 'Moorea', 'Raiatea', 'Bora-Bora', 'Huahine', 'Nuku Hiva'];
 const QUARTIERS_TAHITI = ['Papeete - centre', 'Pirae', 'Faaa', 'Punaauia', 'Mahina', 'Arue'];
 
 function pad(n: number, size = 2): string {
@@ -419,9 +434,11 @@ function pad(n: number, size = 2): string {
 
 export const servicesAdministratifs: ServiceAdministratif[] = SERVICE_TEMPLATES.map(
   (t, i): ServiceAdministratif => {
-    const ile = i < 42 ? 'Tahiti' : (ILES[(i - 42) % ILES.length] ?? 'Tahiti');
-    const adresseLocale =
-      ile === 'Tahiti' ? QUARTIERS_TAHITI[i % QUARTIERS_TAHITI.length] : `${ile} - centre`;
+    // Toutes les directions Pays sont implantées à Tahiti (essentiellement
+    // Papeete et quartiers limitrophes). Les antennes archipel restent
+    // réelles côté CHPF / OPH / DGEE mais ne sont pas listées ici.
+    const ile = 'Tahiti';
+    const adresseLocale = QUARTIERS_TAHITI[i % QUARTIERS_TAHITI.length];
     const tel = `+689 40 ${pad(40 + (i % 60))} ${pad(10 + (i % 90))}`;
     const slug = t.name
       .toLowerCase()
@@ -504,8 +521,9 @@ export const servicesCatalogue: ServiceCatalogue[] = [
   },
   {
     id: 'sv3',
-    titre: "Demande d'attestation de domicile",
-    description: 'Obtenir une attestation officielle de domicile à présenter à un organisme tiers.',
+    titre: 'Mise à jour de la carte CPS',
+    description:
+      'Actualiser ses coordonnées et bénéficiaires auprès de la Caisse de Prévoyance Sociale.',
     categorie: 'identite',
     dureeMoyenne: '2 jours',
     enLigne: true,
@@ -513,8 +531,9 @@ export const servicesCatalogue: ServiceCatalogue[] = [
   },
   {
     id: 'sv4',
-    titre: 'Inscription au registre du commerce',
-    description: 'Enregistrer une nouvelle entreprise, un commerce ou une activité indépendante.',
+    titre: 'Demande de patente',
+    description:
+      'Solliciter une patente auprès de la Direction des impôts pour exercer une activité commerciale ou artisanale.',
     categorie: 'activite',
     dureeMoyenne: '10 jours',
     enLigne: true,
@@ -530,10 +549,10 @@ export const servicesCatalogue: ServiceCatalogue[] = [
   },
   {
     id: 'sv6',
-    titre: 'Demande de permis de construire',
+    titre: 'Demande de permis de conduire',
     description:
-      'Déposer un permis de construire pour une construction neuve, agrandissement ou rénovation lourde.',
-    categorie: 'logement',
+      'Inscrire un candidat au permis de conduire (catégorie B, A, BE) auprès de la Direction des transports terrestres.',
+    categorie: 'mobilite',
     dureeMoyenne: '60 jours',
     enLigne: false,
   },
@@ -549,12 +568,12 @@ export const servicesCatalogue: ServiceCatalogue[] = [
   },
   {
     id: 'sv8',
-    titre: "Reconnaissance d'enfant",
+    titre: 'Allocation de naissance',
     description:
-      "Effectuer une reconnaissance auprès des services d'état civil avant ou après la naissance.",
+      "Demander à la Caisse de Prévoyance Sociale l'allocation versée aux familles à l'arrivée d'un enfant.",
     categorie: 'famille',
-    dureeMoyenne: '1 jour',
-    enLigne: false,
+    dureeMoyenne: '14 jours',
+    enLigne: true,
   },
   {
     id: 'sv9',

--- a/apps/demo-portail/src/layout/AppShell.tsx
+++ b/apps/demo-portail/src/layout/AppShell.tsx
@@ -67,6 +67,16 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
 
   return (
     <div className="app-root">
+      <div className="demo-banner" role="region" aria-label="Avertissement de démonstration">
+        <strong>DÉMO</strong>
+        <span>
+          Cette page illustre le design system Ori avec des données fictives. Aucune information
+          saisie ici n'est transmise à un service réel.
+        </span>
+        <a className="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer">
+          Voir la documentation Ori →
+        </a>
+      </div>
       <Header>
         <Header.Brand>
           <Logo href="#" title="Polynésie française" subtitle="Mon espace usager" />
@@ -105,7 +115,7 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
               <Sun size={16} aria-hidden="true" />
             )}
           </Button>
-          <Avatar alt="Marie Dupont" size="sm" />
+          <Avatar alt="Heitiare TUHEIAVA" size="sm" />
           <Button variant="ghost" size="sm">
             Déconnexion
           </Button>

--- a/apps/demo-portail/src/pages/Dashboard.tsx
+++ b/apps/demo-portail/src/pages/Dashboard.tsx
@@ -70,7 +70,7 @@ export function DashboardPage({ onNavigate }: DashboardPageProps) {
     <>
       <div className="page-header">
         <Breadcrumb items={[{ label: 'Accueil', href: '#' }, { label: 'Tableau de bord' }]} />
-        <h1 className="page-title">Bienvenue, Marie</h1>
+        <h1 className="page-title">Bienvenue, Heitiare</h1>
         <p className="page-subtitle">Voici un aperçu de vos démarches et documents en cours.</p>
       </div>
 

--- a/apps/demo-portail/src/pages/DemandeDetail.tsx
+++ b/apps/demo-portail/src/pages/DemandeDetail.tsx
@@ -142,14 +142,14 @@ export function DemandeDetailPage({ demandeId, onNavigate }: DemandeDetailPagePr
                   ]}
                   defaultValue="mme"
                 />
-                <Input label="Nom" required defaultValue="Dupont" />
-                <Input label="Prénom" required defaultValue="Marie" />
+                <Input label="Nom" required defaultValue="TUHEIAVA" />
+                <Input label="Prénom" required defaultValue="Heitiare" />
                 <DatePicker label="Date de naissance" required defaultValue="1985-06-15" />
                 <Input
                   label="Adresse email"
                   type="email"
                   required
-                  defaultValue="marie.dupont@example.pf"
+                  defaultValue="heitiare.tuheiava@gmail.com"
                 />
                 <Input
                   label="Téléphone"
@@ -159,28 +159,28 @@ export function DemandeDetailPage({ demandeId, onNavigate }: DemandeDetailPagePr
                 />
               </div>
 
-              <RadioGroup
-                label="Moyen de contact préféré"
-                value={moyen}
-                onChange={setMoyen}
-                orientation="inline"
-              >
-                <Radio value="email" label="Email" />
-                <Radio value="sms" label="SMS" />
-                <Radio value="courrier" label="Courrier postal" />
-              </RadioGroup>
+              <div className="form-stack" style={{ marginTop: '1rem' }}>
+                <RadioGroup
+                  label="Moyen de contact préféré"
+                  value={moyen}
+                  onChange={setMoyen}
+                  orientation="inline"
+                >
+                  <Radio value="email" label="Email" />
+                  <Radio value="sms" label="SMS" />
+                  <Radio value="courrier" label="Courrier postal" />
+                </RadioGroup>
 
-              <Textarea
-                label="Notes complémentaires"
-                placeholder="Précisions à transmettre au service instructeur…"
-                rows={4}
-                value={notesInternes}
-                onChange={(e) => setNotesInternes(e.target.value)}
-                hint="Optionnel - 500 caractères max"
-                maxLength={500}
-              />
+                <Textarea
+                  label="Notes complémentaires"
+                  placeholder="Précisions à transmettre au service instructeur…"
+                  rows={4}
+                  value={notesInternes}
+                  onChange={(e) => setNotesInternes(e.target.value)}
+                  hint="Optionnel - 500 caractères max"
+                  maxLength={500}
+                />
 
-              <div style={{ marginTop: '1rem' }}>
                 <Checkbox
                   label="J'atteste sur l'honneur que les informations fournies sont exactes et complètes."
                   checked={acceptCgu}
@@ -306,7 +306,7 @@ export function DemandeDetailPage({ demandeId, onNavigate }: DemandeDetailPagePr
               fontSize: '0.875rem',
             }}
           >
-            Vous recevrez un email de confirmation à <strong>marie.dupont@example.pf</strong>.
+            Vous recevrez un email de confirmation à <strong>heitiare.tuheiava@gmail.com</strong>.
           </p>
         </DialogContent>
       </Dialog>

--- a/apps/demo-portail/src/pages/Preferences.tsx
+++ b/apps/demo-portail/src/pages/Preferences.tsx
@@ -136,7 +136,6 @@ export function PreferencesPage({ onNavigate }: PreferencesPageProps) {
               <option value="Pacific/Tahiti">Tahiti (UTC-10)</option>
               <option value="Pacific/Marquesas">Marquises (UTC-9:30)</option>
               <option value="Pacific/Gambier">Gambier (UTC-9)</option>
-              <option value="Europe/Paris">Paris (UTC+1)</option>
             </Select>
           </div>
         </CardBody>

--- a/apps/demo-portail/src/pages/Profil.tsx
+++ b/apps/demo-portail/src/pages/Profil.tsx
@@ -24,10 +24,10 @@ export function ProfilPage({ onNavigate }: ProfilPageProps) {
   const { toast } = useToast();
 
   const [civilite, setCivilite] = useState('mme');
-  const [nom, setNom] = useState('Dupont');
-  const [prenom, setPrenom] = useState('Marie');
+  const [nom, setNom] = useState('TUHEIAVA');
+  const [prenom, setPrenom] = useState('Heitiare');
   const [dateNaissance, setDateNaissance] = useState('1985-06-12');
-  const [email, setEmail] = useState('marie.dupont@example.pf');
+  const [email, setEmail] = useState('heitiare.tuheiava@gmail.com');
   const [telephone, setTelephone] = useState('+689 87 12 34 56');
   const [adresse, setAdresse] = useState('Avenue Pouvanaa a Oopa');
   const [complement, setComplement] = useState('Résidence Tiare, Bâtiment B');

--- a/apps/demo-portail/src/pages/Securite.tsx
+++ b/apps/demo-portail/src/pages/Securite.tsx
@@ -397,7 +397,7 @@ export function SecuritePage({ onNavigate }: SecuritePageProps) {
               fontSize: '0.875rem',
             }}
           >
-            Un email de confirmation sera envoyé à <strong>marie.dupont@example.pf</strong>.
+            Un email de confirmation sera envoyé à <strong>heitiare.tuheiava@gmail.com</strong>.
           </p>
         </DialogContent>
       </Dialog>

--- a/apps/demo-portail/src/styles.css
+++ b/apps/demo-portail/src/styles.css
@@ -103,6 +103,66 @@
   gap: 1rem 1.25rem;
 }
 
+/* Stack vertical pour les fields full-width qui suivent une `.form-grid`.
+   Sans wrapper, les .ori-field consécutifs (RadioGroup, Textarea, Checkbox)
+   sont collés faute de margin. */
+.form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Bandeau "DÉMO" permanent en haut de la page. Volontairement voyant
+   et non-fermable (aucun bouton dismiss) : un usager ne doit jamais
+   confondre cette démo avec un service réel. Les couleurs feedback
+   warning sont utilisées pour signaler que c'est non-officiel. */
+.demo-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-feedback-warning);
+  color: var(--color-neutral-900);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  border-bottom: 2px solid var(--color-feedback-warning-strong);
+}
+
+.demo-banner strong {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-neutral-900);
+  color: var(--color-feedback-warning);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.demo-banner__link {
+  flex: 0 0 auto;
+  color: var(--color-neutral-900);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.demo-banner__link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.demo-banner__link:focus-visible {
+  outline: 2px solid var(--color-neutral-900);
+  outline-offset: 2px;
+  border-radius: 0.125rem;
+}
+
 .form-actions {
   display: flex;
   justify-content: flex-end;
@@ -838,7 +898,12 @@
 
 .annuaire-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  /* auto-fill (et non auto-fit) pour que les cards gardent leur taille
+     "naturelle" même quand le filtre ne ramène que 1 ou 2 résultats.
+     Avec auto-fit, les colonnes vides étaient collapsed et les 2 cards
+     s'étiraient sur toute la largeur du container, ce qui faisait des
+     fiches déséquilibrées (titre court, beaucoup d'espace vide). */
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 1rem;
 }
 

--- a/apps/playground-react/src/App.tsx
+++ b/apps/playground-react/src/App.tsx
@@ -245,10 +245,10 @@ function DisplaySection() {
 
       <h3>Avatars</h3>
       <div className="app-row">
-        <Avatar alt="Marie Dupont" size="sm" />
-        <Avatar alt="Marie Dupont" size="md" />
-        <Avatar alt="Marie Dupont" size="lg" />
-        <Avatar alt="Marie Dupont" size="xl" />
+        <Avatar alt="Heitiare TUHEIAVA" size="sm" />
+        <Avatar alt="Heitiare TUHEIAVA" size="md" />
+        <Avatar alt="Heitiare TUHEIAVA" size="lg" />
+        <Avatar alt="Heitiare TUHEIAVA" size="xl" />
       </div>
 
       <h3>Tooltip + Link + Highlight</h3>
@@ -545,7 +545,7 @@ const demandes: Demande[] = [
   {
     id: '1',
     numero: '2026-0042',
-    demandeur: 'Marie Dupont',
+    demandeur: 'Heitiare TUHEIAVA',
     type: 'Permis bateau',
     statut: 'en_cours',
     date: '2026-04-22',


### PR DESCRIPTION
## Résumé

Correctifs cosmétiques et de contenu sur la démo portail usager, suite à plusieurs feedbacks externes.

## Bandeau démo permanent

Bandeau **DÉMO** non-fermable en haut de toutes les pages avec lien vers https://ori.gov.pf. Évite qu'un visiteur confonde la démo avec un vrai service.

## Espacement formulaire

Fix sur `DemandeDetail` (tab Informations) : `RadioGroup` + `Textarea` + `Checkbox` étaient collés faute de margin. Englobés dans un `<div className="form-stack">` (flex column gap 1rem).

## Persona polynésienne

| Avant | Après |
| --- | --- |
| Marie Dupont | Heitiare TUHEIAVA |
| marie.dupont@example.pf | heitiare.tuheiava@gmail.com |

## Démarches catalogue (Pays uniquement)

4 démarches hors scope Pays (compétence État ou communale) remplacées par des démarches réellement Pays :

| Avant | Après |
| --- | --- |
| Attestation de domicile | Mise à jour de la carte CPS |
| Inscription au registre du commerce | Demande de patente (DICP) |
| Permis de construire | Permis de conduire (DTT) |
| Reconnaissance d'enfant | Allocation de naissance (CPS) |

## Annuaire refondé

Remplacement des ~50 entrées fictives par les **~28 vraies directions Pays** identifiées dans l'annuaire net.pf :

DGAE, ADE, ISPF, CCISM, SDT, DTRT, SEFI, CFPA, DGEE, DSP, CHPF, CPS, DSFE, IJSPF, OPH, DAF, DTT, DRMM, DIREN, DAG, DICP, DBF, SCP, TNTV, DGRH, DSI, SGG.

- Type `ServiceSecteur` : retrait `'etat-civil'` (compétence communale), ajout `'support'` (RH, SI, SGG)
- Toutes les directions Pays sont implantées à Tahiti (la répartition multi-îles précédente était fictive)

## Préférences

Retrait de l'option fuseau `Europe/Paris` (sans pertinence sur un portail PF). Reste les 3 timezones officielles : Tahiti, Marquises, Gambier.

## Annuaire grid (auto-fit → auto-fill)

Quand un filtre ne ramène que 1-2 résultats, les cards s'étiraient sur toute la largeur. `auto-fit` → `auto-fill` préserve la taille naturelle (~320-400px) avec tracks vides invisibles pour combler.

## Test plan

- [x] Vérification visuelle utilisateur sur localhost:5174
- [x] `pnpm format:check` : OK
- [ ] CI verte sur cette PR