### PR TITLE
feat(empty-state): composition EmptyState inline (React + Angular)

### DIFF
--- a/packages/angular/src/components/empty-state/empty-state.component.ts
+++ b/packages/angular/src/components/empty-state/empty-state.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+
+export type OriEmptyStateSize = 'sm' | 'md' | 'lg';
+
+/**
+ * EmptyState inline.
+ *
+ * Bloc d'absence de données : zone vide d'une liste, recherche sans résultat,
+ * onboarding. Communique pourquoi c'est vide, ce que l'utilisateur peut
+ * faire et comment.
+ *
+ * Pas de role ARIA dédié : c'est du contenu textuel normal qui vit dans le
+ * flux. Pour une page entièrement vide (404), envisager `<ori-error-page>`
+ * qui pose la sémantique de niveau page.
+ *
+ * Slots : `slot="icon"` (rendu en aria-hidden), `slot="actions"` (boutons,
+ * 2 max recommandé).
+ */
+@Component({
+  selector: 'ori-empty-state',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [class]="'ori-empty-state ori-empty-state--' + size">
+      <span class="ori-empty-state__icon" aria-hidden="true">
+        <ng-content select="[slot=icon]"></ng-content>
+      </span>
+      <h3 class="ori-empty-state__title">{{ title }}</h3>
+      @if (description) {
+        <p class="ori-empty-state__description">{{ description }}</p>
+      }
+      <div class="ori-empty-state__actions">
+        <ng-content select="[slot=actions]"></ng-content>
+      </div>
+    </div>
+  `,
+})
+export class OriEmptyStateComponent {
+  @Input() title: string = '';
+  @Input() description: string = '';
+  @Input() size: OriEmptyStateSize = 'md';
+}

--- a/packages/angular/src/components/empty-state/empty-state.stories.ts
+++ b/packages/angular/src/components/empty-state/empty-state.stories.ts
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { LucideAngularModule, Inbox, Search, FilePlus, Users } from 'lucide-angular';
+import { OriEmptyStateComponent } from './empty-state.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriEmptyStateComponent> = {
+  title: 'Composants/Status/EmptyState',
+  component: OriEmptyStateComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [OriEmptyStateComponent, OriButtonComponent, LucideAngularModule],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "Bloc d'absence de données : zone vide, recherche sans résultat, onboarding. Trois tailles (sm, md, lg) selon l'emprise visuelle souhaitée.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriEmptyStateComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    props: { Inbox },
+    template: `
+      <ori-empty-state
+        title="Aucune demande en cours"
+        description="Les demandes que vous déposerez apparaîtront ici. Vous pouvez en créer une dès maintenant."
+      >
+        <lucide-icon slot="icon" [img]="Inbox" [size]="48"></lucide-icon>
+        <ori-button slot="actions">Nouvelle demande</ori-button>
+      </ori-empty-state>
+    `,
+  }),
+};
+
+export const SearchNoResults: Story = {
+  render: () => ({
+    props: { Search },
+    template: `
+      <ori-empty-state
+        size="sm"
+        title="Aucun résultat"
+        description="Aucun service administratif ne correspond à vos critères. Essayez d'élargir votre recherche."
+      >
+        <lucide-icon slot="icon" [img]="Search" [size]="32"></lucide-icon>
+        <ori-button slot="actions" variant="secondary">Réinitialiser les filtres</ori-button>
+      </ori-empty-state>
+    `,
+  }),
+};
+
+export const OnboardingLarge: Story = {
+  render: () => ({
+    props: { Users },
+    template: `
+      <ori-empty-state
+        size="lg"
+        title="Bienvenue dans votre espace"
+        description="Vous n'avez pas encore d'agents associés à votre service. Importez la liste depuis l'annuaire ou créez les comptes manuellement."
+      >
+        <lucide-icon slot="icon" [img]="Users" [size]="64"></lucide-icon>
+        <ng-container slot="actions">
+          <ori-button>Importer depuis l'annuaire</ori-button>
+          <ori-button variant="secondary">Créer un compte</ori-button>
+        </ng-container>
+      </ori-empty-state>
+    `,
+  }),
+};
+
+export const Minimal: Story = {
+  render: () => ({
+    props: { FilePlus },
+    template: `
+      <ori-empty-state title="Aucun document">
+        <lucide-icon slot="icon" [img]="FilePlus" [size]="48"></lucide-icon>
+        <ori-button slot="actions">Téléverser un document</ori-button>
+      </ori-empty-state>
+    `,
+  }),
+};
+
+export const TextOnly: Story = {
+  render: () => ({
+    template: `
+      <ori-empty-state
+        title="Aucune notification"
+        description="Vous serez prévenu ici de toute nouvelle activité concernant vos dossiers."
+      ></ori-empty-state>
+    `,
+  }),
+};

--- a/packages/angular/src/components/empty-state/index.ts
+++ b/packages/angular/src/components/empty-state/index.ts
@@ -1,0 +1,1 @@
+export { OriEmptyStateComponent, type OriEmptyStateSize } from './empty-state.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -29,6 +29,7 @@ export * from './components/highlight';
 export * from './components/progress';
 export * from './components/skeleton';
 export * from './components/spinner';
+export * from './components/empty-state';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { EmptyState } from './EmptyState.js';
+import { Button } from '../Button/Button.js';
+import { Inbox, Search, FilePlus, Users } from 'lucide-react';
+
+const meta = {
+  title: 'Composants/Status/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Cas standard : taille md, une action principale. */
+export const Default: Story = {
+  args: {
+    icon: <Inbox size={48} />,
+    title: 'Aucune demande en cours',
+    description:
+      'Les demandes que vous déposerez apparaîtront ici. Vous pouvez en créer une dès maintenant.',
+    actions: <Button>Nouvelle demande</Button>,
+  },
+};
+
+/** Filtre vide : taille sm, ton plus discret. */
+export const SearchNoResults: Story = {
+  args: {
+    icon: <Search size={32} />,
+    title: 'Aucun résultat',
+    description:
+      "Aucun service administratif ne correspond à vos critères. Essayez d'élargir votre recherche.",
+    actions: <Button variant="secondary">Réinitialiser les filtres</Button>,
+    size: 'sm',
+  },
+};
+
+/** Onboarding : taille lg pour une page entière, deux actions. */
+export const OnboardingLarge: Story = {
+  args: {
+    icon: <Users size={64} />,
+    title: 'Bienvenue dans votre espace',
+    description:
+      "Vous n'avez pas encore d'agents associés à votre service. Importez la liste depuis l'annuaire ou créez les comptes manuellement.",
+    actions: (
+      <>
+        <Button>Importer depuis l'annuaire</Button>
+        <Button variant="secondary">Créer un compte</Button>
+      </>
+    ),
+    size: 'lg',
+  },
+};
+
+/** Sans description : titre seul + action. */
+export const Minimal: Story = {
+  args: {
+    icon: <FilePlus size={48} />,
+    title: 'Aucun document',
+    actions: <Button>Téléverser un document</Button>,
+  },
+};
+
+/** Sans icône ni action : juste le texte d'absence. */
+export const TextOnly: Story = {
+  args: {
+    title: 'Aucune notification',
+    description: 'Vous serez prévenu ici de toute nouvelle activité concernant vos dossiers.',
+  },
+};

--- a/packages/react/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('rend un titre h3', () => {
+    render(<EmptyState title="Aucune donnée" />);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Aucune donnée');
+  });
+
+  it('rend la description quand fournie', () => {
+    render(<EmptyState title="Vide" description="Ajoutez du contenu pour commencer." />);
+    expect(screen.getByText(/ajoutez du contenu/i)).toBeInTheDocument();
+  });
+
+  it('ne rend pas de paragraphe sans description', () => {
+    const { container } = render(<EmptyState title="Vide" />);
+    expect(container.querySelector('.ori-empty-state__description')).toBeNull();
+  });
+
+  it("rend l'icône avec aria-hidden", () => {
+    const { container } = render(<EmptyState title="Vide" icon={<svg data-testid="icon" />} />);
+    const wrap = container.querySelector('.ori-empty-state__icon');
+    expect(wrap).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('rend les actions quand fournies', () => {
+    render(
+      <EmptyState
+        title="Vide"
+        actions={
+          <>
+            <button>Action A</button>
+            <button>Action B</button>
+          </>
+        }
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Action A' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Action B' })).toBeInTheDocument();
+  });
+
+  it('applique la classe de taille sm', () => {
+    const { container } = render(<EmptyState title="Vide" size="sm" />);
+    expect(container.firstChild).toHaveClass('ori-empty-state--sm');
+  });
+
+  it('applique la classe de taille lg', () => {
+    const { container } = render(<EmptyState title="Vide" size="lg" />);
+    expect(container.firstChild).toHaveClass('ori-empty-state--lg');
+  });
+
+  it('md est la taille par défaut', () => {
+    const { container } = render(<EmptyState title="Vide" />);
+    expect(container.firstChild).toHaveClass('ori-empty-state--md');
+  });
+});

--- a/packages/react/src/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,57 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+/**
+ * EmptyState inline.
+ *
+ * Bloc d'absence de données, à utiliser quand une zone (liste, table,
+ * recherche, page) ne contient rien à afficher. Communique trois choses :
+ * pourquoi c'est vide, ce que l'utilisateur peut faire, comment le faire.
+ *
+ * Pas de role ARIA dédié : l'EmptyState est un contenu textuel normal qui
+ * vit dans le flux du document. Si la page est entièrement composée d'un
+ * EmptyState (404 par exemple), envisager `<ErrorPage>` à la place qui pose
+ * la sémantique de niveau page.
+ *
+ * Tailles :
+ * - `sm` : pour les petites zones (filtre vide dans une table, dropdown
+ *   sans résultat) ; icône 32px, padding compact
+ * - `md` : taille par défaut, pour la majorité des cas (liste vide d'une
+ *   page applicative) ; icône 48px
+ * - `lg` : pour les écrans entièrement vides (premier login, onboarding) ;
+ *   icône 64px, padding aéré
+ */
+
+export type EmptyStateSize = 'sm' | 'md' | 'lg';
+
+export interface EmptyStateProps {
+  /** Icône décorative (rendue avec aria-hidden). */
+  icon?: ReactNode;
+  /** Titre court explicitant l'état vide. */
+  title: ReactNode;
+  /** Description optionnelle (1-2 phrases) sur le pourquoi et l'action. */
+  description?: ReactNode;
+  /** Boutons d'action ; 2 max (primaire + secondaire). */
+  actions?: ReactNode;
+  size?: EmptyStateSize;
+  className?: string;
+}
+
+export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(function EmptyState(
+  { icon, title, description, actions, size = 'md', className },
+  ref,
+) {
+  return (
+    <div ref={ref} className={clsx('ori-empty-state', `ori-empty-state--${size}`, className)}>
+      {icon && (
+        <span className="ori-empty-state__icon" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <h3 className="ori-empty-state__title">{title}</h3>
+      {description && <p className="ori-empty-state__description">{description}</p>}
+      {actions && <div className="ori-empty-state__actions">{actions}</div>}
+    </div>
+  );
+});

--- a/packages/react/src/components/EmptyState/index.ts
+++ b/packages/react/src/components/EmptyState/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState.js';
+export type { EmptyStateProps, EmptyStateSize } from './EmptyState.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -29,6 +29,7 @@ export * from './components/Highlight/index.js';
 export * from './components/Progress/index.js';
 export * from './components/Skeleton/index.js';
 export * from './components/Spinner/index.js';
+export * from './components/EmptyState/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1539,6 +1539,73 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       },
     },
 
+    // ─── EmptyState ─────────────────────────────────────────────────────────
+    // Bloc d'absence de données : icône, titre, description, actions empilés
+    // verticalement et centrés. Trois tailles (sm, md, lg) qui ajustent le
+    // padding et la taille de l'icône.
+    '.ori-empty-state': {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      textAlign: 'center',
+      gap: theme('spacing.3'),
+      color: v('text-secondary'),
+    },
+    '.ori-empty-state--sm': {
+      paddingBlock: theme('spacing.6'),
+      paddingInline: theme('spacing.4'),
+      gap: theme('spacing.2'),
+    },
+    '.ori-empty-state--md': {
+      paddingBlock: theme('spacing.10'),
+      paddingInline: theme('spacing.6'),
+    },
+    '.ori-empty-state--lg': {
+      paddingBlock: theme('spacing.16'),
+      paddingInline: theme('spacing.8'),
+      gap: theme('spacing.4'),
+    },
+    '.ori-empty-state__icon': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      color: v('text-muted'),
+      lineHeight: '0',
+    },
+    '.ori-empty-state__icon:empty': {
+      display: 'none',
+    },
+    '.ori-empty-state__title': {
+      margin: '0',
+      fontSize: theme('fontSize.lg'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: v('text-primary'),
+    },
+    '.ori-empty-state--sm .ori-empty-state__title': {
+      fontSize: theme('fontSize.base'),
+    },
+    '.ori-empty-state--lg .ori-empty-state__title': {
+      fontSize: theme('fontSize.xl'),
+    },
+    '.ori-empty-state__description': {
+      margin: '0',
+      maxWidth: '32rem',
+      fontSize: theme('fontSize.sm'),
+      lineHeight: theme('lineHeight.relaxed'),
+      color: v('text-secondary'),
+    },
+    '.ori-empty-state__actions': {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'center',
+      gap: theme('spacing.2'),
+      marginTop: theme('spacing.2'),
+    },
+    '.ori-empty-state__actions:empty': {
+      display: 'none',
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Première Composition de la roadmap. Bloc d'absence de données pour les listes vides, recherches sans résultat, onboarding. Communique pourquoi c'est vide, ce que l'utilisateur peut faire et comment.

## API

\`\`\`tsx
<EmptyState
  icon={<Inbox size={48} />}
  title=\"Aucune demande en cours\"
  description=\"Les demandes que vous déposerez apparaîtront ici.\"
  actions={<Button>Nouvelle demande</Button>}
/>
\`\`\`

\`\`\`html
<ori-empty-state title=\"Aucune demande en cours\" description=\"...\">
  <lucide-icon slot=\"icon\" [img]=\"Inbox\" [size]=\"48\"></lucide-icon>
  <ori-button slot=\"actions\">Nouvelle demande</ori-button>
</ori-empty-state>
\`\`\`

## Tailles

- **sm** : zones internes (filtre vide dans une table, dropdown sans résultat)
- **md** : valeur par défaut, listes vides de pages applicatives
- **lg** : écrans entiers, onboarding, premier login

## a11y

Pas de role ARIA dédié (\`region\`, \`status\`, etc.) : c'est du contenu textuel normal qui vit dans le flux du document. Pour une page entièrement vide (404, accès refusé), envisager \`<ErrorPage>\` qui pose la sémantique de niveau page.

L'icône est rendue \`aria-hidden\` (décorative). Le titre est en \`<h3>\` par défaut ; à adapter par l'app si la hiérarchie de la page le demande (limitation acceptée pour la v1, on pourra exposer un prop \`headingLevel\` plus tard).

## Tests

- 8 tests Vitest (rendu, présence conditionnelle, classes de taille) — 136/136 verts
- 5 stories par framework
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. Première Composition de 6.