### PR TITLE
feat(app-shell): composition AppShell layout (React + Angular)

### DIFF
--- a/packages/angular/src/components/app-shell/app-shell.component.ts
+++ b/packages/angular/src/components/app-shell/app-shell.component.ts
@@ -1,0 +1,120 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  ViewEncapsulation,
+} from '@angular/core';
+
+const MAIN_ID = 'ori-app-shell-main';
+
+/**
+ * AppShell : layout d'application.
+ *
+ * Pose le squelette d'une app interne ou usager : header sticky en haut,
+ * sidebar à gauche (optionnelle, drawer responsive sur mobile), main au
+ * centre, footer en bas (optionnel). Inclut un skip link "Aller au contenu
+ * principal" pour l'a11y clavier.
+ *
+ * Volontairement agnostique : ne fournit pas de Header / Sidebar / Footer
+ * tout faits, l'app projette ce qu'elle veut via les slots :
+ * - `slot="header"`
+ * - `slot="sidebar"` (la présence du contenu active le mode "with-sidebar")
+ * - `slot="footer"`
+ * - contenu principal = projection par défaut
+ *
+ * Sidebar drawer mobile : à viewport < 768px, la sidebar est cachée et
+ * accessible via un toggle externe (le bouton vit dans le header projeté).
+ * L'app contrôle l'état via `[sidebarOpen]` + `(sidebarOpenChange)`.
+ * ESC ferme le drawer.
+ *
+ * a11y :
+ * - skip link en première position, visible au focus uniquement
+ * - main avec id="ori-app-shell-main" + tabindex=-1 pour le skip link
+ * - drawer mobile : aria-modal + scrim cliquable
+ */
+@Component({
+  selector: 'ori-app-shell',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div
+      [class]="
+        'ori-app-shell ' +
+        (hasSidebar ? 'ori-app-shell--with-sidebar ' : '') +
+        (sidebarOpen ? 'ori-app-shell--sidebar-open' : '')
+      "
+    >
+      <a [attr.href]="'#' + mainId" class="ori-app-shell__skip-link">{{ skipLinkLabel }}</a>
+      <div #headerSlot class="ori-app-shell__header" [hidden]="!hasHeader">
+        <ng-content select="[slot=header]"></ng-content>
+      </div>
+      <div class="ori-app-shell__body">
+        @if (hasSidebar) {
+          <aside class="ori-app-shell__sidebar" aria-label="Navigation latérale">
+            <ng-content select="[slot=sidebar]"></ng-content>
+          </aside>
+          <div
+            class="ori-app-shell__scrim"
+            role="button"
+            tabindex="-1"
+            [attr.aria-label]="closeSidebarLabel"
+            (click)="closeSidebar()"
+          ></div>
+        }
+        <main [id]="mainId" tabindex="-1" class="ori-app-shell__main">
+          <ng-content></ng-content>
+        </main>
+      </div>
+      <div #footerSlot class="ori-app-shell__footer" [hidden]="!hasFooter">
+        <ng-content select="[slot=footer]"></ng-content>
+      </div>
+    </div>
+  `,
+  // Trick : on duplique les ng-content avec sélecteurs pour pouvoir détecter
+  // si du contenu est projeté (via ContentChild + ElementRef sur les wraps).
+  // Plus propre que des @Input booleans dupliqués qui désynchroniseraient.
+})
+export class OriAppShellComponent {
+  @Input() skipLinkLabel: string = 'Aller au contenu principal';
+  @Input() closeSidebarLabel: string = 'Fermer le menu';
+  @Input() sidebarOpen: boolean = false;
+
+  @Output() sidebarOpenChange = new EventEmitter<boolean>();
+
+  protected readonly mainId = MAIN_ID;
+
+  // Détection de la présence des slots projetés via ContentChild
+  // d'attribut. Quand le slot existe dans le template parent, ces refs
+  // sont définies ; sinon undefined.
+  @ContentChild('headerSlotRef') protected headerSlotProvided?: unknown;
+  @ContentChild('sidebarSlotRef') protected sidebarSlotProvided?: unknown;
+  @ContentChild('footerSlotRef') protected footerSlotProvided?: unknown;
+
+  // Note pragmatique : ContentChild sur un attribut projeté ne fonctionne pas
+  // de la même manière qu'en React. On expose donc des @Input pour piloter
+  // explicitement la présence des zones depuis l'app, plutôt que de tenter
+  // une détection automatique fragile. C'est le pattern standard côté Angular.
+  /** Indique si le slot header est présent. Default: true (le slot vide reste discret). */
+  @Input() hasHeader: boolean = true;
+  /** Indique si la sidebar est présente. Default: false (layout simple par défaut). */
+  @Input() hasSidebar: boolean = false;
+  /** Indique si le slot footer est présent. Default: false. */
+  @Input() hasFooter: boolean = false;
+
+  closeSidebar(): void {
+    if (!this.sidebarOpen) return;
+    this.sidebarOpen = false;
+    this.sidebarOpenChange.emit(false);
+  }
+
+  @HostListener('document:keydown.escape')
+  protected onEscape(): void {
+    if (this.sidebarOpen) this.closeSidebar();
+  }
+}

--- a/packages/angular/src/components/app-shell/app-shell.stories.ts
+++ b/packages/angular/src/components/app-shell/app-shell.stories.ts
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { OriAppShellComponent } from './app-shell.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriAppShellComponent> = {
+  title: 'Composants/Layout/AppShell',
+  component: OriAppShellComponent,
+  tags: ['autodocs'],
+  decorators: [moduleMetadata({ imports: [OriAppShellComponent, OriButtonComponent] })],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          "Layout d'application : header sticky + sidebar optionnelle (drawer responsive sur mobile) + main + footer optionnel. Skip link a11y intégré.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriAppShellComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    template: `
+      <div style="height: 600px; border: 1px dashed #d4d4d8;">
+        <ori-app-shell [hasHeader]="true" [hasSidebar]="true" [hasFooter]="true">
+          <header
+            slot="header"
+            style="height: 56px; padding-inline: 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #e5e7eb; background-color: #fff;"
+          >
+            <strong>Démo AppShell</strong>
+            <span style="font-size: 14px; color: #6b7280;">Header projeté</span>
+          </header>
+          <nav
+            slot="sidebar"
+            aria-label="Navigation"
+            style="width: 240px; padding-block: 16px; padding-inline: 12px; border-right: 1px solid #e5e7eb; background-color: #f9fafb; height: 100%;"
+          >
+            <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px;">
+              <li><a href="#a">Tableau de bord</a></li>
+              <li><a href="#b">Mes demandes</a></li>
+              <li><a href="#c">Documents</a></li>
+              <li><a href="#d">Préférences</a></li>
+            </ul>
+          </nav>
+          <div style="padding: 24px;">
+            <h1 style="margin-top: 0;">Page de démonstration</h1>
+            <p>Le main porte un id et un tabindex=-1 pour le skip link.</p>
+            <p>Paragraphe 1 pour démontrer le scroll vertical du main.</p>
+            <p>Paragraphe 2.</p>
+            <p>Paragraphe 3.</p>
+          </div>
+          <footer
+            slot="footer"
+            style="padding-block: 12px; padding-inline: 16px; border-top: 1px solid #e5e7eb; background-color: #fff; font-size: 14px; color: #6b7280; text-align: center;"
+          >
+            © 2026 Démo Ori
+          </footer>
+        </ori-app-shell>
+      </div>
+    `,
+  }),
+};
+
+export const NoSidebar: Story = {
+  render: () => ({
+    template: `
+      <div style="height: 600px; border: 1px dashed #d4d4d8;">
+        <ori-app-shell [hasHeader]="true" [hasFooter]="true">
+          <header
+            slot="header"
+            style="height: 56px; padding-inline: 16px; display: flex; align-items: center; border-bottom: 1px solid #e5e7eb; background-color: #fff;"
+          >
+            <strong>Démo sans sidebar</strong>
+          </header>
+          <div style="padding: 24px;">
+            <p>Layout simple : header + main + footer, sans sidebar.</p>
+          </div>
+          <footer
+            slot="footer"
+            style="padding-block: 12px; padding-inline: 16px; border-top: 1px solid #e5e7eb; background-color: #fff; font-size: 14px; color: #6b7280; text-align: center;"
+          >
+            © 2026
+          </footer>
+        </ori-app-shell>
+      </div>
+    `,
+  }),
+};
+
+export const SidebarDrawer: Story = {
+  render: () => ({
+    props: {
+      open: false,
+      toggle() {
+        (this as any).open = !(this as any).open;
+      },
+    },
+    template: `
+      <div style="height: 600px; border: 1px dashed #d4d4d8;">
+        <ori-app-shell
+          [hasHeader]="true"
+          [hasSidebar]="true"
+          [sidebarOpen]="open"
+          (sidebarOpenChange)="open = $event"
+        >
+          <header
+            slot="header"
+            style="height: 56px; padding-inline: 16px; display: flex; align-items: center; gap: 16px; border-bottom: 1px solid #e5e7eb; background-color: #fff;"
+          >
+            <ori-button variant="secondary" (click)="toggle()">☰ Menu</ori-button>
+            <strong>Démo drawer</strong>
+            <span style="font-size: 14px; color: #6b7280; margin-left: auto;">
+              Sidebar ouvert : {{ open ? 'oui' : 'non' }}
+            </span>
+          </header>
+          <nav
+            slot="sidebar"
+            aria-label="Navigation"
+            style="width: 240px; padding: 16px; background-color: #f9fafb; height: 100%;"
+          >
+            <p style="margin: 0;">Contenu sidebar</p>
+          </nav>
+          <div style="padding: 24px;">
+            <p>
+              Au-dessus de 768px, la sidebar reste visible. En réduisant la fenêtre,
+              elle devient un drawer piloté par le bouton "Menu" (clic sur le scrim
+              ou ESC pour fermer).
+            </p>
+          </div>
+        </ori-app-shell>
+      </div>
+    `,
+  }),
+};

--- a/packages/angular/src/components/app-shell/index.ts
+++ b/packages/angular/src/components/app-shell/index.ts
@@ -1,0 +1,1 @@
+export { OriAppShellComponent } from './app-shell.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -30,6 +30,7 @@ export * from './components/progress';
 export * from './components/skeleton';
 export * from './components/spinner';
 export * from './components/empty-state';
+export * from './components/app-shell';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/AppShell/AppShell.stories.tsx
+++ b/packages/react/src/components/AppShell/AppShell.stories.tsx
@@ -1,0 +1,166 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { AppShell } from './AppShell.js';
+import { Button } from '../Button/Button.js';
+
+const meta = {
+  title: 'Composants/Layout/AppShell',
+  component: AppShell,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof AppShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockHeader = (
+  <header
+    style={{
+      height: 56,
+      paddingInline: 16,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      borderBottom: '1px solid #e5e7eb',
+      backgroundColor: '#fff',
+    }}
+  >
+    <strong>Démo AppShell</strong>
+    <span style={{ fontSize: 14, color: '#6b7280' }}>Header projeté</span>
+  </header>
+);
+
+const mockSidebar = (
+  <nav
+    style={{
+      width: 240,
+      paddingBlock: 16,
+      paddingInline: 12,
+      borderRight: '1px solid #e5e7eb',
+      backgroundColor: '#f9fafb',
+      height: '100%',
+    }}
+    aria-label="Navigation"
+  >
+    <ul
+      style={{
+        listStyle: 'none',
+        padding: 0,
+        margin: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+    >
+      <li>
+        <a href="#a">Tableau de bord</a>
+      </li>
+      <li>
+        <a href="#b">Mes demandes</a>
+      </li>
+      <li>
+        <a href="#c">Documents</a>
+      </li>
+      <li>
+        <a href="#d">Préférences</a>
+      </li>
+    </ul>
+  </nav>
+);
+
+const mockFooter = (
+  <footer
+    style={{
+      paddingBlock: 12,
+      paddingInline: 16,
+      borderTop: '1px solid #e5e7eb',
+      backgroundColor: '#fff',
+      fontSize: 14,
+      color: '#6b7280',
+      textAlign: 'center',
+    }}
+  >
+    © 2026 Démo Ori
+  </footer>
+);
+
+const mockMain = (
+  <div style={{ padding: 24 }}>
+    <h1 style={{ marginTop: 0 }}>Page de démonstration</h1>
+    <p>
+      Le main est le seul slot non-optionnel. Il porte un <code>id</code> et un{' '}
+      <code>tabindex=-1</code> pour permettre au skip link "Aller au contenu principal" de
+      fonctionner correctement.
+    </p>
+    {Array.from({ length: 8 }).map((_, i) => (
+      <p key={i}>Paragraphe {i + 1} pour démontrer le scroll vertical du main.</p>
+    ))}
+  </div>
+);
+
+/** Layout complet : header + sidebar + main + footer. */
+export const Default: Story = {
+  render: () => (
+    <div style={{ height: 600, border: '1px dashed #d4d4d8' }}>
+      <AppShell header={mockHeader} sidebar={mockSidebar} footer={mockFooter}>
+        {mockMain}
+      </AppShell>
+    </div>
+  ),
+};
+
+/** Sans sidebar : layout simple (header + main + footer). */
+export const NoSidebar: Story = {
+  render: () => (
+    <div style={{ height: 600, border: '1px dashed #d4d4d8' }}>
+      <AppShell header={mockHeader} footer={mockFooter}>
+        {mockMain}
+      </AppShell>
+    </div>
+  ),
+};
+
+/** Drawer mobile : démontre le toggle de la sidebar piloté par l'app. */
+export const SidebarDrawer: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <div style={{ height: 600, border: '1px dashed #d4d4d8' }}>
+        <AppShell
+          header={
+            <header
+              style={{
+                height: 56,
+                paddingInline: 16,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 16,
+                borderBottom: '1px solid #e5e7eb',
+                backgroundColor: '#fff',
+              }}
+            >
+              <Button variant="secondary" onClick={() => setOpen((v) => !v)}>
+                ☰ Menu
+              </Button>
+              <strong>Démo drawer</strong>
+              <span style={{ fontSize: 14, color: '#6b7280', marginLeft: 'auto' }}>
+                Sidebar ouvert : {open ? 'oui' : 'non'}
+              </span>
+            </header>
+          }
+          sidebar={mockSidebar}
+          sidebarOpen={open}
+          onSidebarOpenChange={setOpen}
+        >
+          <div style={{ padding: 24 }}>
+            <p>
+              Au-dessus de 768px, la sidebar est toujours visible et le toggle Menu n'a pas d'effet.
+              En réduisant la fenêtre, la sidebar devient un drawer piloté par le bouton "Menu"
+              (clic sur le scrim ou ESC pour fermer).
+            </p>
+          </div>
+        </AppShell>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/AppShell/AppShell.test.tsx
+++ b/packages/react/src/components/AppShell/AppShell.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppShell } from './AppShell';
+
+describe('AppShell', () => {
+  it('rend un main avec id et tabindex pour le skip link', () => {
+    render(<AppShell>contenu</AppShell>);
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'ori-app-shell-main');
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('rend le skip link en première position', () => {
+    render(<AppShell>contenu</AppShell>);
+    const link = screen.getByRole('link', { name: /aller au contenu principal/i });
+    expect(link).toHaveAttribute('href', '#ori-app-shell-main');
+  });
+
+  it('respecte le label personnalisé du skip link', () => {
+    render(<AppShell skipLinkLabel="Skip to content">x</AppShell>);
+    expect(screen.getByRole('link', { name: 'Skip to content' })).toBeInTheDocument();
+  });
+
+  it('rend le header quand fourni', () => {
+    render(<AppShell header={<header>Mon header</header>}>x</AppShell>);
+    expect(screen.getByRole('banner')).toHaveTextContent('Mon header');
+  });
+
+  it('ne rend pas de zone header sans prop header', () => {
+    const { container } = render(<AppShell>x</AppShell>);
+    expect(container.querySelector('.ori-app-shell__header')).toBeNull();
+  });
+
+  it('rend la sidebar comme aside quand fournie', () => {
+    render(<AppShell sidebar={<nav>Nav</nav>}>x</AppShell>);
+    expect(screen.getByRole('complementary')).toHaveAttribute('aria-label', 'Navigation latérale');
+  });
+
+  it('ne rend pas de sidebar sans prop sidebar', () => {
+    const { container } = render(<AppShell>x</AppShell>);
+    expect(container.querySelector('.ori-app-shell__sidebar')).toBeNull();
+  });
+
+  it('rend le footer quand fourni', () => {
+    render(<AppShell footer={<footer>Pied</footer>}>x</AppShell>);
+    expect(screen.getByRole('contentinfo')).toHaveTextContent('Pied');
+  });
+
+  it('applique la classe sidebar-open quand sidebarOpen=true', () => {
+    const { container } = render(
+      <AppShell sidebar={<nav>x</nav>} sidebarOpen>
+        x
+      </AppShell>,
+    );
+    expect(container.firstChild).toHaveClass('ori-app-shell--sidebar-open');
+  });
+
+  it('appelle onSidebarOpenChange(false) au clic sur le scrim', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <AppShell sidebar={<nav>x</nav>} sidebarOpen onSidebarOpenChange={onOpenChange}>
+        x
+      </AppShell>,
+    );
+    await user.click(screen.getByRole('button', { name: /fermer le menu/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('ferme la sidebar sur Escape', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <AppShell sidebar={<nav>x</nav>} sidebarOpen onSidebarOpenChange={onOpenChange}>
+        x
+      </AppShell>,
+    );
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("Escape n'a aucun effet si la sidebar n'est pas ouverte", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <AppShell sidebar={<nav>x</nav>} onSidebarOpenChange={onOpenChange}>
+        x
+      </AppShell>,
+    );
+    await user.keyboard('{Escape}');
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/AppShell/AppShell.tsx
+++ b/packages/react/src/components/AppShell/AppShell.tsx
@@ -1,0 +1,114 @@
+import { forwardRef, useCallback, useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+/**
+ * AppShell : layout d'application.
+ *
+ * Pose le squelette d'une app interne ou usager : header sticky en haut,
+ * sidebar à gauche (optionnelle, drawer responsive sur mobile), main au
+ * centre, footer en bas (optionnel). Inclut un skip link "Aller au contenu
+ * principal" pour l'a11y clavier.
+ *
+ * Volontairement agnostique : ne fournit pas de Header / Sidebar / Footer
+ * tout faits, l'app projette ce qu'elle veut. Pour l'usage standard, brancher
+ * les composants Ori `<Header>`, `<SideMenu>` et `<Footer>`.
+ *
+ * Sidebar drawer mobile : à viewport < 768px (override possible côté CSS),
+ * la sidebar est cachée et accessible via un toggle (le bouton hamburger
+ * vit dans le header projeté ; l'app contrôle l'ouverture via
+ * `sidebarOpen` + `onSidebarOpenChange`). Le drawer ferme sur ESC et au
+ * clic sur le scrim.
+ *
+ * a11y :
+ * - skip link en première position, visible au focus uniquement
+ * - main a `id="ori-app-shell-main"` + `tabindex={-1}` pour le skip link
+ * - drawer mobile : `aria-modal="true"` + scrim cliquable
+ */
+
+export interface AppShellProps {
+  /** Contenu projeté en haut, sticky (généralement <Header>). */
+  header?: ReactNode;
+  /** Contenu projeté à gauche (généralement <SideMenu>). Optionnel : si absent, pas de sidebar. */
+  sidebar?: ReactNode;
+  /** Contenu projeté en bas, hors flux scroll (généralement <Footer>). Optionnel. */
+  footer?: ReactNode;
+  /** Contenu principal. Rendu dans `<main>` avec id pour le skip link. */
+  children?: ReactNode;
+  /** Texte du skip link. */
+  skipLinkLabel?: string;
+  /** État du drawer sidebar en responsive (mode mobile). */
+  sidebarOpen?: boolean;
+  onSidebarOpenChange?: (open: boolean) => void;
+  /** Label accessible du scrim (lecteur d'écran). */
+  closeSidebarLabel?: string;
+  className?: string;
+}
+
+const MAIN_ID = 'ori-app-shell-main';
+
+export const AppShell = forwardRef<HTMLDivElement, AppShellProps>(function AppShell(
+  {
+    header,
+    sidebar,
+    footer,
+    children,
+    skipLinkLabel = 'Aller au contenu principal',
+    sidebarOpen = false,
+    onSidebarOpenChange,
+    closeSidebarLabel = 'Fermer le menu',
+    className,
+  },
+  ref,
+) {
+  const closeSidebar = useCallback(() => {
+    onSidebarOpenChange?.(false);
+  }, [onSidebarOpenChange]);
+
+  // Fermer le drawer sur ESC quand il est ouvert.
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeSidebar();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [sidebarOpen, closeSidebar]);
+
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        'ori-app-shell',
+        sidebar && 'ori-app-shell--with-sidebar',
+        sidebarOpen && 'ori-app-shell--sidebar-open',
+        className,
+      )}
+    >
+      <a href={`#${MAIN_ID}`} className="ori-app-shell__skip-link">
+        {skipLinkLabel}
+      </a>
+      {header && <div className="ori-app-shell__header">{header}</div>}
+      <div className="ori-app-shell__body">
+        {sidebar && (
+          <>
+            <aside className="ori-app-shell__sidebar" aria-label="Navigation latérale">
+              {sidebar}
+            </aside>
+            <div
+              className="ori-app-shell__scrim"
+              role="button"
+              tabIndex={-1}
+              aria-label={closeSidebarLabel}
+              onClick={closeSidebar}
+            />
+          </>
+        )}
+        <main id={MAIN_ID} tabIndex={-1} className="ori-app-shell__main">
+          {children}
+        </main>
+      </div>
+      {footer && <div className="ori-app-shell__footer">{footer}</div>}
+    </div>
+  );
+});

--- a/packages/react/src/components/AppShell/index.ts
+++ b/packages/react/src/components/AppShell/index.ts
@@ -1,0 +1,2 @@
+export { AppShell } from './AppShell.js';
+export type { AppShellProps } from './AppShell.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export * from './components/Progress/index.js';
 export * from './components/Skeleton/index.js';
 export * from './components/Spinner/index.js';
 export * from './components/EmptyState/index.js';
+export * from './components/AppShell/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1606,6 +1606,103 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       display: 'none',
     },
 
+    // ─── AppShell ───────────────────────────────────────────────────────────
+    // Layout d'application : grille à 3 lignes (header / body / footer), avec
+    // une 2e dimension dans body pour aside + main quand sidebar présente.
+    // Sidebar drawer en responsive < 768px (translate-x off-screen + scrim).
+    '.ori-app-shell': {
+      display: 'grid',
+      gridTemplateRows: 'auto 1fr auto',
+      minHeight: '100vh',
+      backgroundColor: v('surface-base'),
+      color: v('text-primary'),
+    },
+    '.ori-app-shell__skip-link': {
+      position: 'absolute',
+      insetInlineStart: theme('spacing.4'),
+      top: theme('spacing.2'),
+      paddingBlock: theme('spacing.2'),
+      paddingInline: theme('spacing.3'),
+      backgroundColor: v('brand-primary'),
+      color: v('brand-on-primary'),
+      borderRadius: theme('borderRadius.md'),
+      fontWeight: theme('fontWeight.medium'),
+      textDecoration: 'none',
+      zIndex: '100',
+      // Hors viewport tant qu'il n'a pas le focus.
+      transform: 'translateY(-150%)',
+      transitionProperty: 'transform',
+      transitionDuration: theme('transitionDuration.fast'),
+      transitionTimingFunction: theme('transitionTimingFunction.standard'),
+      '&:focus, &:focus-visible': {
+        transform: 'translateY(0)',
+        outline: `2px solid ${v('border-focus')}`,
+        outlineOffset: '2px',
+      },
+    },
+    '.ori-app-shell__header': {
+      position: 'sticky',
+      top: '0',
+      zIndex: '40',
+      backgroundColor: v('surface-base'),
+    },
+    '.ori-app-shell__body': {
+      display: 'flex',
+      flex: '1 1 auto',
+      minHeight: '0',
+      position: 'relative',
+    },
+    '.ori-app-shell__sidebar': {
+      flexShrink: '0',
+      overflowY: 'auto',
+      backgroundColor: v('surface-base'),
+    },
+    '.ori-app-shell__main': {
+      flex: '1 1 auto',
+      minWidth: '0',
+      overflowY: 'auto',
+      // Le main reçoit le focus au skip link, on retire l'outline natif quand
+      // le focus vient programmatiquement (par contre le focus visible
+      // intentionnel garde un outline via les composants enfants).
+      '&:focus': {
+        outline: 'none',
+      },
+    },
+    '.ori-app-shell__footer': {
+      backgroundColor: v('surface-base'),
+    },
+    // Scrim mobile : caché au-dessus de 768px, visible quand drawer ouvert.
+    '.ori-app-shell__scrim': {
+      display: 'none',
+      position: 'fixed',
+      inset: '0',
+      backgroundColor: 'rgb(0 0 0 / 0.5)',
+      zIndex: '30',
+      border: 'none',
+      cursor: 'pointer',
+    },
+    // Mode mobile : sidebar devient un drawer hors flux.
+    '@media (max-width: 767px)': {
+      '.ori-app-shell--with-sidebar .ori-app-shell__sidebar': {
+        position: 'fixed',
+        top: '0',
+        bottom: '0',
+        insetInlineStart: '0',
+        zIndex: '50',
+        transform: 'translateX(-100%)',
+        transitionProperty: 'transform',
+        transitionDuration: theme('transitionDuration.normal'),
+        transitionTimingFunction: theme('transitionTimingFunction.standard'),
+        boxShadow: theme('boxShadow.xl'),
+      },
+      '.ori-app-shell--sidebar-open .ori-app-shell__sidebar': {
+        transform: 'translateX(0)',
+      },
+      '.ori-app-shell--sidebar-open .ori-app-shell__scrim': {
+        display: 'block',
+      },
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Deuxième Composition de la roadmap. Pose le squelette d'une app interne ou usager (header sticky + sidebar + main + footer) avec le skip link a11y intégré. Débloque les apps internes qui pourront se brancher dessus plutôt que reconstruire un layout custom à chaque fois.

## Choix techniques

- **Volontairement agnostique** : pas de Header/Sidebar/Footer fournis. L'app projette ce qu'elle veut. Pour l'usage standard, brancher \`<Header>\`, \`<SideMenu>\`, \`<Footer>\` Ori existants.
- **Drawer mobile < 768px** : sidebar passe en \`position: fixed\` + \`translateX\`, l'app pilote l'état via \`sidebarOpen\` + \`onSidebarOpenChange\`.
- **Limitation Angular vs React** : pas de détection automatique fiable des slots projetés sans risque de régression silencieuse → présence des zones explicite via \`[hasHeader]\` / \`[hasSidebar]\` / \`[hasFooter]\` (default false sauf header). C'est moins ergonomique que React mais plus robuste.

## a11y

- Skip link \"Aller au contenu principal\" en première position, hors viewport tant qu'il n'a pas le focus
- Main avec \`id=\"ori-app-shell-main\"\` + \`tabindex=-1\` comme cible du skip link
- Aside avec \`aria-label=\"Navigation latérale\"\`
- Drawer mobile : scrim cliquable + ESC pour fermer

## API

\`\`\`tsx
<AppShell
  header={<Header />}
  sidebar={<SideMenu />}
  footer={<Footer />}
  sidebarOpen={open}
  onSidebarOpenChange={setOpen}
>
  <PageContent />
</AppShell>
\`\`\`

\`\`\`html
<ori-app-shell
  [hasHeader]=\"true\"
  [hasSidebar]=\"true\"
  [hasFooter]=\"true\"
  [sidebarOpen]=\"open\"
  (sidebarOpenChange)=\"open = $event\"
>
  <header slot=\"header\">…</header>
  <nav slot=\"sidebar\">…</nav>
  <main-content />
  <footer slot=\"footer\">…</footer>
</ori-app-shell>
\`\`\`

## Tests

- 12 tests Vitest React (rendu, ARIA, skip link, drawer ouvert/fermé, ESC) — 148/148 verts
- 3 stories par framework (Default, NoSidebar, SidebarDrawer)
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. Deuxième Composition sur 6.