### PR TITLE
feat(alert-dialog): primitive AlertDialog (React + Angular)

### DIFF
--- a/packages/angular/src/components/alert-dialog/alert-dialog.component.ts
+++ b/packages/angular/src/components/alert-dialog/alert-dialog.component.ts
@@ -1,0 +1,139 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Inject,
+  Input,
+  OnDestroy,
+  Output,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { A11yModule, ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
+
+let nextUid = 0;
+
+/**
+ * AlertDialog : variante du Dialog dédiée aux confirmations critiques.
+ *
+ * Distinct du Dialog par sa sémantique ARIA :
+ * - role="alertdialog" (au lieu de role="dialog") : annoncé spécifiquement
+ *   par les lecteurs d'écran comme une alerte interrompant le flux
+ * - aria-describedby explicite (description requise)
+ * - pas de bouton de fermeture (X) ; l'utilisateur doit cliquer Annuler ou
+ *   Action pour rendre l'intention explicite
+ * - le clic sur le backdrop ne ferme pas (idem)
+ *
+ * Comportement a11y aligné sur le Dialog :
+ * - Focus trap (`@angular/cdk/a11y`) avec focus initial sur le bouton Annuler
+ *   pour éviter qu'un Entrée accidentel ne déclenche l'action destructive
+ * - Restauration du focus à la fermeture
+ * - Scroll lock du body
+ * - ESC ferme et émet `(cancel)`
+ *
+ * In-place dans le DOM (pas de portal, cohérent avec décision B.1).
+ */
+@Component({
+  selector: 'ori-alert-dialog',
+  standalone: true,
+  imports: [A11yModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    @if (open) {
+      <div class="ori-dialog-overlay"></div>
+      <div
+        #dialogElement
+        class="ori-dialog ori-alert-dialog"
+        role="alertdialog"
+        [attr.aria-labelledby]="titleId"
+        [attr.aria-describedby]="descriptionId"
+      >
+        <div class="ori-dialog__header">
+          <h3 [id]="titleId" class="ori-dialog__title">{{ title }}</h3>
+        </div>
+        <div [id]="descriptionId" class="ori-dialog__body">
+          <ng-content></ng-content>
+        </div>
+        <div class="ori-dialog__footer">
+          <ng-content select="[slot=footer]"></ng-content>
+        </div>
+      </div>
+    }
+  `,
+})
+export class OriAlertDialogComponent implements OnDestroy {
+  @Input() set open(value: boolean) {
+    if (value === this._open) return;
+    this._open = value;
+    if (value) this.handleOpen();
+    else this.handleClose();
+  }
+  get open(): boolean {
+    return this._open;
+  }
+
+  @Input() title: string = '';
+
+  /** Émis quand l'utilisateur appuie sur ESC. Le composant ne ferme pas
+   *  automatiquement : le parent décide via `[open]`. */
+  @Output() cancel = new EventEmitter<void>();
+
+  @ViewChild('dialogElement') protected dialogRef?: ElementRef<HTMLElement>;
+
+  private readonly uid = ++nextUid;
+  readonly titleId = `pf-alert-dialog-title-${this.uid}`;
+  readonly descriptionId = `pf-alert-dialog-description-${this.uid}`;
+
+  private _open = false;
+  private focusTrap?: ConfigurableFocusTrap;
+  private previousFocus: HTMLElement | null = null;
+  private originalBodyOverflow = '';
+
+  constructor(
+    private readonly focusTrapFactory: ConfigurableFocusTrapFactory,
+    @Inject(DOCUMENT) private readonly document: Document,
+  ) {}
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this._open) this.cancel.emit();
+  }
+
+  ngOnDestroy(): void {
+    this.handleClose();
+  }
+
+  private handleOpen(): void {
+    const active = this.document.activeElement;
+    this.previousFocus = active instanceof HTMLElement ? active : null;
+
+    this.originalBodyOverflow = this.document.body.style.overflow;
+    this.document.body.style.overflow = 'hidden';
+
+    requestAnimationFrame(() => {
+      if (this.dialogRef) {
+        this.focusTrap = this.focusTrapFactory.create(this.dialogRef.nativeElement);
+        this.focusTrap.focusInitialElementWhenReady();
+      }
+    });
+  }
+
+  private handleClose(): void {
+    if (this.focusTrap) {
+      this.focusTrap.destroy();
+      this.focusTrap = undefined;
+    }
+
+    this.document.body.style.overflow = this.originalBodyOverflow;
+    this.originalBodyOverflow = '';
+
+    if (this.previousFocus && typeof this.previousFocus.focus === 'function') {
+      this.previousFocus.focus();
+    }
+    this.previousFocus = null;
+  }
+}

--- a/packages/angular/src/components/alert-dialog/alert-dialog.stories.ts
+++ b/packages/angular/src/components/alert-dialog/alert-dialog.stories.ts
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { OriAlertDialogComponent } from './alert-dialog.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriAlertDialogComponent> = {
+  title: 'Composants/Feedback/AlertDialog',
+  component: OriAlertDialogComponent,
+  tags: ['autodocs'],
+  decorators: [moduleMetadata({ imports: [OriAlertDialogComponent, OriButtonComponent] })],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Modale de confirmation critique. Sémantique role="alertdialog", focus initial sur Annuler, pas de bouton de fermeture (X) ni de fermeture au clic backdrop : la décision doit être explicite.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriAlertDialogComponent>;
+
+/**
+ * Cas standard : confirmation d'une suppression. Le focus initial est posé
+ * sur "Annuler" pour éviter qu'un Entrée accidentel ne déclenche l'action.
+ */
+export const Default: Story = {
+  render: () => ({
+    props: {
+      isOpen: false,
+      open() {
+        (this as any).isOpen = true;
+      },
+      close() {
+        (this as any).isOpen = false;
+      },
+    },
+    template: `
+      <ori-button variant="danger" (click)="open()">Supprimer le compte</ori-button>
+      <ori-alert-dialog
+        [open]="isOpen"
+        title="Supprimer le compte ?"
+        (cancel)="close()"
+      >
+        <p style="margin: 0">
+          Cette action est définitive. Toutes les données associées au compte
+          seront effacées et ne pourront pas être récupérées.
+        </p>
+        <ng-container slot="footer">
+          <ori-button variant="secondary" (click)="close()">Annuler</ori-button>
+          <ori-button variant="danger" (click)="close()">Supprimer définitivement</ori-button>
+        </ng-container>
+      </ori-alert-dialog>
+    `,
+  }),
+};
+
+/**
+ * Action non destructive : déconnexion. Même API, action principale en
+ * variant standard plutôt que danger.
+ */
+export const Logout: Story = {
+  render: () => ({
+    props: {
+      isOpen: false,
+      open() {
+        (this as any).isOpen = true;
+      },
+      close() {
+        (this as any).isOpen = false;
+      },
+    },
+    template: `
+      <ori-button variant="secondary" (click)="open()">Se déconnecter</ori-button>
+      <ori-alert-dialog
+        [open]="isOpen"
+        title="Se déconnecter ?"
+        (cancel)="close()"
+      >
+        <p style="margin: 0">
+          Vous devrez vous reconnecter pour accéder à nouveau à votre espace personnel.
+        </p>
+        <ng-container slot="footer">
+          <ori-button variant="secondary" (click)="close()">Rester connecté</ori-button>
+          <ori-button (click)="close()">Se déconnecter</ori-button>
+        </ng-container>
+      </ori-alert-dialog>
+    `,
+  }),
+};

--- a/packages/angular/src/components/alert-dialog/index.ts
+++ b/packages/angular/src/components/alert-dialog/index.ts
@@ -1,0 +1,1 @@
+export { OriAlertDialogComponent } from './alert-dialog.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -3,6 +3,7 @@ export * from './components/input';
 export * from './components/card';
 export * from './components/alert';
 export * from './components/dialog';
+export * from './components/alert-dialog';
 export * from './components/dropdown-menu';
 export * from './components/checkbox';
 export * from './components/radio';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,6 +33,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "clsx": "^2.1.1",

--- a/packages/react/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from './AlertDialog.js';
+import { Button } from '../Button/Button.js';
+
+// Pas d'autodocs : Radix Portal rend depuis document.body, le rendu auto-doc
+// en isolation casse. Mêmes contraintes que Dialog / DropdownMenu.
+const meta = {
+  title: 'Composants/Feedback/AlertDialog',
+  component: AlertDialog,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof AlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Cas standard : confirmation d'une suppression. Le focus initial est posé
+ * sur "Annuler" pour éviter qu'un Entrée accidentel ne déclenche l'action
+ * destructive.
+ */
+export const Default: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="danger">Supprimer le compte</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        title="Supprimer le compte ?"
+        description="Cette action est définitive. Toutes les données associées au compte seront effacées et ne pourront pas être récupérées."
+        footer={
+          <>
+            <AlertDialogCancel asChild>
+              <Button variant="secondary">Annuler</Button>
+            </AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button variant="danger">Supprimer définitivement</Button>
+            </AlertDialogAction>
+          </>
+        }
+      />
+    </AlertDialog>
+  ),
+};
+
+/**
+ * Action non destructive : déconnexion. Même API, mais l'action principale
+ * n'est pas en variant="danger".
+ */
+export const Logout: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="secondary">Se déconnecter</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        title="Se déconnecter ?"
+        description="Vous devrez vous reconnecter pour accéder à nouveau à votre espace personnel."
+        footer={
+          <>
+            <AlertDialogCancel asChild>
+              <Button variant="secondary">Rester connecté</Button>
+            </AlertDialogCancel>
+            <AlertDialogAction asChild>
+              <Button>Se déconnecter</Button>
+            </AlertDialogAction>
+          </>
+        }
+      />
+    </AlertDialog>
+  ),
+};

--- a/packages/react/src/components/AlertDialog/AlertDialog.test.tsx
+++ b/packages/react/src/components/AlertDialog/AlertDialog.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from './AlertDialog';
+
+function setup(extra: { onAction?: () => void; onCancel?: () => void } = {}) {
+  return render(
+    <AlertDialog>
+      <AlertDialogTrigger>Supprimer</AlertDialogTrigger>
+      <AlertDialogContent
+        title="Supprimer le compte ?"
+        description="Cette action est définitive."
+        footer={
+          <>
+            <AlertDialogCancel onClick={extra.onCancel}>Annuler</AlertDialogCancel>
+            <AlertDialogAction onClick={extra.onAction}>Supprimer</AlertDialogAction>
+          </>
+        }
+      />
+    </AlertDialog>,
+  );
+}
+
+describe('AlertDialog', () => {
+  describe('rendu', () => {
+    it('ne rend pas le contenu quand fermé', () => {
+      setup();
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+
+    it('ouvre le dialog avec role="alertdialog" au clic sur le trigger', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Supprimer' }));
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    });
+
+    it('lie le titre via aria-labelledby et la description via aria-describedby', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Supprimer' }));
+      const dialog = screen.getByRole('alertdialog');
+      const labelledById = dialog.getAttribute('aria-labelledby');
+      const describedById = dialog.getAttribute('aria-describedby');
+      expect(labelledById).toBeTruthy();
+      expect(describedById).toBeTruthy();
+      expect(document.getElementById(labelledById!)).toHaveTextContent('Supprimer le compte ?');
+      expect(document.getElementById(describedById!)).toHaveTextContent(
+        'Cette action est définitive.',
+      );
+    });
+  });
+
+  describe('actions', () => {
+    it('appelle onClick sur Annuler et ferme le dialog', async () => {
+      const user = userEvent.setup();
+      const onCancel = vi.fn();
+      setup({ onCancel });
+      await user.click(screen.getByRole('button', { name: 'Supprimer' }));
+      await user.click(screen.getByRole('button', { name: 'Annuler' }));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+
+    it('appelle onClick sur Action et ferme le dialog', async () => {
+      const user = userEvent.setup();
+      const onAction = vi.fn();
+      render(
+        <AlertDialog>
+          <AlertDialogTrigger>Ouvrir</AlertDialogTrigger>
+          <AlertDialogContent
+            title="Titre"
+            description="Description"
+            footer={
+              <>
+                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                <AlertDialogAction onClick={onAction}>Confirmer</AlertDialogAction>
+              </>
+            }
+          />
+        </AlertDialog>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Ouvrir' }));
+      await user.click(screen.getByRole('button', { name: 'Confirmer' }));
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+
+    it('ferme le dialog sur Escape', async () => {
+      const user = userEvent.setup();
+      setup();
+      await user.click(screen.getByRole('button', { name: 'Supprimer' }));
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+      await user.keyboard('{Escape}');
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('contrôlé', () => {
+    it('respecte la prop open', () => {
+      render(
+        <AlertDialog open={true}>
+          <AlertDialogTrigger>Trigger</AlertDialogTrigger>
+          <AlertDialogContent
+            title="Titre"
+            description="Description"
+            footer={
+              <>
+                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                <AlertDialogAction>OK</AlertDialogAction>
+              </>
+            }
+          />
+        </AlertDialog>,
+      );
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    });
+
+    it("appelle onOpenChange à l'ouverture", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(
+        <AlertDialog onOpenChange={onOpenChange}>
+          <AlertDialogTrigger>Trigger</AlertDialogTrigger>
+          <AlertDialogContent
+            title="Titre"
+            description="Description"
+            footer={
+              <>
+                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                <AlertDialogAction>OK</AlertDialogAction>
+              </>
+            }
+          />
+        </AlertDialog>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Trigger' }));
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/packages/react/src/components/AlertDialog/AlertDialog.tsx
+++ b/packages/react/src/components/AlertDialog/AlertDialog.tsx
@@ -1,0 +1,74 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import * as RadixAlertDialog from '@radix-ui/react-alert-dialog';
+import { clsx } from 'clsx';
+
+/**
+ * AlertDialog accessible, basé sur @radix-ui/react-alert-dialog.
+ *
+ * Distinct du Dialog : sémantique `role="alertdialog"` et focus initial sur
+ * le bouton de confirmation (cancel ou action). À utiliser pour interrompre
+ * un flux et exiger une décision binaire de l'utilisateur, typiquement une
+ * confirmation d'action destructive (suppression, déconnexion forcée).
+ *
+ * Différences clés vs Dialog :
+ * - role="alertdialog" (au lieu de role="dialog")
+ * - pas de bouton de fermeture (X) : l'utilisateur DOIT cliquer Cancel ou
+ *   Action, ce qui rend l'intention explicite
+ * - le clic sur le backdrop ne ferme pas (idem)
+ * - description requise (aria-describedby)
+ *
+ * Visuellement, la classe `.ori-alert-dialog` réutilise `.ori-dialog` avec
+ * une variante pour les actions destructives (bouton danger en avant).
+ */
+
+export interface AlertDialogProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+}
+
+export function AlertDialog({ open, defaultOpen, onOpenChange, children }: AlertDialogProps) {
+  return (
+    <RadixAlertDialog.Root open={open} defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
+      {children}
+    </RadixAlertDialog.Root>
+  );
+}
+
+export const AlertDialogTrigger = RadixAlertDialog.Trigger;
+export const AlertDialogCancel = RadixAlertDialog.Cancel;
+export const AlertDialogAction = RadixAlertDialog.Action;
+
+export interface AlertDialogContentProps {
+  /** Titre court (obligatoire pour aria-labelledby). */
+  title: ReactNode;
+  /** Description du choix à faire (obligatoire pour aria-describedby). */
+  description: ReactNode;
+  /** Boutons d'action (Cancel + Action via les sous-composants). */
+  footer: ReactNode;
+  className?: string;
+}
+
+export const AlertDialogContent = forwardRef<HTMLDivElement, AlertDialogContentProps>(
+  function AlertDialogContent({ title, description, footer, className }, ref) {
+    return (
+      <RadixAlertDialog.Portal>
+        <RadixAlertDialog.Overlay className="ori-dialog-overlay" />
+        <RadixAlertDialog.Content
+          ref={ref}
+          className={clsx('ori-dialog', 'ori-alert-dialog', className)}
+        >
+          <div className="ori-dialog__header">
+            <RadixAlertDialog.Title className="ori-dialog__title">{title}</RadixAlertDialog.Title>
+          </div>
+          <div className="ori-dialog__body">
+            <RadixAlertDialog.Description>{description}</RadixAlertDialog.Description>
+          </div>
+          <div className="ori-dialog__footer">{footer}</div>
+        </RadixAlertDialog.Content>
+      </RadixAlertDialog.Portal>
+    );
+  },
+);

--- a/packages/react/src/components/AlertDialog/index.ts
+++ b/packages/react/src/components/AlertDialog/index.ts
@@ -1,0 +1,8 @@
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from './AlertDialog.js';
+export type { AlertDialogProps, AlertDialogContentProps } from './AlertDialog.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/Input/index.js';
 export * from './components/Card/index.js';
 export * from './components/Alert/index.js';
 export * from './components/Dialog/index.js';
+export * from './components/AlertDialog/index.js';
 export * from './components/DropdownMenu/index.js';
 export * from './components/Checkbox/index.js';
 export * from './components/Radio/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.4
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog':
         specifier: ^1.1.4
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3005,6 +3008,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -12574,6 +12590,20 @@ snapshots:
     optional: true
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Contexte

Deuxième Primitive de la roadmap. Variante critique du Dialog dédiée aux confirmations d'actions destructives (suppression, déconnexion forcée). Distincte sémantiquement et comportementalement.

## Différences vs Dialog

| | Dialog | AlertDialog |
| - | - | - |
| Rôle ARIA | \`role=\"dialog\"\` | \`role=\"alertdialog\"\` |
| Bouton fermer (X) | Oui | Non |
| Fermeture clic backdrop | Oui | Non |
| Description | Optionnelle | Requise (\`aria-describedby\`) |
| Focus initial | Premier focusable | Bouton Annuler (sécurité) |

## Choix techniques

- **React** : wrapper de \`@radix-ui/react-alert-dialog\`. API composée \`AlertDialog\` + \`Trigger\` + \`Content\` + \`Cancel\` + \`Action\`.
- **Angular** : fork du Dialog existant avec \`role=\"alertdialog\"\` et focus-trap CDK. In-place dans le DOM (cohérent avec décision B.1).
- **CSS** : réutilise les classes \`.ori-dialog*\` existantes ; hook \`.ori-alert-dialog\` ajouté en cas de besoin de personnalisation future.

## Tests

- 8 tests Vitest React : rendu, ARIA labelling/description, sélection Cancel/Action, Escape, mode contrôlé
- 2 stories React et Angular : suppression destructive + déconnexion non-destructive
- \`pnpm --filter @govpf/ori-react test\` : 92/92 verts
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge.