### PR TITLE
feat(dropdown-menu): primitive DropdownMenu (React + Angular)

### DIFF
--- a/packages/angular/src/components/dropdown-menu/dropdown-menu.component.ts
+++ b/packages/angular/src/components/dropdown-menu/dropdown-menu.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -7,7 +8,9 @@ import {
   HostListener,
   Inject,
   Input,
+  OnDestroy,
   Output,
+  Renderer2,
   ViewChild,
   ViewChildren,
   ViewEncapsulation,
@@ -63,9 +66,6 @@ export interface OriDropdownMenuItem {
       <span
         #triggerWrap
         class="ori-dropdown-menu-trigger-wrap"
-        [attr.aria-haspopup]="'menu'"
-        [attr.aria-expanded]="isOpen"
-        [attr.aria-controls]="menuId"
         (click)="toggle()"
         (keydown)="onTriggerKeyDown($event)"
       >
@@ -114,7 +114,7 @@ export interface OriDropdownMenuItem {
     </div>
   `,
 })
-export class OriDropdownMenuComponent {
+export class OriDropdownMenuComponent implements AfterViewInit, OnDestroy {
   @Input() items: OriDropdownMenuItem[] = [];
   /** Alignement horizontal du menu sous le trigger. */
   @Input() align: 'start' | 'center' | 'end' = 'start';
@@ -133,8 +133,36 @@ export class OriDropdownMenuComponent {
 
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly hostRef = inject(ElementRef<HTMLElement>);
+  private readonly renderer = inject(Renderer2);
+  private triggerButton?: HTMLElement;
 
   constructor(@Inject(DOCUMENT) private readonly document: Document) {}
+
+  ngAfterViewInit(): void {
+    // Le bouton réel est projeté via slot="trigger" ; on le retrouve dans le
+    // wrap et on lui applique les attributs ARIA (axe-core refuse aria-haspopup
+    // sur un span sans rôle, donc on cible le bouton lui-même).
+    const wrap = this.triggerWrap?.nativeElement;
+    if (!wrap) return;
+    this.triggerButton =
+      wrap.querySelector<HTMLElement>('button') ??
+      wrap.querySelector<HTMLElement>('[slot=trigger]') ??
+      undefined;
+    if (this.triggerButton) {
+      this.renderer.setAttribute(this.triggerButton, 'aria-haspopup', 'menu');
+      this.renderer.setAttribute(this.triggerButton, 'aria-controls', this.menuId);
+      this.updateAriaExpanded();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.triggerButton = undefined;
+  }
+
+  private updateAriaExpanded(): void {
+    if (!this.triggerButton) return;
+    this.renderer.setAttribute(this.triggerButton, 'aria-expanded', String(this.isOpen));
+  }
 
   toggle(): void {
     if (this.isOpen) this.closeMenu();
@@ -146,6 +174,7 @@ export class OriDropdownMenuComponent {
     this.isOpen = true;
     this.activeIndex = this.firstEnabledIndex();
     this.openChange.emit(true);
+    this.updateAriaExpanded();
     this.cdr.markForCheck();
     requestAnimationFrame(() => this.focusActive());
   }
@@ -155,13 +184,10 @@ export class OriDropdownMenuComponent {
     this.isOpen = false;
     this.activeIndex = -1;
     this.openChange.emit(false);
+    this.updateAriaExpanded();
     this.cdr.markForCheck();
     if (restoreFocus) {
-      // Re-focus le premier élément focusable du trigger (le plus souvent un button)
-      const focusable = this.triggerWrap?.nativeElement.querySelector<HTMLElement>(
-        'button, [tabindex]:not([tabindex="-1"])',
-      );
-      focusable?.focus();
+      this.triggerButton?.focus();
     }
   }
 

--- a/packages/angular/src/components/dropdown-menu/dropdown-menu.component.ts
+++ b/packages/angular/src/components/dropdown-menu/dropdown-menu.component.ts
@@ -1,0 +1,283 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Inject,
+  Input,
+  Output,
+  ViewChild,
+  ViewChildren,
+  ViewEncapsulation,
+  inject,
+  type QueryList,
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { LucideAngularModule, Edit } from 'lucide-angular';
+
+type LucideIconData = typeof Edit;
+
+let nextUid = 0;
+
+/**
+ * Item d'un `<ori-dropdown-menu>`.
+ *
+ * - `separator: true` rend une ligne de séparation et ignore les autres champs.
+ * - `id` est requis sauf pour les séparateurs ; il est renvoyé par l'event
+ *   `(select)` quand l'item est activé.
+ */
+export interface OriDropdownMenuItem {
+  id?: string;
+  label?: string;
+  icon?: LucideIconData;
+  shortcut?: string;
+  destructive?: boolean;
+  disabled?: boolean;
+  separator?: boolean;
+}
+
+/**
+ * DropdownMenu accessible, sans dépendance externe.
+ *
+ * - In-place dans le DOM (pas de portal, cohérent avec décision B.1)
+ * - Click outside et touche Escape pour fermer
+ * - Navigation clavier : ArrowUp / ArrowDown (avec wrap), Home, End
+ * - ARIA : `role="menu"` / `role="menuitem"`, `aria-haspopup="menu"`,
+ *   `aria-expanded` sur le trigger
+ *
+ * Le trigger doit être projeté avec `slot="trigger"`. Les items sont passés en
+ * data-driven via la prop `[items]`. Pour des items custom (composants
+ * imbriqués, contenus riches), une variante composée pourra être ajoutée si
+ * le besoin se confirme côté apps consommatrices.
+ */
+@Component({
+  selector: 'ori-dropdown-menu',
+  standalone: true,
+  imports: [LucideAngularModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div class="ori-dropdown-menu-wrap">
+      <span
+        #triggerWrap
+        class="ori-dropdown-menu-trigger-wrap"
+        [attr.aria-haspopup]="'menu'"
+        [attr.aria-expanded]="isOpen"
+        [attr.aria-controls]="menuId"
+        (click)="toggle()"
+        (keydown)="onTriggerKeyDown($event)"
+      >
+        <ng-content select="[slot=trigger]"></ng-content>
+      </span>
+
+      @if (isOpen) {
+        <div
+          [id]="menuId"
+          class="ori-dropdown-menu"
+          [class.ori-dropdown-menu--align-end]="align === 'end'"
+          [class.ori-dropdown-menu--align-center]="align === 'center'"
+          role="menu"
+          [attr.aria-label]="ariaLabel || null"
+        >
+          @for (item of items; track item.id ?? $index; let i = $index) {
+            @if (item.separator) {
+              <div class="ori-dropdown-menu__separator" role="separator"></div>
+            } @else {
+              <button
+                #menuItem
+                type="button"
+                role="menuitem"
+                class="ori-dropdown-menu__item"
+                [class.ori-dropdown-menu__item--destructive]="item.destructive"
+                [disabled]="item.disabled"
+                [attr.tabindex]="i === activeIndex ? 0 : -1"
+                (click)="selectItem(item)"
+                (keydown)="onItemKeyDown($event, i, item)"
+                (mouseenter)="setActive(i)"
+              >
+                @if (item.icon) {
+                  <span class="ori-dropdown-menu__item-icon" aria-hidden="true">
+                    <lucide-icon [img]="item.icon" [size]="16"></lucide-icon>
+                  </span>
+                }
+                <span class="ori-dropdown-menu__item-label">{{ item.label }}</span>
+                @if (item.shortcut) {
+                  <span class="ori-dropdown-menu__item-shortcut">{{ item.shortcut }}</span>
+                }
+              </button>
+            }
+          }
+        </div>
+      }
+    </div>
+  `,
+})
+export class OriDropdownMenuComponent {
+  @Input() items: OriDropdownMenuItem[] = [];
+  /** Alignement horizontal du menu sous le trigger. */
+  @Input() align: 'start' | 'center' | 'end' = 'start';
+  /** Label accessible du menu (lu par les lecteurs d'écran à l'ouverture). */
+  @Input() ariaLabel: string = '';
+
+  @Output() select = new EventEmitter<OriDropdownMenuItem>();
+  @Output() openChange = new EventEmitter<boolean>();
+
+  @ViewChild('triggerWrap') protected triggerWrap?: ElementRef<HTMLElement>;
+  @ViewChildren('menuItem') protected menuItems?: QueryList<ElementRef<HTMLButtonElement>>;
+
+  protected isOpen = false;
+  protected activeIndex = -1;
+  protected readonly menuId = `pf-dropdown-menu-${++nextUid}`;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly hostRef = inject(ElementRef<HTMLElement>);
+
+  constructor(@Inject(DOCUMENT) private readonly document: Document) {}
+
+  toggle(): void {
+    if (this.isOpen) this.closeMenu();
+    else this.openMenu();
+  }
+
+  openMenu(): void {
+    if (this.isOpen) return;
+    this.isOpen = true;
+    this.activeIndex = this.firstEnabledIndex();
+    this.openChange.emit(true);
+    this.cdr.markForCheck();
+    requestAnimationFrame(() => this.focusActive());
+  }
+
+  closeMenu(restoreFocus = true): void {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.activeIndex = -1;
+    this.openChange.emit(false);
+    this.cdr.markForCheck();
+    if (restoreFocus) {
+      // Re-focus le premier élément focusable du trigger (le plus souvent un button)
+      const focusable = this.triggerWrap?.nativeElement.querySelector<HTMLElement>(
+        'button, [tabindex]:not([tabindex="-1"])',
+      );
+      focusable?.focus();
+    }
+  }
+
+  selectItem(item: OriDropdownMenuItem): void {
+    if (item.disabled || item.separator) return;
+    this.select.emit(item);
+    this.closeMenu();
+  }
+
+  protected setActive(index: number): void {
+    if (this.activeIndex === index) return;
+    this.activeIndex = index;
+    this.cdr.markForCheck();
+  }
+
+  protected onTriggerKeyDown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (!this.isOpen) this.openMenu();
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!this.isOpen) {
+        this.openMenu();
+        // Focus sur le dernier item activable
+        const last = this.lastEnabledIndex();
+        if (last >= 0) {
+          this.activeIndex = last;
+          requestAnimationFrame(() => this.focusActive());
+        }
+      }
+    } else if (event.key === 'Escape' && this.isOpen) {
+      event.preventDefault();
+      this.closeMenu();
+    }
+  }
+
+  protected onItemKeyDown(event: KeyboardEvent, index: number, item: OriDropdownMenuItem): void {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.moveFocus(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.moveFocus(-1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.activeIndex = this.firstEnabledIndex();
+        this.focusActive();
+        break;
+      case 'End':
+        event.preventDefault();
+        this.activeIndex = this.lastEnabledIndex();
+        this.focusActive();
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.closeMenu();
+        break;
+      case 'Tab':
+        // Tab ferme le menu sans bloquer la navigation naturelle
+        this.closeMenu(false);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        this.selectItem(item);
+        break;
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  protected onDocumentClick(event: MouseEvent): void {
+    if (!this.isOpen) return;
+    const target = event.target as Node;
+    if (!this.hostRef.nativeElement.contains(target)) {
+      this.closeMenu(false);
+    }
+  }
+
+  private moveFocus(delta: number): void {
+    const enabledIndices = this.items
+      .map((it, idx) => ({ it, idx }))
+      .filter(({ it }) => !it.separator && !it.disabled)
+      .map(({ idx }) => idx);
+    if (!enabledIndices.length) return;
+    const currentPos = enabledIndices.indexOf(this.activeIndex);
+    const nextPos = (currentPos + delta + enabledIndices.length) % enabledIndices.length;
+    this.activeIndex = enabledIndices[nextPos];
+    this.focusActive();
+  }
+
+  private firstEnabledIndex(): number {
+    return this.items.findIndex((it) => !it.separator && !it.disabled);
+  }
+
+  private lastEnabledIndex(): number {
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      const it = this.items[i];
+      if (!it.separator && !it.disabled) return i;
+    }
+    return -1;
+  }
+
+  private focusActive(): void {
+    if (this.activeIndex < 0) return;
+    const buttons = this.menuItems?.toArray() ?? [];
+    // L'index dans la query list ne correspond pas à activeIndex (les
+    // séparateurs ne sont pas rendus comme menuItem). On retrouve le bon
+    // bouton via son ordinal parmi les items non-séparateur précédents.
+    let visibleOrdinal = 0;
+    for (let i = 0; i < this.activeIndex; i++) {
+      if (!this.items[i].separator) visibleOrdinal++;
+    }
+    buttons[visibleOrdinal]?.nativeElement.focus();
+    this.cdr.markForCheck();
+  }
+}

--- a/packages/angular/src/components/dropdown-menu/dropdown-menu.stories.ts
+++ b/packages/angular/src/components/dropdown-menu/dropdown-menu.stories.ts
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { Edit, Copy, Share2, Trash2, User, Settings, LogOut, HelpCircle } from 'lucide-angular';
+import { OriDropdownMenuComponent, type OriDropdownMenuItem } from './dropdown-menu.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriDropdownMenuComponent> = {
+  title: 'Composants/Navigation/DropdownMenu',
+  component: OriDropdownMenuComponent,
+  tags: ['autodocs'],
+  decorators: [moduleMetadata({ imports: [OriDropdownMenuComponent, OriButtonComponent] })],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Menu déroulant accessible (role="menu"), avec navigation clavier complète, click-outside et restauration du focus. Items data-driven via la prop `[items]`, trigger projeté via `slot="trigger"`.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriDropdownMenuComponent>;
+
+const actions: OriDropdownMenuItem[] = [
+  { id: 'edit', label: 'Modifier', icon: Edit },
+  { id: 'duplicate', label: 'Dupliquer', icon: Copy },
+  { id: 'share', label: 'Partager', icon: Share2 },
+  { id: 'sep1', separator: true },
+  { id: 'delete', label: 'Supprimer', icon: Trash2, destructive: true },
+];
+
+const userActions: OriDropdownMenuItem[] = [
+  { id: 'profile', label: 'Profil', icon: User },
+  { id: 'prefs', label: 'Préférences', icon: Settings },
+  { id: 'help', label: 'Aide', icon: HelpCircle },
+  { id: 'sep1', separator: true },
+  { id: 'logout', label: 'Se déconnecter', icon: LogOut, destructive: true },
+];
+
+const editActions: OriDropdownMenuItem[] = [
+  { id: 'edit', label: 'Modifier', icon: Edit, shortcut: 'Ctrl+E' },
+  { id: 'copy', label: 'Copier', icon: Copy, shortcut: 'Ctrl+C' },
+  { id: 'sep1', separator: true },
+  { id: 'delete', label: 'Supprimer', icon: Trash2, shortcut: 'Suppr', destructive: true },
+];
+
+const moreActions: OriDropdownMenuItem[] = [
+  { id: 'edit', label: 'Modifier', icon: Edit },
+  { id: 'share', label: 'Partager (à venir)', icon: Share2, disabled: true },
+  { id: 'duplicate', label: 'Dupliquer', icon: Copy },
+];
+
+export const Default: Story = {
+  render: () => ({
+    props: {
+      items: actions,
+      handleSelect: (item: OriDropdownMenuItem) => {
+        // eslint-disable-next-line no-console
+        console.log('Action sélectionnée :', item.id);
+      },
+    },
+    template: `
+      <ori-dropdown-menu [items]="items" (select)="handleSelect($event)" ariaLabel="Actions">
+        <ori-button slot="trigger">Actions ▾</ori-button>
+      </ori-dropdown-menu>
+    `,
+  }),
+};
+
+export const UserMenu: Story = {
+  render: () => ({
+    props: {
+      items: userActions,
+      handleSelect: (item: OriDropdownMenuItem) => {
+        // eslint-disable-next-line no-console
+        console.log('Action utilisateur :', item.id);
+      },
+    },
+    template: `
+      <ori-dropdown-menu [items]="items" align="end" (select)="handleSelect($event)" ariaLabel="Mon compte">
+        <ori-button variant="secondary" slot="trigger">Mon compte ▾</ori-button>
+      </ori-dropdown-menu>
+    `,
+  }),
+};
+
+export const WithShortcuts: Story = {
+  render: () => ({
+    props: {
+      items: editActions,
+    },
+    template: `
+      <ori-dropdown-menu [items]="items" ariaLabel="Édition">
+        <ori-button slot="trigger">Édition ▾</ori-button>
+      </ori-dropdown-menu>
+    `,
+  }),
+};
+
+export const WithDisabledItem: Story = {
+  render: () => ({
+    props: {
+      items: moreActions,
+    },
+    template: `
+      <ori-dropdown-menu [items]="items" ariaLabel="Plus d'options">
+        <ori-button slot="trigger">Plus d'options ▾</ori-button>
+      </ori-dropdown-menu>
+    `,
+  }),
+};

--- a/packages/angular/src/components/dropdown-menu/index.ts
+++ b/packages/angular/src/components/dropdown-menu/index.ts
@@ -1,0 +1,1 @@
+export { OriDropdownMenuComponent, type OriDropdownMenuItem } from './dropdown-menu.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -3,6 +3,7 @@ export * from './components/input';
 export * from './components/card';
 export * from './components/alert';
 export * from './components/dialog';
+export * from './components/dropdown-menu';
 export * from './components/checkbox';
 export * from './components/radio';
 export * from './components/switch';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
+    "@radix-ui/react-dropdown-menu": "^2.1.4",
     "clsx": "^2.1.1",
     "lucide-react": "^0.469.0"
   },

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './DropdownMenu.js';
+import { Button } from '../Button/Button.js';
+import {
+  ChevronDown,
+  Edit,
+  Copy,
+  Share2,
+  Trash2,
+  User,
+  Settings,
+  LogOut,
+  HelpCircle,
+} from 'lucide-react';
+
+// Pas d'autodocs : Radix Portal rend dans document.body, le rendu auto-doc en
+// isolation casse ("Cannot destructure 'document'"). Mêmes contraintes que Dialog.
+const meta = {
+  title: 'Composants/Navigation/DropdownMenu',
+  component: DropdownMenu,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>
+          Actions <ChevronDown size={16} aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem icon={<Edit size={16} />}>Modifier</DropdownMenuItem>
+        <DropdownMenuItem icon={<Copy size={16} />}>Dupliquer</DropdownMenuItem>
+        <DropdownMenuItem icon={<Share2 size={16} />}>Partager</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem icon={<Trash2 size={16} />} destructive>
+          Supprimer
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const UserMenu: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="secondary">
+          <User size={16} aria-hidden="true" /> Mon compte{' '}
+          <ChevronDown size={16} aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Connecté en tant que Léonard T.</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem icon={<User size={16} />}>Profil</DropdownMenuItem>
+        <DropdownMenuItem icon={<Settings size={16} />}>Préférences</DropdownMenuItem>
+        <DropdownMenuItem icon={<HelpCircle size={16} />}>Aide</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem icon={<LogOut size={16} />} destructive>
+          Se déconnecter
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const WithShortcuts: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Édition</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem icon={<Edit size={16} />} shortcut="Ctrl+E">
+          Modifier
+        </DropdownMenuItem>
+        <DropdownMenuItem icon={<Copy size={16} />} shortcut="Ctrl+C">
+          Copier
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem icon={<Trash2 size={16} />} shortcut="Suppr" destructive>
+          Supprimer
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const WithDisabledItem: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>Plus d'options</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem icon={<Edit size={16} />}>Modifier</DropdownMenuItem>
+        <DropdownMenuItem icon={<Share2 size={16} />} disabled>
+          Partager (à venir)
+        </DropdownMenuItem>
+        <DropdownMenuItem icon={<Copy size={16} />}>Dupliquer</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};
+
+export const ControlledOpen: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'center' }}>
+        <p style={{ margin: 0 }}>Menu {open ? 'ouvert' : 'fermé'}</p>
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button>Toggle</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onSelect={() => setOpen(false)}>Action A</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setOpen(false)}>Action B</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './DropdownMenu';
+
+function setup(extra: { onModifier?: () => void; onSupprimer?: () => void } = {}) {
+  return render(
+    <DropdownMenu>
+      <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>Actions disponibles</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={extra.onModifier}>Modifier</DropdownMenuItem>
+        <DropdownMenuItem disabled>Partager</DropdownMenuItem>
+        <DropdownMenuItem destructive onSelect={extra.onSupprimer}>
+          Supprimer
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>,
+  );
+}
+
+describe('DropdownMenu', () => {
+  describe('rendu', () => {
+    it('rend un trigger avec aria-haspopup="menu"', () => {
+      setup();
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('ne rend pas le menu quand fermé', () => {
+      setup();
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('ouvre le menu au clic sur le trigger', async () => {
+      const user = userEvent.setup();
+      setup();
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      await user.click(trigger);
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      // Une fois le menu ouvert, Radix marque le trigger aria-hidden ; on lit
+      // donc l'attribut directement plutôt que via getByRole.
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('rend chaque item avec role="menuitem"', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      const items = screen.getAllByRole('menuitem');
+      // 3 items (Modifier, Partager disabled, Supprimer) ; le label n'est pas un menuitem
+      expect(items).toHaveLength(3);
+    });
+
+    it('marque les items disabled avec aria-disabled', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      expect(screen.getByRole('menuitem', { name: 'Partager' })).toHaveAttribute(
+        'data-disabled',
+        '',
+      );
+    });
+
+    it('applique la classe destructive aux items destructive', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      expect(screen.getByRole('menuitem', { name: 'Supprimer' })).toHaveClass(
+        'ori-dropdown-menu__item--destructive',
+      );
+    });
+  });
+
+  describe('sélection', () => {
+    it('appelle onSelect au clic sur un item', async () => {
+      const user = userEvent.setup();
+      const onModifier = vi.fn();
+      setup({ onModifier });
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Modifier' }));
+      expect(onModifier).toHaveBeenCalledTimes(1);
+    });
+
+    it("ferme le menu après sélection d'un item", async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Modifier' }));
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it("n'appelle pas onSelect sur un item disabled", async () => {
+      const user = userEvent.setup();
+      const onShare = vi.fn();
+      render(
+        <DropdownMenu>
+          <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem disabled onSelect={onShare}>
+              Partager
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Partager' }));
+      expect(onShare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation clavier', () => {
+    it('ferme le menu sur Escape', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    it('déclenche onSelect sur Entrée', async () => {
+      const user = userEvent.setup();
+      const onModifier = vi.fn();
+      setup({ onModifier });
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      trigger.focus();
+      await user.keyboard('{Enter}');
+      // Radix focus le premier item ouvert au clavier
+      await user.keyboard('{Enter}');
+      expect(onModifier).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('contrôlé', () => {
+    it('respecte la prop open', () => {
+      render(
+        <DropdownMenu open={true}>
+          <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Modifier</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it("appelle onOpenChange à l'ouverture", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <DropdownMenu onOpenChange={onOpenChange}>
+          <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Modifier</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,140 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import { clsx } from 'clsx';
+
+/**
+ * DropdownMenu accessible, basé sur @radix-ui/react-dropdown-menu.
+ *
+ * Couvre les cas d'usage standard : menu d'actions sur un bouton, menu
+ * utilisateur dans un header, actions de ligne dans une table.
+ *
+ * Radix gère : focus management, type-ahead, navigation clavier
+ * (Tab, Flèches, Home/End, Esc), ARIA (role="menu" / "menuitem"),
+ * auto-positioning avec collision detection, fermeture click-outside.
+ *
+ * Non couvert v1 : sous-menus imbriqués, items checkbox / radio.
+ * Ces variantes pourront être ajoutées comme primitives séparées si le
+ * besoin se confirme côté apps consommatrices.
+ */
+
+export interface DropdownMenuProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+}
+
+export function DropdownMenu({ open, defaultOpen, onOpenChange, children }: DropdownMenuProps) {
+  return (
+    <RadixDropdownMenu.Root open={open} defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
+      {children}
+    </RadixDropdownMenu.Root>
+  );
+}
+
+export const DropdownMenuTrigger = RadixDropdownMenu.Trigger;
+
+export type DropdownMenuSide = 'top' | 'right' | 'bottom' | 'left';
+export type DropdownMenuAlign = 'start' | 'center' | 'end';
+
+export interface DropdownMenuContentProps {
+  /** Côté d'apparition par rapport au trigger. Default: 'bottom'. */
+  side?: DropdownMenuSide;
+  /** Alignement par rapport au trigger. Default: 'start'. */
+  align?: DropdownMenuAlign;
+  /** Décalage en pixels par rapport au trigger. Default: 4. */
+  sideOffset?: number;
+  className?: string;
+  children?: ReactNode;
+}
+
+export const DropdownMenuContent = forwardRef<HTMLDivElement, DropdownMenuContentProps>(
+  function DropdownMenuContent(
+    { side = 'bottom', align = 'start', sideOffset = 4, className, children },
+    ref,
+  ) {
+    return (
+      <RadixDropdownMenu.Portal>
+        <RadixDropdownMenu.Content
+          ref={ref}
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          className={clsx('ori-dropdown-menu', className)}
+        >
+          {children}
+        </RadixDropdownMenu.Content>
+      </RadixDropdownMenu.Portal>
+    );
+  },
+);
+
+export interface DropdownMenuItemProps {
+  /** Icône optionnelle affichée en début d'item (recommandé : lucide-react). */
+  icon?: ReactNode;
+  /** Raccourci clavier affiché en fin d'item (informatif, non câblé). */
+  shortcut?: string;
+  /** Variante destructive (rouge) pour les actions de suppression. */
+  destructive?: boolean;
+  /** Désactive l'item ; reste visible mais non focusable / non cliquable. */
+  disabled?: boolean;
+  /** Callback déclenché au clic ou à la touche Entrée / Espace. */
+  onSelect?: (event: Event) => void;
+  className?: string;
+  children?: ReactNode;
+}
+
+export const DropdownMenuItem = forwardRef<HTMLDivElement, DropdownMenuItemProps>(
+  function DropdownMenuItem(
+    { icon, shortcut, destructive, disabled, onSelect, className, children },
+    ref,
+  ) {
+    return (
+      <RadixDropdownMenu.Item
+        ref={ref}
+        disabled={disabled}
+        onSelect={onSelect}
+        className={clsx(
+          'ori-dropdown-menu__item',
+          destructive && 'ori-dropdown-menu__item--destructive',
+          className,
+        )}
+      >
+        {icon && (
+          <span className="ori-dropdown-menu__item-icon" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <span className="ori-dropdown-menu__item-label">{children}</span>
+        {shortcut && <span className="ori-dropdown-menu__item-shortcut">{shortcut}</span>}
+      </RadixDropdownMenu.Item>
+    );
+  },
+);
+
+export interface DropdownMenuLabelProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+export const DropdownMenuLabel = forwardRef<HTMLDivElement, DropdownMenuLabelProps>(
+  function DropdownMenuLabel({ className, children }, ref) {
+    return (
+      <RadixDropdownMenu.Label ref={ref} className={clsx('ori-dropdown-menu__label', className)}>
+        {children}
+      </RadixDropdownMenu.Label>
+    );
+  },
+);
+
+export const DropdownMenuSeparator = forwardRef<HTMLDivElement, { className?: string }>(
+  function DropdownMenuSeparator({ className }, ref) {
+    return (
+      <RadixDropdownMenu.Separator
+        ref={ref}
+        className={clsx('ori-dropdown-menu__separator', className)}
+      />
+    );
+  },
+);

--- a/packages/react/src/components/DropdownMenu/index.ts
+++ b/packages/react/src/components/DropdownMenu/index.ts
@@ -1,0 +1,16 @@
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from './DropdownMenu.js';
+export type {
+  DropdownMenuProps,
+  DropdownMenuContentProps,
+  DropdownMenuItemProps,
+  DropdownMenuLabelProps,
+  DropdownMenuSide,
+  DropdownMenuAlign,
+} from './DropdownMenu.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/Input/index.js';
 export * from './components/Card/index.js';
 export * from './components/Alert/index.js';
 export * from './components/Dialog/index.js';
+export * from './components/DropdownMenu/index.js';
 export * from './components/Checkbox/index.js';
 export * from './components/Radio/index.js';
 export * from './components/Switch/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -2149,6 +2149,113 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       borderTopColor: v('border-subtle'),
       backgroundColor: v('surface-muted'),
     },
+
+    // ─── DropdownMenu ────────────────────────────────────────────────────────
+    // Trigger projeté + content positionné sous le trigger. Côté React, Radix
+    // positionne via Portal + collision detection ; côté Angular, position
+    // absolute sous le wrap (in-place, cohérent avec décision B.1).
+    '.ori-dropdown-menu-wrap': {
+      position: 'relative',
+      display: 'inline-block',
+    },
+    '.ori-dropdown-menu-trigger-wrap': {
+      display: 'inline-block',
+    },
+    '.ori-dropdown-menu': {
+      position: 'absolute',
+      top: 'calc(100% + 4px)',
+      left: '0',
+      minWidth: '12rem',
+      maxWidth: '20rem',
+      paddingBlock: theme('spacing.1'),
+      backgroundColor: v('surface-base'),
+      border: `1px solid ${v('border-subtle')}`,
+      borderRadius: theme('borderRadius.md'),
+      boxShadow: theme('boxShadow.lg'),
+      zIndex: '60',
+      animation:
+        'ori-fade-in var(--ori-duration-fast, 150ms) var(--ori-easing-standard, cubic-bezier(0.4, 0, 0.2, 1))',
+      // Radix React rend dans un Portal (position fixe) : on neutralise alors
+      // le positionnement absolu de la version Angular.
+      '&[data-radix-menu-content]': {
+        position: 'static',
+      },
+    },
+    '.ori-dropdown-menu--align-center': {
+      left: '50%',
+      transform: 'translateX(-50%)',
+    },
+    '.ori-dropdown-menu--align-end': {
+      left: 'auto',
+      right: '0',
+    },
+    '.ori-dropdown-menu__label': {
+      paddingInline: theme('spacing.3'),
+      paddingBlock: theme('spacing.2'),
+      fontSize: theme('fontSize.xs'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: v('text-secondary'),
+      textTransform: 'uppercase',
+      letterSpacing: '0.04em',
+    },
+    '.ori-dropdown-menu__separator': {
+      height: '1px',
+      marginBlock: theme('spacing.1'),
+      backgroundColor: v('border-subtle'),
+    },
+    '.ori-dropdown-menu__item': {
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme('spacing.2'),
+      width: '100%',
+      paddingInline: theme('spacing.3'),
+      paddingBlock: theme('spacing.2'),
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+      fontSize: theme('fontSize.sm'),
+      color: v('text-primary'),
+      textAlign: 'left',
+      outline: 'none',
+      '&:hover:not([disabled]):not([data-disabled])': {
+        backgroundColor: v('surface-muted'),
+      },
+      '&:focus-visible, &[data-highlighted]': {
+        backgroundColor: v('surface-muted'),
+        outline: `2px solid ${v('border-focus')}`,
+        outlineOffset: '-2px',
+      },
+      '&[disabled], &[data-disabled]': {
+        opacity: '0.5',
+        cursor: 'not-allowed',
+      },
+    },
+    '.ori-dropdown-menu__item-icon': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      flexShrink: '0',
+      color: v('text-secondary'),
+    },
+    '.ori-dropdown-menu__item-label': {
+      flex: '1 1 auto',
+      minWidth: '0',
+    },
+    '.ori-dropdown-menu__item-shortcut': {
+      flexShrink: '0',
+      marginLeft: theme('spacing.4'),
+      fontSize: theme('fontSize.xs'),
+      color: v('text-muted'),
+      fontFamily: theme('fontFamily.mono'),
+    },
+    '.ori-dropdown-menu__item--destructive': {
+      color: v('feedback-danger'),
+      '& .ori-dropdown-menu__item-icon': {
+        color: v('feedback-danger'),
+      },
+      '&:hover:not([disabled]):not([data-disabled])': {
+        backgroundColor: v('feedback-danger-bg'),
+      },
+    },
   });
 
   // ─── Publishing : composants pour landing pages et documentation ──────────

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.4
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.4
+        version: 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2042,6 +2045,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@gar/promise-retry@1.0.3':
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2988,6 +3006,32 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -3019,8 +3063,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3063,6 +3129,32 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -3091,6 +3183,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3155,6 +3260,27 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -9736,7 +9862,7 @@ snapshots:
       tree-kill: 1.2.2
       tslib: 2.8.1
       typescript: 5.9.3
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.9)
       webpack-dev-middleware: 7.4.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.9))
       webpack-dev-server: 5.2.2(tslib@2.8.1)(webpack@5.105.0(esbuild@0.25.9))
       webpack-merge: 6.0.1
@@ -11464,6 +11590,23 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@gar/promise-retry@1.0.3': {}
 
   '@hapi/address@5.1.1':
@@ -12432,6 +12575,27 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -12466,6 +12630,12 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -12473,6 +12643,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -12503,6 +12688,50 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12526,6 +12755,23 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -12572,6 +12818,22 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -15938,7 +16200,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.9)
     optional: true
 
   html-webpack-plugin@5.6.7(webpack@5.106.2(@swc/core@1.15.32)(esbuild@0.25.12)):
@@ -19527,14 +19789,6 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
-  terser-webpack-plugin@5.5.0(webpack@5.105.0(esbuild@0.25.9)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.43.1
-      webpack: 5.105.0
-
   terser-webpack-plugin@5.5.0(webpack@5.106.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -20167,7 +20421,7 @@ snapshots:
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.7(webpack@5.105.0))(webpack@5.105.0(esbuild@0.25.9)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.105.0
+      webpack: 5.105.0(esbuild@0.25.9)
     optionalDependencies:
       html-webpack-plugin: 5.6.7(webpack@5.105.0)
 
@@ -20186,38 +20440,6 @@ snapshots:
       html-webpack-plugin: 5.6.7(webpack@5.106.2)
 
   webpack-virtual-modules@0.6.2: {}
-
-  webpack@5.105.0:
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.0
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.2
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(webpack@5.105.0(esbuild@0.25.9))
-      watchpack: 2.5.1
-      webpack-sources: 3.4.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
 
   webpack@5.105.0(@swc/core@1.15.32)(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Contexte

Première Primitive de la roadmap (cf. décision B.0). Menu déroulant accessible attendu par tous les DS de référence (Material, Radix, DSFR…). Débloque les Compositions à venir (DataTable actions de ligne, Header user menu).

## Choix techniques

- **React** : basé sur `@radix-ui/react-dropdown-menu` (cohérent avec Dialog React). Radix gère focus, type-ahead, auto-positioning, collision detection, ARIA.
- **Angular** : implémentation custom in-place, cohérente avec la décision B.1 sur Dialog (pas de portal). Navigation clavier custom (↑↓ avec wrap, Home, End, Esc, Tab).
- **Pas de submenu en v1** : à ouvrir comme primitive séparée si besoin avéré côté apps.

## API

### React (composée)
\`\`\`tsx
<DropdownMenu>
  <DropdownMenuTrigger asChild><Button>Actions ▾</Button></DropdownMenuTrigger>
  <DropdownMenuContent align=\"end\">
    <DropdownMenuItem icon={<Edit size={16} />}>Modifier</DropdownMenuItem>
    <DropdownMenuSeparator />
    <DropdownMenuItem destructive>Supprimer</DropdownMenuItem>
  </DropdownMenuContent>
</DropdownMenu>
\`\`\`

### Angular (data-driven)
\`\`\`html
<ori-dropdown-menu [items]=\"actions\" align=\"end\" (select)=\"handle($event)\">
  <button slot=\"trigger\" class=\"ori-btn\">Actions ▾</button>
</ori-dropdown-menu>
\`\`\`

## Variantes implémentées

- \`icon\` : icône lucide en début d'item
- \`shortcut\` : raccourci clavier affiché en fin (informatif)
- \`destructive\` : variante rouge pour les actions de suppression
- \`disabled\` : item visible mais non focusable / non cliquable
- \`label\` : section header (React)
- \`separator\` : ligne de séparation

## Tests

- 13 tests Vitest React : rendu, ARIA, sélection, navigation clavier (Esc, Enter), mode contrôlé
- Storybook React : 5 stories (Default, UserMenu, WithShortcuts, WithDisabledItem, ControlledOpen)
- Storybook Angular : 4 stories équivalentes

## Test plan

- [x] \`pnpm --filter @govpf/ori-react test\` : 84/84 verts
- [x] \`pnpm build\` : tokens + tailwind-preset + react + angular OK
- [ ] Vérifier visuellement les stories React et Angular dans Storybook
- [ ] Vérifier a11y axe-core sur les nouvelles stories (CI)

## Roadmap

Item passé à \"In progress\" sur le board #3 → passera à \"Done\" au merge.