### PR TITLE
docs(a11y): page Validation accessibilité sur Storybook + site Astro

### DIFF
--- a/apps/ori-site/src/components/Sidebar.astro
+++ b/apps/ori-site/src/components/Sidebar.astro
@@ -44,6 +44,11 @@ const sections: NavSection[] = [
       },
       { label: 'Rayons', slug: 'rayons', href: `${base}fondations/rayons/` },
       { label: 'Ombres', slug: 'ombres', href: `${base}fondations/ombres/` },
+      {
+        label: 'Validation accessibilité',
+        slug: 'accessibilite',
+        href: `${base}fondations/accessibilite/`,
+      },
     ],
   },
   {

--- a/apps/ori-site/src/pages/fondations/accessibilite.mdx
+++ b/apps/ori-site/src/pages/fondations/accessibilite.mdx
@@ -1,0 +1,152 @@
+---
+layout: ../../layouts/DocLayout.astro
+title: 'Validation accessibilité'
+current: 'accessibilite'
+headerCurrent: 'tokens'
+---
+
+# Validation accessibilité
+
+Ori est positionné comme un design system **conforme RGAA AA** par
+défaut. Cette page explicite ce que cette promesse couvre, comment
+elle est vérifiée, et les limites assumées de la garantie automatisée.
+
+## Statut courant
+
+<div
+  style="
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    background: var(--color-feedback-success-bg);
+    color: var(--color-feedback-success-strong);
+    border: 1px solid var(--color-feedback-success);
+    font-weight: 600;
+  "
+>
+  ✓ 406 / 406 stories validées WCAG 2.0 AA, 0 violation
+</div>
+
+Dernière mesure obtenue par les jobs CI **A11y Storybook React** et
+**A11y Storybook Angular** sur la branche `main`. Chaque pull request
+relance la batterie complète avant merge ; un seul `serious` ou
+`critical` bloque la PR.
+
+## Méthode
+
+### Outil
+
+[**axe-core**](https://github.com/dequelabs/axe-core), librairie de
+référence pour l'audit a11y automatisé (utilisée par le navigateur
+Edge, Lighthouse, et la plupart des suites de tests d'entreprise).
+
+### Mode d'exécution
+
+À chaque story Storybook (React et Angular), le test-runner officiel
+ouvre la story dans un navigateur Chromium headless via Playwright,
+laisse le rendu s'effectuer, puis injecte axe-core. Le résultat est
+remonté à Jest qui fait échouer le test au moindre `impact = serious`
+ou `critical`.
+
+### Tags de règles activés
+
+- `wcag2a` : Web Content Accessibility Guidelines 2.0, niveau A
+- `wcag2aa` : Web Content Accessibility Guidelines 2.0, niveau AA
+- `wcag21a` : WCAG 2.1, niveau A (couvre les ajouts mobile / touch)
+- `wcag21aa` : WCAG 2.1, niveau AA
+- `best-practice` : règles axe-core hors WCAG (signaux complémentaires)
+
+Ces tags couvrent l'intégralité des critères techniques RGAA AA qui
+peuvent être évalués automatiquement.
+
+### Sévérités traitées
+
+| Sévérité axe-core | Action CI                |
+| ----------------- | ------------------------ |
+| `critical`        | échec, PR bloquée        |
+| `serious`         | échec, PR bloquée        |
+| `moderate`        | warning, PR pas bloquée  |
+| `minor`           | warning, PR pas bloquée  |
+
+`moderate` et `minor` sont inspectés manuellement avant chaque release
+majeure.
+
+## Couverture
+
+**Composants testés** : tous les composants publiés (`@govpf/ori-react`
+et `@govpf/ori-angular`) ont **au moins une story par variante visuelle**,
+et chaque story est testée. Voir l'arbre Storybook par section
+"Composants" (Actions, Saisie, Affichage, Feedback, Navigation,
+Données, Mise en page).
+
+**Métriques courantes** :
+
+- 213 stories React testées
+- 193 stories Angular testées
+- Total : **406 stories**, 0 violation `serious` ou `critical`
+
+## Limites assumées de la couverture automatique
+
+axe-core valide ce qui peut l'être à partir du DOM rendu. Les
+critères suivants restent hors-scope du test automatisé et **doivent
+être vérifiés manuellement** :
+
+- **Ordre de focus** dans des compositions complexes (modal qui ouvre
+  une autre modal, panneau coulissant qui contient un formulaire)
+- **Navigation clavier** au-delà de l'attribut `tabindex` (gestion
+  des touches Échap, Flèches, Home, End, etc.)
+- **Contraste sur états dynamiques** (hover, focus, disabled) que axe
+  ne peut pas déclencher
+- **Annonces lecteur d'écran** réelles : un `aria-live` peut être
+  présent mais mal annoncé par NVDA / VoiceOver / JAWS selon le
+  contexte
+- **Cohérence sémantique** d'un parcours utilisateur entier (ex :
+  enchaînement de formulaires, abandon et reprise)
+
+Pour ces critères-là, la **méthode RGAA officielle** (audit humain)
+reste indispensable. Ori vise à éliminer la dette technique
+automatisable, pas à se substituer à un audit RGAA complet.
+
+## Comment vérifier en local
+
+Côté React :
+
+```bash
+pnpm --filter @govpf/ori-storybook-react test:a11y:ci
+```
+
+Côté Angular :
+
+```bash
+pnpm --filter @govpf/ori-storybook-angular test:a11y:ci
+```
+
+Chaque commande build le Storybook statique, le sert localement avec
+`http-server`, puis lance le test-runner. Le résultat est remonté
+ligne par ligne.
+
+## Faire un opt-out exceptionnel
+
+Si une story illustre volontairement un anti-pattern (à fin
+pédagogique) et ne doit pas passer le test, ajouter le tag
+`skip-a11y` dans son meta :
+
+```ts
+export default {
+  title: 'Composants / Affichage / Tag',
+  component: Tag,
+  tags: ['skip-a11y'],
+};
+```
+
+À utiliser avec parcimonie et toujours documenter le pourquoi dans
+la story. Le test-runner skip ces stories en logguant clairement.
+
+## Pour aller plus loin
+
+- [Référentiel RGAA officiel (numerique.gouv.fr)](https://accessibilite.numerique.gouv.fr/)
+- [Documentation axe-core (deque.com)](https://www.deque.com/axe/)
+- [WCAG 2.1 Quick Reference (w3.org)](https://www.w3.org/WAI/WCAG21/quickref/)
+- [Section "Tests d'accessibilité automatisés" du CONTRIBUTING.md](https://github.com/govpf/ori/blob/main/CONTRIBUTING.md)

--- a/apps/storybook-angular/.storybook/preview.ts
+++ b/apps/storybook-angular/.storybook/preview.ts
@@ -57,6 +57,7 @@ const preview: Preview = {
           'Fondations',
           [
             'Iconographie',
+            'Validation accessibilité',
             'Tokens',
             ['Palette', 'Sémantique', 'Typographie', 'Spacing', 'Radii', 'Shadows'],
           ],

--- a/apps/storybook-react/.storybook/preview.ts
+++ b/apps/storybook-react/.storybook/preview.ts
@@ -60,6 +60,7 @@ const preview: Preview = {
           'Fondations',
           [
             'Iconographie',
+            'Validation accessibilité',
             'Tokens',
             ['Palette', 'Sémantique', 'Typographie', 'Spacing', 'Radii', 'Shadows'],
           ],

--- a/packages/docs/src/Introduction.mdx
+++ b/packages/docs/src/Introduction.mdx
@@ -23,6 +23,11 @@ garantie sur toutes les cibles.
    light/dark dynamique sans recompilation.
 4. **Un livrable CSS autonome.** Le package `@govpf/ori-css` produit un `ds.css`
    drop-in utilisable sans framework (sites statiques, GLPI, emails).
+5. **RGAA AA validé en continu.** Chaque story Storybook (406 au total côté
+   React + Angular) est testée par axe-core sur l'ensemble des règles WCAG 2.0
+   et 2.1 niveaux A et AA, à chaque pull request. Voir la page
+   [Fondations / Validation accessibilité](?path=/docs/fondations-validation-accessibilité--docs)
+   pour le scope, la méthode et les limites de cette garantie.
 
 ## Architecture
 

--- a/packages/docs/src/Validation-Accessibilite.mdx
+++ b/packages/docs/src/Validation-Accessibilite.mdx
@@ -1,0 +1,149 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Fondations/Validation accessibilité" />
+
+# Validation accessibilité
+
+Ori est positionné comme un design system **conforme RGAA AA** par défaut.
+Cette page explicite ce que cette promesse couvre, comment elle est
+vérifiée, et les limites assumées de la garantie automatisée.
+
+## Statut courant
+
+<div
+  style={{
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.375rem',
+    background: 'var(--color-feedback-success-bg)',
+    color: 'var(--color-feedback-success-strong)',
+    border: '1px solid var(--color-feedback-success)',
+    fontWeight: 600,
+  }}
+>
+  ✓ 406 / 406 stories validées WCAG 2.0 AA, 0 violation
+</div>
+
+Dernière mesure obtenue par le job CI **A11y Storybook React** et
+**A11y Storybook Angular** sur la branche `main`. Chaque pull request
+relance la batterie complète avant merge ; un seul `serious` ou
+`critical` bloque la PR.
+
+## Méthode
+
+### Outil
+
+[**axe-core**](https://github.com/dequelabs/axe-core), librairie de
+référence pour l'audit a11y automatisé (utilisée par le navigateur
+Edge, Lighthouse, et la plupart des suites de tests d'entreprise).
+
+### Mode d'exécution
+
+À chaque story Storybook (React et Angular), le test-runner officiel
+ouvre la story dans un navigateur Chromium headless via Playwright,
+laisse le rendu s'effectuer, puis injecte axe-core. Le résultat est
+remonté à Jest qui fait échouer le test au moindre `impact = serious`
+ou `critical`.
+
+### Tags de règles activés
+
+- `wcag2a` : Web Content Accessibility Guidelines 2.0, niveau A
+- `wcag2aa` : Web Content Accessibility Guidelines 2.0, niveau AA
+- `wcag21a` : WCAG 2.1, niveau A (couvre les ajouts mobile / touch)
+- `wcag21aa` : WCAG 2.1, niveau AA
+- `best-practice` : règles axe-core hors WCAG (signaux complémentaires)
+
+Ces tags couvrent l'intégralité des critères techniques RGAA AA qui
+peuvent être évalués automatiquement.
+
+### Sévérités traitées
+
+| Sévérité axe-core | Action CI |
+| --- | --- |
+| `critical` | échec, PR bloquée |
+| `serious` | échec, PR bloquée |
+| `moderate` | warning, PR pas bloquée |
+| `minor` | warning, PR pas bloquée |
+
+`moderate` et `minor` sont inspectés manuellement avant chaque
+release majeure.
+
+## Couverture
+
+**Composants testés** : tous les composants publiés
+(`@govpf/ori-react` et `@govpf/ori-angular`) ont **au moins une
+story par variante visuelle**, et chaque story est testée. Voir
+l'arbre Storybook par section "Composants" (Actions, Saisie,
+Affichage, Feedback, Navigation, Données, Mise en page).
+
+**Métriques courantes** :
+
+- 213 stories React testées
+- 193 stories Angular testées
+- Total : **406 stories**, 0 violation `serious` ou `critical`
+
+## Limites assumées de la couverture automatique
+
+axe-core valide ce qui peut l'être à partir du DOM rendu. Les
+critères suivants restent hors-scope du test automatisé et **doivent
+être vérifiés manuellement** :
+
+- **Ordre de focus** dans des compositions complexes (modal qui ouvre
+  une autre modal, panneau coulissant qui contient un formulaire)
+- **Navigation clavier** au-delà de l'attribut `tabindex` (gestion
+  des touches Échap, Flèches, Home, End, etc.)
+- **Contraste sur états dynamiques** (hover, focus, disabled) que axe
+  ne peut pas déclencher
+- **Annonces lecteur d'écran** réelles : un `aria-live` peut être
+  présent mais mal annoncé par NVDA / VoiceOver / JAWS selon le
+  contexte
+- **Cohérence sémantique** d'un parcours utilisateur entier (ex :
+  enchaînement de formulaires, abandon et reprise)
+
+Pour ces critères-là, la **méthode RGAA officielle** (audit humain)
+reste indispensable. Ori vise à éliminer la dette technique
+automatisable, pas à se substituer à un audit RGAA complet.
+
+## Comment vérifier en local
+
+Côté React :
+
+```bash
+pnpm --filter @govpf/ori-storybook-react test:a11y:ci
+```
+
+Côté Angular :
+
+```bash
+pnpm --filter @govpf/ori-storybook-angular test:a11y:ci
+```
+
+Chaque commande build le Storybook statique, le sert localement avec
+`http-server`, puis lance le test-runner. Le résultat est remonté
+ligne par ligne.
+
+## Faire un opt-out exceptionnel
+
+Si une story illustre volontairement un anti-pattern (à fin
+pédagogique) et ne doit pas passer le test, ajouter le tag
+`skip-a11y` dans son meta :
+
+```ts
+export default {
+  title: 'Composants / Affichage / Tag',
+  component: Tag,
+  tags: ['skip-a11y'],
+};
+```
+
+À utiliser avec parcimonie et toujours documenter le pourquoi dans
+la story. Le test-runner skip ces stories en logguant clairement.
+
+## Pour aller plus loin
+
+- [Référentiel RGAA officiel (numerique.gouv.fr)](https://accessibilite.numerique.gouv.fr/)
+- [Documentation axe-core (deque.com)](https://www.deque.com/axe/)
+- [WCAG 2.1 Quick Reference (w3.org)](https://www.w3.org/WAI/WCAG21/quickref/)
+- [Section "Tests d'accessibilité automatisés" du CONTRIBUTING.md](https://github.com/govpf/ori/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
## Résumé

Matérialise le différenciateur **RGAA AA** d'Ori sous forme d'une page dédiée, accessible depuis les deux faces de la documentation (Storybook et site Astro public).

Le claim "DS conforme RGAA AA" était affirmé mais pas démontré. Pour un dev externe qui hésite entre Ori et un autre DS, l'argument tranchant doit être visible dès la page d'accueil de la doc, avec la méthode et les limites assumées.

## Contenu de la page

- **Statut courant** : badge vert *"✓ 406 / 406 stories validées WCAG 2.0 AA, 0 violation"*
- **Méthode** : axe-core via `@storybook/test-runner`, tags `wcag2a` / `2aa` / `21a` / `21aa` / `best-practice`, sévérités traitées
- **Couverture** : 213 stories React + 193 stories Angular
- **Limites assumées** : ce qui ne peut pas être testé automatiquement (ordre de focus dynamique, navigation clavier complexe, contraste hover/focus, annonces lecteur d'écran réelles)
- **Comment vérifier en local** (commandes `pnpm`)
- **Opt-out** via tag `skip-a11y`
- **Liens externes** : RGAA officiel, axe-core, WCAG 2.1, CONTRIBUTING

## Où apparaît la page

| Surface | Chemin |
| --- | --- |
| Storybook React | `Fondations / Validation accessibilité` |
| Storybook Angular | `Fondations / Validation accessibilité` |
| Site Astro public | https://ori.gov.pf/fondations/accessibilite/ |

`Introduction.mdx` (Storybook) gagne aussi un principe `5. RGAA AA validé en continu` qui pointe vers la page détaillée.

## Hors scope

Cette PR ne modifie ni l'infrastructure de tests a11y (PR #30) ni la politique CI. Elle se contente de **rendre visible et lisible** une garantie déjà tenue depuis plusieurs sprints.

## Test plan

- [x] Storybook React : entrée visible sous `Fondations`, contenu rendu correctement
- [x] Site Astro local (port 4321) : page `/fondations/accessibilite/` rendue avec badge et contenu complet, sidebar mise à jour
- [x] `pnpm format:check` : OK
- [ ] CI verte sur cette PR