### PR TITLE
chore(governance): politique semver pré-1.0 + 4 issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-a11y.yml
+++ b/.github/ISSUE_TEMPLATE/bug-a11y.yml
@@ -1,0 +1,91 @@
+name: Bug d'accessibilité
+description: Signaler un défaut RGAA AA sur un composant Ori (DOM, focus, clavier, lecteur d'écran).
+title: '[a11y] '
+labels: ['a11y', 'bug', 'à trier']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ori est positionné comme conforme RGAA AA. Tout écart est traité
+        en priorité. Avant de soumettre, vérifier que le composant ne
+        figure pas déjà dans la [page Validation accessibilité](https://ori.gov.pf/fondations/accessibilite/)
+        avec une limite documentée.
+
+  - type: input
+    id: composant
+    attributes:
+      label: Composant impacté
+      description: Nom du composant et chemin Storybook si possible.
+      placeholder: Dialog (Composants / Feedback / Dialog)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type de défaut
+      options:
+        - Contraste insuffisant (texte / fond / bordure)
+        - Élément non focusable au clavier
+        - Ordre de focus incorrect
+        - Pas de retour au focus après fermeture (ex. modal)
+        - Annonce lecteur d'écran absente ou incorrecte
+        - Rôle ARIA manquant ou incorrect
+        - Attribut `aria-*` manquant ou incorrect
+        - Texte alternatif manquant (image, icône)
+        - Autre (préciser dans la description)
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Comment reproduire
+      description: Étapes précises pour reproduire l'écart, en partant idéalement d'une story Storybook.
+      placeholder: |
+        1. Ouvrir https://govpf.github.io/ori/storybook/react/?path=/docs/composants-feedback-dialog--default
+        2. Cliquer sur "Ouvrir la modale"
+        3. Appuyer sur Tab
+        4. Le focus ne reste pas dans la modale (sort sur l'arrière-plan)
+    validations:
+      required: true
+
+  - type: textarea
+    id: attendu
+    attributes:
+      label: Comportement attendu
+      description: Comment ça devrait se comporter selon RGAA AA / WCAG 2.1.
+    validations:
+      required: true
+
+  - type: input
+    id: outil
+    attributes:
+      label: Outil ayant détecté l'écart
+      description: axe-core, NVDA, VoiceOver, JAWS, Lighthouse, audit humain, etc.
+      placeholder: NVDA + Firefox
+
+  - type: input
+    id: critere-rgaa
+    attributes:
+      label: Critère RGAA / WCAG concerné
+      description: Numéro du critère si connu. Sinon laisser vide, on le retrouvera.
+      placeholder: 'RGAA 7.3 / WCAG 2.1 SC 2.1.2 (No Keyboard Trap)'
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework concerné
+      options:
+        - React
+        - Angular
+        - Les deux (cross-framework)
+        - CSS pur (@govpf/ori-css)
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte
+      description: App PF impactée, urgence, capture d'écran ou enregistrement.

--- a/.github/ISSUE_TEMPLATE/composant-manquant.yml
+++ b/.github/ISSUE_TEMPLATE/composant-manquant.yml
@@ -1,0 +1,73 @@
+name: Composant manquant
+description: Demander l'ajout d'un nouveau composant ou d'une nouvelle variante au DS Ori.
+title: '[Composant] '
+labels: ['composant', 'à trier']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de contribuer à Ori. Avant de soumettre, vérifier que le
+        composant n'existe pas déjà dans le [catalogue Storybook](https://govpf.github.io/ori/storybook/react/).
+
+  - type: input
+    id: composant
+    attributes:
+      label: Nom proposé du composant
+      description: En PascalCase. Exemple - DropdownMenu, Combobox, MultiSelect.
+      placeholder: DropdownMenu
+    validations:
+      required: true
+
+  - type: textarea
+    id: usage
+    attributes:
+      label: Cas d'usage concret
+      description: Décrire un cas d'usage concret dans une app PF (ex. menu utilisateur en haut à droite, filtre sur une table d'agents, etc.). Permet de calibrer l'API.
+      placeholder: |
+        Dans l'app annuaire, on a besoin d'un menu déroulant pour les
+        actions par ligne (modifier, supprimer, désactiver). Aujourd'hui
+        on bricole avec un Button + un panel custom positionné via JS.
+    validations:
+      required: true
+
+  - type: textarea
+    id: variantes
+    attributes:
+      label: Variantes / props attendues
+      description: Lister les variantes visuelles (size, variant, etc.) et les props essentielles. Pas besoin d'être exhaustif, on en discutera dans l'issue.
+      placeholder: |
+        - size : sm / md / lg
+        - position : top / bottom / left / right (auto par défaut)
+        - items : array de { label, icon?, onClick, variant? }
+        - searchable : bool
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives évaluées
+      description: Si vous avez regardé d'autres DS (shadcn, Material, Chakra, Carbon, DSFR), citer les inspirations. Aide à benchmarker l'API.
+
+  - type: textarea
+    id: a11y
+    attributes:
+      label: Contraintes d'accessibilité connues
+      description: Le composant a-t-il des spécificités RGAA AA à considérer dès la conception (focus trap, role ARIA, navigation clavier, annonces lecteur d'écran) ?
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework prioritaire
+      description: Vous bloque côté React, Angular, ou les deux ?
+      options:
+        - Les deux (publier React + Angular en miroir)
+        - React uniquement (Angular peut suivre plus tard)
+        - Angular uniquement (React peut suivre plus tard)
+        - HTML / CSS pur (via @govpf/ori-css)
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte / lien app pilote
+      description: App PF qui en a besoin, échéance éventuelle, lien vers une issue interne. Aide la priorisation.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# Configuration des templates d'issue. Désactive les issues vides
+# (force le contributeur à choisir un template) et propose des canaux
+# alternatifs pour les sujets qui ne sont pas du bug ou du feature
+# request technique.
+blank_issues_enabled: false
+contact_links:
+  - name: Question d'usage
+    url: https://github.com/govpf/ori/issues/new?template=question-usage.yml
+    about: Vous ne savez pas quel composant utiliser, ou comment composer plusieurs composants ensemble.
+  - name: Documentation Ori
+    url: https://ori.gov.pf
+    about: Site documentaire public, à consulter avant d'ouvrir une issue.
+  - name: Storybook (catalogue interactif)
+    url: https://govpf.github.io/ori/storybook/react/
+    about: Catalogue des composants avec exemples interactifs. Vérifier si le composant existe avant d'ouvrir une demande.
+  - name: Sujet sécurité
+    url: https://github.com/govpf/ori/security/advisories/new
+    about: Pour rapporter une faille en privé. Ne JAMAIS ouvrir d'issue publique pour un sujet sécurité.

--- a/.github/ISSUE_TEMPLATE/pattern-applicatif.yml
+++ b/.github/ISSUE_TEMPLATE/pattern-applicatif.yml
@@ -1,0 +1,73 @@
+name: Pattern applicatif
+description: Demander un pattern composé (DataTable, Wizard, Login layout, EmptyState…) qui dépasse la primitive.
+title: '[Pattern] '
+labels: ['pattern', 'à trier']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Un pattern est une **composition** réutilisable de plusieurs
+        primitives Ori (Table + Pagination + filtres = DataTable). Si
+        votre besoin est un seul composant atomique, utiliser plutôt
+        le template **Composant manquant**.
+
+  - type: input
+    id: pattern
+    attributes:
+      label: Nom du pattern
+      placeholder: DataTable filtré et paginé
+    validations:
+      required: true
+
+  - type: textarea
+    id: composition
+    attributes:
+      label: Composition cible
+      description: Quelles primitives Ori sont assemblées dans ce pattern ?
+      placeholder: |
+        Table + Pagination + Input (recherche) + Select (filtre par
+        secteur) + Tag (statut par ligne) + DropdownMenu (actions
+        par ligne).
+    validations:
+      required: true
+
+  - type: textarea
+    id: usage
+    attributes:
+      label: Cas d'usage concret
+      description: Décrire un cas d'usage concret dans une app PF qui réutilise ce pattern (ex. liste d'agents, catalogue de démarches, journal d'audit).
+      placeholder: |
+        Dans l'app annuaire, on a besoin d'afficher la liste des agents
+        avec recherche libre, filtre par direction, tri par nom, et
+        actions par ligne. On a aujourd'hui 4 implémentations
+        divergentes dans 4 apps différentes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: api
+    attributes:
+      label: API souhaitée (props, callbacks, slots)
+      description: Esquisse de la prop interface. Pas besoin d'être complet, on affinera dans l'issue.
+      placeholder: |
+        <DataTable
+          rows={agents}
+          columns={[...]}
+          searchable
+          onSearch={...}
+          filters={[...]}
+          pagination={{ page, perPage, total, onPageChange }}
+          rowActions={[...]}
+        />
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives évaluées
+      description: Patterns existants dans d'autres DS (TanStack Table, Material DataGrid, etc.) qui pourraient inspirer.
+
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte / app pilote
+      description: App PF qui en a besoin, échéance, lien vers issue interne.

--- a/.github/ISSUE_TEMPLATE/question-usage.yml
+++ b/.github/ISSUE_TEMPLATE/question-usage.yml
@@ -1,0 +1,57 @@
+name: Question d'usage
+description: Vous ne savez pas quel composant utiliser, comment composer plusieurs composants, ou comment override un comportement.
+title: '[Question] '
+labels: ['question', 'à trier']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Avant de poser la question, vérifier rapidement :
+
+        - La page [Storybook](https://govpf.github.io/ori/storybook/react/) du composant
+        - La page d'usage MDX si elle existe (ex. Composants / Feedback / Dialog → onglet Docs)
+        - Le [site de doc](https://ori.gov.pf) (Patterns React, Patterns Angular)
+        - Les [Décisions de design](https://ori.gov.pf/) qui expliquent pourquoi tel choix d'API
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Votre question
+      description: Décrire précisément ce que vous cherchez à faire et là où vous bloquez.
+      placeholder: |
+        Comment afficher un Dialog avec un formulaire dedans ET garder le
+        focus sur le premier champ ? J'ai essayé `autoFocus` sur l'Input
+        mais ça ne marche pas, le focus reste sur le bouton trigger.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tentatives
+    attributes:
+      label: Ce que vous avez essayé
+      description: Code que vous avez écrit, comportement obtenu vs attendu.
+      render: tsx
+      placeholder: |
+        <Dialog open={open}>
+          <DialogContent title="Modifier l'agent">
+            <Input label="Nom" autoFocus />
+          </DialogContent>
+        </Dialog>
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Framework
+      options:
+        - React
+        - Angular
+        - HTML / CSS pur
+        - Pas applicable (question transverse)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version d'Ori utilisée
+      placeholder: '@govpf/ori-react 0.3.2'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,9 +311,29 @@ Conventions calées sur Conventional Commits :
 | `feat!` ou `BREAKING CHANGE` dans le corps         | `major`                            |
 | `chore`, `docs`, `refactor`, `test`, `ci`, `style` | **pas de bump** (pas de changeset) |
 
-Tant que le DS est en `0.x`, un breaking change peut rester en `minor`
-(c'est la sémantique semver). À partir de `1.0`, tout breaking devient
-`major`.
+#### Politique semver pré-1.0
+
+Tant que le DS est en `0.x` (phase de bootstrap), la règle est :
+
+| Bump  | Format  | Sémantique                                                                                             |
+| ----- | ------- | ------------------------------------------------------------------------------------------------------ |
+| Patch | `0.x.y` | Compatibilité ascendante garantie. Bug fixes uniquement.                                               |
+| Minor | `0.x.0` | **Breaking changes autorisés**. Nouvelles fonctionnalités, modifications d'API publique, suppressions. |
+| Major | `1.0.0` | Sortira après stabilisation par X apps PF en production.                                               |
+
+**Pour les consommateurs** : verrouiller la version exacte d'Ori en
+`dependencies` (`"@govpf/ori-react": "0.3.2"`, pas `"^0.3.2"`). Lire
+le `CHANGELOG.md` de chaque package avant tout bump minor.
+
+**Pour les contributeurs Ori** : tout changement d'API publique doit
+embarquer un changeset minor avec un résumé clair. Si le changement
+est breaking, le résumé doit lister explicitement « Breaking : ... »
+avec un exemple `avant` / `après` quand c'est court.
+
+À partir de `1.0`, tout breaking deviendra `major` (sémantique semver
+classique).
+
+Voir aussi la décision tranchée [C.5 dans Décisions à prendre](https://ori.gov.pf/) du Storybook.
 
 #### Que se passe-t-il après merge ?
 

--- a/packages/docs/src/Decisions-A-Prendre.mdx
+++ b/packages/docs/src/Decisions-A-Prendre.mdx
@@ -524,6 +524,52 @@ dette technique.
 
 ---
 
+### C.5 - Politique semver pré-1.0
+
+🟢 **Statut** : tranchée
+
+**Contexte** : Ori est en phase de bootstrap (versions `0.x`). Le
+versioning est piloté par Changesets depuis la PR #34 mais la règle
+de bump n'était pas explicite, ce qui crée de l'incertitude pour les
+premiers consommateurs qui doivent verrouiller leurs versions sans
+savoir à quelle fréquence les breaking changes peuvent tomber.
+
+**Décision** : adopter la politique standard semver pré-1.0
+recommandée par la spec npm.
+
+| Bump   | Format   | Sémantique                                 |
+| ------ | -------- | ------------------------------------------ |
+| Patch  | `0.x.y`  | Compatibilité ascendante garantie. Bug fixes uniquement. |
+| Minor  | `0.x.0`  | **Breaking changes autorisés**. Nouvelles fonctionnalités, modifications d'API publique, suppressions. |
+| Major  | `1.0.0`  | Sortira après stabilisation par X apps PF en production (cf. décision dédiée à venir). |
+
+**Conséquence pour les consommateurs** :
+
+- Verrouiller la version exacte d'Ori en `dependencies` (`"@govpf/ori-react": "0.3.2"`, pas `"^0.3.2"`).
+- Lire le `CHANGELOG.md` de chaque package avant tout bump minor : il liste les
+  breaking changes et les codemods quand applicables.
+- Tester les bumps minor en environnement de recette avant production.
+
+**Conséquence côté Ori** :
+
+- Toute PR qui change l'API publique d'un composant publié doit
+  embarquer un changeset **minor**. Le bot Changesets ouvre la PR
+  `chore(release): version packages` à chaque push main et bumpe les
+  packages concernés.
+- Le `CHANGELOG.md` de chaque package doit lister explicitement les
+  breaking changes en tête, avec un exemple `avant` / `après` quand
+  c'est court à montrer.
+- Pas de breaking change non documenté en patch : si un patch en
+  contient un par accident, on bump immédiatement en minor et on
+  publie un correctif.
+
+**Documentation** : à reprendre dans `CONTRIBUTING.md` section
+"Versioning et release", et dans la page d'installation du site
+Astro `ori.gov.pf` pour informer les consommateurs avant
+installation.
+
+---
+
 ## D. Stratégie produit
 
 ### D.1 - Gestion de la migration des apps existantes


### PR DESCRIPTION
## Résumé

Réponse partielle au [feedback externe](https://github.com/govpf/ori/discussions) sur la migration `directory`. Cette PR matérialise deux items du sprint immédiat :

1. **Politique semver pré-1.0** (Decisions-A-Prendre C.5 + section dans CONTRIBUTING.md)
2. **4 issue templates GitHub** form-based pour structurer les demandes externes

L'item 3 (roadmap publique GitHub Projects) suit dans une étape distincte (besoin du scope `project` sur le token gh).

## Politique semver pré-1.0

Tant que le DS est en `0.x` :

| Bump | Format | Sémantique |
| --- | --- | --- |
| Patch | `0.x.y` | Compatibilité ascendante garantie, bug fixes uniquement |
| Minor | `0.x.0` | **Breaking changes autorisés**, nouvelles features, modifications d'API publique |
| Major | `1.0.0` | Sortira après stabilisation par X apps PF en production |

**Pour les consommateurs** : verrouiller la version exacte (`"0.3.2"`, pas `"^0.3.2"`). Lire le `CHANGELOG.md` avant tout bump minor.

## Issue templates GitHub

| Template | Pour quoi |
| --- | --- |
| `composant-manquant.yml` | Ajout d'une primitive (DropdownMenu, Combobox, MultiSelect, etc.) |
| `bug-a11y.yml` | Défaut RGAA AA (contraste, focus, ARIA, lecteur d'écran) avec champs structurés |
| `pattern-applicatif.yml` | Composition haute (DataTable, Wizard, Login layout) distincte d'une primitive |
| `question-usage.yml` | Question d'usage qui n'est pas un bug |

Plus un `config.yml` qui désactive les issues vides, propose des liens contextuels (Storybook, site doc, security advisories pour les sujets sécurité).

## Test plan

- [x] `pnpm format:check` : OK
- [ ] CI verte sur cette PR
- [ ] Tester l'ouverture d'une issue avec un template (vérifier rendu form-based) une fois mergé