### PR TITLE
chore(docs): lien vers la roadmap publique GitHub Projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,24 @@ cassé, classe CSS oubliée), **ouvrir une issue d'abord** pour discuter
 du besoin. Cela évite de produire du code qui ne sera pas mergé pour
 des raisons de design ou de stratégie.
 
+Le repo embarque [4 templates d'issues](./.github/ISSUE_TEMPLATE/) :
+composant manquant, bug a11y, pattern applicatif, question d'usage.
+À choisir dès la création d'une issue.
+
+### Roadmap publique
+
+Le suivi des chantiers est visible sur le **[GitHub Project Ori roadmap](https://github.com/orgs/govpf/projects/3)** :
+
+- 4 colonnes : `Backlog` (items reconnus), `Up next` (1-2 sprints à venir),
+  `In progress` (PR ouverte), `Done` (livré)
+- Filtres par `Catégorie` (Composant / Pattern / A11y / DX / Doc /
+  Écosystème / Gouvernance / Sécu), `Size` (effort estimé),
+  `Source` (Feedback externe / Roadmap interne / Bug remonté /
+  Décision tranchée)
+
+Avant d'ouvrir un nouveau ticket, vérifier que l'item n'est pas
+déjà dans la roadmap. Si oui, commenter sur la card concernée.
+
 ### Code de conduite
 
 Ce projet suit le [Contributor Covenant](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ complète des composants disponibles et leurs API.
 - **Site documentaire** (à venir) : <https://ori.gov.pf>
 - **Storybooks de test interactif** : déployés en sous-chemins du site documentaire
 - **Décisions de design** et **stratégie d'ouverture** : pages MDX dans `packages/docs/`
+- **Roadmap publique** : <https://github.com/orgs/govpf/projects/3> (Backlog, Up next, In progress, Done ; filtres par catégorie, effort, source)
 
 ## Démarrer
 

--- a/apps/ori-site/src/layouts/BaseLayout.astro
+++ b/apps/ori-site/src/layouts/BaseLayout.astro
@@ -92,6 +92,7 @@ const base = import.meta.env.BASE_URL;
               <nav class="ori-footer__column" aria-label="Liens externes">
                 <span class="ori-footer__column-title">Code source</span>
                 <a class="ori-link ori-link--quiet" href="https://github.com/govpf/ori" target="_blank" rel="noreferrer">GitHub<span class="ori-link__external" aria-hidden="true">↗</span></a>
+                <a class="ori-link ori-link--quiet" href="https://github.com/orgs/govpf/projects/3" target="_blank" rel="noreferrer">Roadmap publique<span class="ori-link__external" aria-hidden="true">↗</span></a>
                 <a class="ori-link ori-link--quiet" href="https://www.npmjs.com/org/govpf" target="_blank" rel="noreferrer">npm @govpf<span class="ori-link__external" aria-hidden="true">↗</span></a>
                 <a class="ori-link ori-link--quiet" href={`${base}storybook/react/`}>Storybook React</a>
                 <a class="ori-link ori-link--quiet" href={`${base}storybook/angular/`}>Storybook Angular</a>


### PR DESCRIPTION
## Résumé

Le [Project "Ori roadmap"](https://github.com/orgs/govpf/projects/3) est désormais alimenté avec **36 items** couvrant :
- Le feedback externe sur la migration `directory`
- L'historique des PR mergées (Done)
- Les chantiers gouvernance internes (CODEOWNERS, second mainteneur npm)

Cette PR ajoute le lien à 3 endroits pour qu'un consommateur ou contributeur le découvre rapidement :

| Surface | Emplacement |
| --- | --- |
| `README.md` | Section "Documentation", après le site doc et les Storybooks |
| `CONTRIBUTING.md` | Nouvelle sous-section "Roadmap publique" sous "Avant de contribuer", avec mention des [4 templates d'issues](https://github.com/govpf/ori/tree/main/.github/ISSUE_TEMPLATE) ajoutés en PR #42 |
| Footer site Astro | Colonne "Code source", entre GitHub et npm |

## Configuration du Project

- **4 colonnes Status** : `Backlog` (27 items), `Up next` (1), `In progress` (1), `Done` (7)
- **4 fields custom** :
  - `Catégorie` : Composant, Pattern, A11y, DX, Doc, Écosystème, Gouvernance, Sécu
  - `Size` : XS, S, M, L, XL (effort estimé)
  - `Source` : Feedback externe, Roadmap interne, Bug remonté, Décision tranchée

## Test plan

- [x] `pnpm format:check` : OK
- [x] Project visible publiquement via l'URL
- [ ] CI verte sur cette PR