### PR TITLE
feat(spinner): primitive Spinner inline (React + Angular)

### DIFF
--- a/packages/angular/src/components/spinner/index.ts
+++ b/packages/angular/src/components/spinner/index.ts
@@ -1,0 +1,1 @@
+export { OriSpinnerComponent, type OriSpinnerSize } from './spinner.component';

--- a/packages/angular/src/components/spinner/spinner.component.ts
+++ b/packages/angular/src/components/spinner/spinner.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+
+export type OriSpinnerSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Spinner inline accessible.
+ *
+ * Indicateur de chargement compact pour bouton, champ ou texte. Pour les
+ * chargements pleine page, utiliser un overlay applicatif dédié.
+ *
+ * a11y :
+ * - role="status" (annonce polite par défaut)
+ * - aria-label requis (par défaut "Chargement…")
+ * - SVG en aria-hidden pour ne pas dupliquer le label
+ *
+ * Couleur : héritée du parent via currentColor.
+ */
+@Component({
+  selector: 'ori-spinner',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <span role="status" [attr.aria-label]="label" [class]="'ori-spinner ori-spinner--' + size">
+      <svg
+        class="ori-spinner__svg"
+        viewBox="0 0 16 16"
+        [attr.width]="px"
+        [attr.height]="px"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle
+          cx="8"
+          cy="8"
+          r="6"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-dasharray="28 12"
+        />
+      </svg>
+    </span>
+  `,
+})
+export class OriSpinnerComponent {
+  /** Taille : sm = 12px, md = 16px (défaut), lg = 20px. */
+  @Input() size: OriSpinnerSize = 'md';
+  /** Label accessible annoncé par les lecteurs d'écran. */
+  @Input() label: string = 'Chargement…';
+
+  protected get px(): number {
+    return this.size === 'sm' ? 12 : this.size === 'lg' ? 20 : 16;
+  }
+}

--- a/packages/angular/src/components/spinner/spinner.stories.ts
+++ b/packages/angular/src/components/spinner/spinner.stories.ts
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { OriSpinnerComponent } from './spinner.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriSpinnerComponent> = {
+  title: 'Composants/Status/Spinner',
+  component: OriSpinnerComponent,
+  tags: ['autodocs'],
+  decorators: [moduleMetadata({ imports: [OriSpinnerComponent, OriButtonComponent] })],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Indicateur de chargement compact (role="status", aria-label requis). Hérite de currentColor pour s\'intégrer dans un bouton, un texte ou un champ.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriSpinnerComponent>;
+
+export const Default: Story = {
+  args: { size: 'md', label: 'Chargement…' },
+};
+
+export const Sizes: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; align-items: center; gap: 16px;">
+        <ori-spinner size="sm"></ori-spinner>
+        <ori-spinner size="md"></ori-spinner>
+        <ori-spinner size="lg"></ori-spinner>
+      </div>
+    `,
+  }),
+};
+
+export const InsideButton: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; gap: 12px;">
+        <ori-button [disabled]="true">
+          <ori-spinner size="sm" label="Envoi en cours…"></ori-spinner>
+          <span>Envoi…</span>
+        </ori-button>
+        <ori-button variant="secondary" [disabled]="true">
+          <ori-spinner size="sm"></ori-spinner>
+        </ori-button>
+      </div>
+    `,
+  }),
+};
+
+export const InlineInText: Story = {
+  render: () => ({
+    template: `
+      <p style="display: flex; align-items: center; gap: 8px; margin: 0;">
+        <ori-spinner size="sm" label="Vérification du numéro fiscal"></ori-spinner>
+        Vérification du numéro fiscal en cours…
+      </p>
+    `,
+  }),
+};
+
+export const CustomColor: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; align-items: center; gap: 16px; color: #dc2626;">
+        <ori-spinner size="lg"></ori-spinner>
+        <span>Hérite de currentColor</span>
+      </div>
+    `,
+  }),
+};

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -26,6 +26,7 @@ export * from './components/link';
 export * from './components/highlight';
 export * from './components/progress';
 export * from './components/skeleton';
+export * from './components/spinner';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/Spinner/Spinner.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Spinner } from './Spinner.js';
+import { Button } from '../Button/Button.js';
+
+const meta = {
+  title: 'Composants/Status/Spinner',
+  component: Spinner,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { size: 'md', label: 'Chargement…' },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+      <Spinner size="sm" />
+      <Spinner size="md" />
+      <Spinner size="lg" />
+    </div>
+  ),
+};
+
+/**
+ * Inline dans un bouton : le spinner remplace le texte ou l'accompagne
+ * pendant une action asynchrone (envoi de formulaire, validation).
+ */
+export const InsideButton: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 12 }}>
+      <Button disabled>
+        <Spinner size="sm" label="Envoi en cours…" /> <span>Envoi…</span>
+      </Button>
+      <Button variant="secondary" disabled>
+        <Spinner size="sm" />
+      </Button>
+    </div>
+  ),
+};
+
+/**
+ * Inline dans un texte : indique un chargement local sans bloquer l'écran.
+ */
+export const InlineInText: Story = {
+  render: () => (
+    <p style={{ display: 'flex', alignItems: 'center', gap: 8, margin: 0 }}>
+      <Spinner size="sm" label="Vérification du numéro fiscal" />
+      Vérification du numéro fiscal en cours…
+    </p>
+  ),
+};
+
+/**
+ * Couleur custom : le spinner hérite de la couleur du parent via
+ * `currentColor`. Ici, un parent en rouge.
+ */
+export const CustomColor: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, color: '#dc2626' }}>
+      <Spinner size="lg" />
+      <span>Hérite de currentColor</span>
+    </div>
+  ),
+};

--- a/packages/react/src/components/Spinner/Spinner.test.tsx
+++ b/packages/react/src/components/Spinner/Spinner.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Spinner } from './Spinner';
+
+describe('Spinner', () => {
+  it('rend un élément avec role="status"', () => {
+    render(<Spinner />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('utilise le label par défaut "Chargement…"', () => {
+    render(<Spinner />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Chargement…');
+  });
+
+  it('respecte le label personnalisé', () => {
+    render(<Spinner label="Vérification…" />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Vérification…');
+  });
+
+  it('applique la classe de taille sm', () => {
+    render(<Spinner size="sm" />);
+    expect(screen.getByRole('status')).toHaveClass('ori-spinner', 'ori-spinner--sm');
+  });
+
+  it('applique la classe de taille lg', () => {
+    render(<Spinner size="lg" />);
+    expect(screen.getByRole('status')).toHaveClass('ori-spinner--lg');
+  });
+
+  it('rend un SVG aria-hidden pour ne pas dupliquer le label', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    expect(svg).toHaveAttribute('focusable', 'false');
+  });
+
+  it('fusionne une className additionnelle', () => {
+    render(<Spinner className="ml-2" />);
+    expect(screen.getByRole('status')).toHaveClass('ori-spinner', 'ml-2');
+  });
+});

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,66 @@
+import { forwardRef } from 'react';
+import { clsx } from 'clsx';
+
+/**
+ * Spinner inline accessible.
+ *
+ * Indicateur de chargement compact, destiné à se glisser dans un bouton, un
+ * champ ou un texte sans imposer de taille fixe au parent. Pour les
+ * chargements pleine page, utiliser le Skeleton ou un overlay applicatif
+ * dédié plutôt qu'un Spinner.
+ *
+ * a11y :
+ * - `role="status"` (annonce polite par défaut)
+ * - `aria-label` requis (ex : "Chargement…", "Vérification…", "Envoi…")
+ * - `aria-hidden="true"` sur le SVG pour ne pas dupliquer le label
+ *
+ * Couleur : héritée du contexte via `currentColor` ; pour forcer une teinte,
+ * appliquer une classe Tailwind ou une CSS variable au parent.
+ */
+
+export type SpinnerSize = 'sm' | 'md' | 'lg';
+
+export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'aria-label'> {
+  /** Taille : sm = 12px, md = 16px (défaut), lg = 20px. */
+  size?: SpinnerSize;
+  /** Label accessible annoncé par les lecteurs d'écran. */
+  label?: string;
+}
+
+const sizeMap: Record<SpinnerSize, number> = { sm: 12, md: 16, lg: 20 };
+
+export const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(function Spinner(
+  { size = 'md', label = 'Chargement…', className, ...rest },
+  ref,
+) {
+  const px = sizeMap[size];
+  return (
+    <span
+      ref={ref}
+      role="status"
+      aria-label={label}
+      className={clsx('ori-spinner', `ori-spinner--${size}`, className)}
+      {...rest}
+    >
+      <svg
+        className="ori-spinner__svg"
+        viewBox="0 0 16 16"
+        width={px}
+        height={px}
+        aria-hidden="true"
+        focusable="false"
+      >
+        <circle
+          cx="8"
+          cy="8"
+          r="6"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeDasharray="28 12"
+        />
+      </svg>
+    </span>
+  );
+});

--- a/packages/react/src/components/Spinner/index.ts
+++ b/packages/react/src/components/Spinner/index.ts
@@ -1,0 +1,2 @@
+export { Spinner } from './Spinner.js';
+export type { SpinnerProps, SpinnerSize } from './Spinner.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export * from './components/Link/index.js';
 export * from './components/Highlight/index.js';
 export * from './components/Progress/index.js';
 export * from './components/Skeleton/index.js';
+export * from './components/Spinner/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1199,6 +1199,27 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       borderRadius: '9999px',
     },
 
+    // ─── Spinner inline ─────────────────────────────────────────────────────
+    // Indicateur de chargement compact, hérite de currentColor.
+    '.ori-spinner': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      lineHeight: '0',
+      verticalAlign: 'middle',
+      color: 'currentColor',
+    },
+    '.ori-spinner__svg': {
+      animation: 'ori-spinner-rotate 0.9s linear infinite',
+    },
+    // Réduction motion : on ralentit fortement plutôt que de figer (un
+    // chargement statique perd son sens).
+    '@media (prefers-reduced-motion: reduce)': {
+      '.ori-spinner__svg': {
+        animationDuration: '4s',
+      },
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',
@@ -2847,6 +2868,10 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
     '@keyframes ori-side-menu-in': {
       from: { transform: 'translateX(-100%)' },
       to: { transform: 'translateX(0)' },
+    },
+    '@keyframes ori-spinner-rotate': {
+      from: { transform: 'rotate(0deg)' },
+      to: { transform: 'rotate(360deg)' },
     },
   });
 }


### PR DESCRIPTION
## Contexte

Troisième Primitive de la roadmap. Indicateur de chargement compact, à glisser dans un bouton, un champ ou un texte. Débloque les états de chargement dans les Compositions à venir (DataTable, Wizard, Form layout).

## API

\`\`\`tsx
<Spinner /> // 16px, label "Chargement…"
<Spinner size=\"sm\" label=\"Vérification…\" />
\`\`\`

\`\`\`html
<ori-spinner size=\"sm\" label=\"Vérification…\"></ori-spinner>
\`\`\`

Tailles : \`sm\` (12px), \`md\` (16px, défaut), \`lg\` (20px). Hérite de \`currentColor\` pour s'adapter à la couleur du parent sans prop dédiée.

## a11y

- \`role=\"status\"\` + \`aria-label\` requis (annonce polite par défaut)
- SVG en \`aria-hidden\` pour ne pas dupliquer le label
- \`prefers-reduced-motion\` : animation ralentie à 4s plutôt que figée (un chargement statique perd son sens)

## Tests

- 7 tests Vitest (99/99 verts au total avec les autres composants)
- 5 stories par framework (Default, Sizes, InsideButton, InlineInText, CustomColor)
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge.