### PR TITLE
feat(form): composition Form layout standardisé (React + Angular)

### DIFF
--- a/packages/angular/src/components/form/form.component.ts
+++ b/packages/angular/src/components/form/form.component.ts
@@ -1,0 +1,161 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewEncapsulation,
+} from '@angular/core';
+
+let nextUid = 0;
+
+/**
+ * Form layout standardisé.
+ *
+ * Pose la structure standard d'un formulaire administratif. Le DS ne fournit
+ * ni validation ni gestion d'erreurs (chaque app a déjà ses propres tools :
+ * Reactive Forms, signals…). Seule la structure visuelle et l'a11y sont
+ * standardisées.
+ *
+ * Pattern composé : <ori-form> + <ori-form-section> + <ori-form-field> +
+ * <ori-form-actions>.
+ *
+ * Différences vs React (où FormField utilise une render-prop pour passer
+ * id / aria-describedby / required au control) : côté Angular, l'utilisateur
+ * récupère les ids via les variables locales `#field` ou `#errorTpl` et les
+ * applique manuellement sur l'<input>. Pattern idiomatique Angular.
+ */
+@Component({
+  selector: 'ori-form',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <form class="ori-form" novalidate (submit)="onSubmit($event)">
+      <ng-content></ng-content>
+    </form>
+  `,
+})
+export class OriFormComponent {
+  @Output() formSubmit = new EventEmitter<Event>();
+
+  protected onSubmit(event: Event): void {
+    event.preventDefault();
+    this.formSubmit.emit(event);
+  }
+}
+
+/**
+ * Section d'un formulaire : titre + description + groupe de champs.
+ */
+@Component({
+  selector: 'ori-form-section',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <section [attr.aria-labelledby]="title ? titleId : null" class="ori-form-section">
+      @if (title || description) {
+        <header class="ori-form-section__header">
+          @if (title) {
+            <h3 [id]="titleId" class="ori-form-section__title">{{ title }}</h3>
+          }
+          @if (description) {
+            <p class="ori-form-section__description">{{ description }}</p>
+          }
+        </header>
+      }
+      <div class="ori-form-section__fields">
+        <ng-content></ng-content>
+      </div>
+    </section>
+  `,
+})
+export class OriFormSectionComponent {
+  @Input() title: string = '';
+  @Input() description: string = '';
+  protected readonly titleId = `pf-form-section-${++nextUid}`;
+}
+
+/**
+ * Champ de formulaire : label + slot input + hint + erreur, avec ARIA câblé.
+ *
+ * L'utilisateur projette son input via le slot par défaut. Pour brancher
+ * `aria-describedby` et l'`id` du label, lire les propriétés exposées via
+ * la variable de template :
+ *
+ * ```html
+ * <ori-form-field #field label="Nom" required hint="Indication">
+ *   <ori-input [id]="field.controlId" [attr.aria-describedby]="field.describedById"></ori-input>
+ * </ori-form-field>
+ * ```
+ *
+ * Pour des cas simples, l'utilisateur peut aussi se contenter d'imbriquer
+ * un `<input>` natif sans wiring (le label restera lié visuellement mais
+ * pas via htmlFor).
+ */
+@Component({
+  selector: 'ori-form-field',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [class]="'ori-form-field ' + (error ? 'ori-form-field--invalid' : '')">
+      <label [attr.for]="controlId" class="ori-form-field__label">
+        {{ label }}
+        @if (required) {
+          <span class="ori-form-field__required" aria-hidden="true"> *</span>
+        }
+      </label>
+      <ng-content></ng-content>
+      @if (hint) {
+        <p [id]="hintId" class="ori-form-field__hint">{{ hint }}</p>
+      }
+      @if (error) {
+        <p [id]="errorId" class="ori-form-field__error" role="alert">{{ error }}</p>
+      }
+    </div>
+  `,
+})
+export class OriFormFieldComponent {
+  @Input() label: string = '';
+  @Input() hint: string = '';
+  @Input() error: string = '';
+  @Input() required: boolean = false;
+
+  private readonly uid = ++nextUid;
+  /** ID exposé pour brancher l'input projeté via [id] et [for] du label. */
+  readonly controlId = `pf-form-field-${this.uid}`;
+
+  get hintId(): string | null {
+    return this.hint ? `${this.controlId}-hint` : null;
+  }
+
+  get errorId(): string | null {
+    return this.error ? `${this.controlId}-error` : null;
+  }
+
+  /** À brancher sur l'input via [attr.aria-describedby]. */
+  get describedById(): string | null {
+    const parts = [this.hintId, this.errorId].filter(Boolean);
+    return parts.length ? parts.join(' ') : null;
+  }
+}
+
+/**
+ * Pied du formulaire : zone d'actions (boutons).
+ */
+@Component({
+  selector: 'ori-form-actions',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [class]="'ori-form-actions ori-form-actions--' + align">
+      <ng-content></ng-content>
+    </div>
+  `,
+})
+export class OriFormActionsComponent {
+  @Input() align: 'start' | 'center' | 'end' = 'end';
+}

--- a/packages/angular/src/components/form/form.stories.ts
+++ b/packages/angular/src/components/form/form.stories.ts
@@ -1,0 +1,163 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import {
+  OriFormComponent,
+  OriFormSectionComponent,
+  OriFormFieldComponent,
+  OriFormActionsComponent,
+} from './form.component';
+import { OriInputComponent } from '../input/input.component';
+import { OriTextareaComponent } from '../textarea/textarea.component';
+import { OriButtonComponent } from '../button/button.component';
+
+const meta: Meta<OriFormComponent> = {
+  title: 'Composants/Layout/Form',
+  component: OriFormComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [
+        OriFormComponent,
+        OriFormSectionComponent,
+        OriFormFieldComponent,
+        OriFormActionsComponent,
+        OriInputComponent,
+        OriTextareaComponent,
+        OriButtonComponent,
+      ],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "Formulaire standardisé : structure visuelle et a11y, sans validation ni gestion d'état (chaque app branche ses propres tools : Reactive Forms, signals, react-hook-form…).",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriFormComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    template: `
+      <ori-form style="max-width: 480px;">
+        <ori-form-section title="Identité" description="Renseignez votre identité administrative.">
+          <ori-form-field #nomField label="Nom" [required]="true">
+            <ori-input
+              [id]="nomField.controlId"
+              [attr.aria-describedby]="nomField.describedById"
+              placeholder="TAVAE"
+            ></ori-input>
+          </ori-form-field>
+          <ori-form-field #prenomField label="Prénom" [required]="true">
+            <ori-input
+              [id]="prenomField.controlId"
+              [attr.aria-describedby]="prenomField.describedById"
+              placeholder="Léonard"
+            ></ori-input>
+          </ori-form-field>
+        </ori-form-section>
+        <ori-form-actions>
+          <ori-button variant="secondary" type="button">Annuler</ori-button>
+          <ori-button type="submit">Enregistrer</ori-button>
+        </ori-form-actions>
+      </ori-form>
+    `,
+  }),
+};
+
+export const MultipleSections: Story = {
+  render: () => ({
+    template: `
+      <ori-form style="max-width: 560px;">
+        <ori-form-section title="Identité" description="Informations administratives.">
+          <ori-form-field #nom label="Nom de famille" [required]="true">
+            <ori-input [id]="nom.controlId" [attr.aria-describedby]="nom.describedById"></ori-input>
+          </ori-form-field>
+          <ori-form-field #prenom label="Prénom usuel" [required]="true">
+            <ori-input [id]="prenom.controlId" [attr.aria-describedby]="prenom.describedById"></ori-input>
+          </ori-form-field>
+        </ori-form-section>
+        <ori-form-section title="Coordonnées">
+          <ori-form-field
+            #email
+            label="Adresse électronique"
+            [required]="true"
+            hint="Utilisée pour les notifications administratives uniquement."
+          >
+            <ori-input
+              [id]="email.controlId"
+              [attr.aria-describedby]="email.describedById"
+              type="email"
+              placeholder="exemple@administration.gov.pf"
+            ></ori-input>
+          </ori-form-field>
+          <ori-form-field #tel label="Téléphone">
+            <ori-input
+              [id]="tel.controlId"
+              [attr.aria-describedby]="tel.describedById"
+              type="tel"
+              placeholder="+689 40 00 00 00"
+            ></ori-input>
+          </ori-form-field>
+        </ori-form-section>
+        <ori-form-section title="Demande" description="Décrivez votre demande de manière concise.">
+          <ori-form-field #objet label="Objet" [required]="true">
+            <ori-input [id]="objet.controlId" [attr.aria-describedby]="objet.describedById"></ori-input>
+          </ori-form-field>
+          <ori-form-field #details label="Détails" hint="500 caractères maximum.">
+            <ori-textarea
+              [id]="details.controlId"
+              [attr.aria-describedby]="details.describedById"
+              [rows]="4"
+            ></ori-textarea>
+          </ori-form-field>
+        </ori-form-section>
+        <ori-form-actions>
+          <ori-button variant="secondary" type="button">Enregistrer comme brouillon</ori-button>
+          <ori-button type="submit">Envoyer la demande</ori-button>
+        </ori-form-actions>
+      </ori-form>
+    `,
+  }),
+};
+
+export const WithErrors: Story = {
+  render: () => ({
+    template: `
+      <ori-form style="max-width: 480px;">
+        <ori-form-section title="Identité">
+          <ori-form-field #nom label="Nom" [required]="true" error="Le nom est obligatoire.">
+            <ori-input
+              [id]="nom.controlId"
+              [attr.aria-describedby]="nom.describedById"
+              [attr.aria-invalid]="true"
+            ></ori-input>
+          </ori-form-field>
+          <ori-form-field
+            #email
+            label="Adresse électronique"
+            [required]="true"
+            error="Le format de l'adresse n'est pas valide."
+            hint="Exemple : prenom.nom@administration.gov.pf"
+          >
+            <ori-input
+              [id]="email.controlId"
+              [attr.aria-describedby]="email.describedById"
+              [attr.aria-invalid]="true"
+              type="email"
+              value="pas-une-adresse"
+            ></ori-input>
+          </ori-form-field>
+        </ori-form-section>
+        <ori-form-actions>
+          <ori-button type="submit">Soumettre</ori-button>
+        </ori-form-actions>
+      </ori-form>
+    `,
+  }),
+};

--- a/packages/angular/src/components/form/index.ts
+++ b/packages/angular/src/components/form/index.ts
@@ -1,0 +1,6 @@
+export {
+  OriFormComponent,
+  OriFormSectionComponent,
+  OriFormFieldComponent,
+  OriFormActionsComponent,
+} from './form.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -31,6 +31,7 @@ export * from './components/skeleton';
 export * from './components/spinner';
 export * from './components/empty-state';
 export * from './components/app-shell';
+export * from './components/form';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/Form/Form.stories.tsx
+++ b/packages/react/src/components/Form/Form.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Form, FormSection, FormField, FormActions } from './Form.js';
+import { Input } from '../Input/Input.js';
+import { Textarea } from '../Textarea/Textarea.js';
+import { Button } from '../Button/Button.js';
+
+const meta = {
+  title: 'Composants/Layout/Form',
+  component: Form,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Form>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Formulaire simple : une section, deux champs, deux actions. */
+export const Default: Story = {
+  render: () => (
+    <Form
+      onSubmit={(e) => {
+        e.preventDefault();
+        alert('Soumis');
+      }}
+      style={{ maxWidth: 480 }}
+    >
+      <FormSection title="Identité" description="Renseignez votre identité administrative.">
+        <FormField label="Nom" required>
+          {(p) => <Input {...p} placeholder="TAVAE" />}
+        </FormField>
+        <FormField label="Prénom" required>
+          {(p) => <Input {...p} placeholder="Léonard" />}
+        </FormField>
+      </FormSection>
+      <FormActions>
+        <Button variant="secondary" type="button">
+          Annuler
+        </Button>
+        <Button type="submit">Enregistrer</Button>
+      </FormActions>
+    </Form>
+  ),
+};
+
+/** Plusieurs sections : démontre la séparation visuelle entre groupes de champs. */
+export const MultipleSections: Story = {
+  render: () => (
+    <Form style={{ maxWidth: 560 }}>
+      <FormSection title="Identité" description="Informations administratives.">
+        <FormField label="Nom de famille" required>
+          {(p) => <Input {...p} />}
+        </FormField>
+        <FormField label="Prénom usuel" required>
+          {(p) => <Input {...p} />}
+        </FormField>
+      </FormSection>
+      <FormSection title="Coordonnées">
+        <FormField
+          label="Adresse électronique"
+          required
+          hint="Utilisée pour les notifications administratives uniquement."
+        >
+          {(p) => <Input {...p} type="email" placeholder="exemple@administration.gov.pf" />}
+        </FormField>
+        <FormField label="Téléphone">
+          {(p) => <Input {...p} type="tel" placeholder="+689 40 00 00 00" />}
+        </FormField>
+      </FormSection>
+      <FormSection title="Demande" description="Décrivez votre demande de manière concise.">
+        <FormField label="Objet" required>
+          {(p) => <Input {...p} />}
+        </FormField>
+        <FormField label="Détails" hint="500 caractères maximum.">
+          {(p) => <Textarea {...p} rows={4} />}
+        </FormField>
+      </FormSection>
+      <FormActions>
+        <Button variant="secondary" type="button">
+          Enregistrer comme brouillon
+        </Button>
+        <Button type="submit">Envoyer la demande</Button>
+      </FormActions>
+    </Form>
+  ),
+};
+
+/** Validation : démontre l'affichage d'erreur en rouge sous le champ. */
+export const WithErrors: Story = {
+  render: () => {
+    const [submitted, setSubmitted] = useState(false);
+    return (
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSubmitted(true);
+        }}
+        style={{ maxWidth: 480 }}
+      >
+        <FormSection title="Identité">
+          <FormField label="Nom" required error={submitted ? 'Le nom est obligatoire.' : undefined}>
+            {(p) => <Input {...p} />}
+          </FormField>
+          <FormField
+            label="Adresse électronique"
+            required
+            error={submitted ? "Le format de l'adresse n'est pas valide." : undefined}
+            hint="Exemple : prenom.nom@administration.gov.pf"
+          >
+            {(p) => <Input {...p} type="email" defaultValue="pas-une-adresse" />}
+          </FormField>
+        </FormSection>
+        <FormActions>
+          <Button type="submit">Soumettre pour voir les erreurs</Button>
+        </FormActions>
+      </Form>
+    );
+  },
+};
+
+/** Aligned start : actions à gauche au lieu de droite. */
+export const ActionsAlignedStart: Story = {
+  render: () => (
+    <Form style={{ maxWidth: 480 }}>
+      <FormSection>
+        <FormField label="Recherche">{(p) => <Input {...p} placeholder="Mot-clé" />}</FormField>
+      </FormSection>
+      <FormActions align="start">
+        <Button type="submit">Rechercher</Button>
+      </FormActions>
+    </Form>
+  ),
+};

--- a/packages/react/src/components/Form/Form.test.tsx
+++ b/packages/react/src/components/Form/Form.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form, FormSection, FormField, FormActions } from './Form';
+
+describe('Form', () => {
+  it('rend un <form> avec noValidate', () => {
+    const { container } = render(<Form>x</Form>);
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    expect(form).toHaveAttribute('novalidate');
+  });
+
+  it('appelle onSubmit au submit', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn((e) => e.preventDefault());
+    render(
+      <Form onSubmit={onSubmit}>
+        <button type="submit">OK</button>
+      </Form>,
+    );
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});
+
+describe('FormSection', () => {
+  it('rend un <section> avec un titre h3 lié via aria-labelledby', () => {
+    render(
+      <FormSection title="Mon titre">
+        <span>contenu</span>
+      </FormSection>,
+    );
+    const section = screen.getByRole('region', { name: 'Mon titre' });
+    expect(section).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Mon titre');
+  });
+
+  it('rend la description sous le titre', () => {
+    render(<FormSection title="T" description="Une description courte." />);
+    expect(screen.getByText('Une description courte.')).toBeInTheDocument();
+  });
+
+  it('ne rend pas de header sans titre ni description', () => {
+    const { container } = render(<FormSection>x</FormSection>);
+    expect(container.querySelector('.ori-form-section__header')).toBeNull();
+  });
+});
+
+describe('FormField', () => {
+  it('lie le label au control via htmlFor / id', () => {
+    render(<FormField label="Nom">{(p) => <input {...p} />}</FormField>);
+    const input = screen.getByLabelText('Nom');
+    expect(input).toBeInTheDocument();
+    expect(input.id).toMatch(/^pf-form-field-/);
+  });
+
+  it('affiche le marker required (visuel + aria-required sur le control)', () => {
+    render(
+      <FormField label="Nom" required>
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    expect(screen.getByLabelText(/nom/i)).toBeRequired();
+    // Le marker visuel * est en aria-hidden ; on vérifie sa présence dans le DOM
+    const { container } = render(
+      <FormField label="X" required>
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    expect(container.querySelector('.ori-form-field__required')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+
+  it('expose le hint via aria-describedby', () => {
+    render(
+      <FormField label="Nom" hint="Indication">
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText('Nom');
+    const describedById = input.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+    expect(document.getElementById(describedById!)).toHaveTextContent('Indication');
+  });
+
+  it("expose l'erreur via aria-describedby + aria-invalid", () => {
+    render(
+      <FormField label="Nom" error="Erreur de saisie">
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText('Nom');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    const describedById = input.getAttribute('aria-describedby');
+    expect(document.getElementById(describedById!)).toHaveTextContent('Erreur de saisie');
+  });
+
+  it("rend l'erreur en role=alert (annoncée par les lecteurs d'écran)", () => {
+    render(
+      <FormField label="Nom" error="Boom">
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Boom');
+  });
+
+  it('hint et erreur cohabitent (les deux liés via aria-describedby)', () => {
+    render(
+      <FormField label="Nom" hint="Astuce" error="Erreur">
+        {(p) => <input {...p} />}
+      </FormField>,
+    );
+    const input = screen.getByLabelText('Nom');
+    const describedBy = input.getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(' ')).toHaveLength(2);
+  });
+});
+
+describe('FormActions', () => {
+  it("applique la classe d'alignement (default end)", () => {
+    const { container } = render(<FormActions>x</FormActions>);
+    expect(container.firstChild).toHaveClass('ori-form-actions--end');
+  });
+
+  it('respecte align=start', () => {
+    const { container } = render(<FormActions align="start">x</FormActions>);
+    expect(container.firstChild).toHaveClass('ori-form-actions--start');
+  });
+
+  it('respecte align=center', () => {
+    const { container } = render(<FormActions align="center">x</FormActions>);
+    expect(container.firstChild).toHaveClass('ori-form-actions--center');
+  });
+});

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -1,0 +1,163 @@
+import {
+  forwardRef,
+  useId,
+  type FormHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import { clsx } from 'clsx';
+
+/**
+ * Form layout standardisé.
+ *
+ * Pose la structure standard d'un formulaire administratif : sections avec
+ * titre + description, champs avec label + hint + erreur, actions en pied.
+ * Espacement vertical et alignement cohérents entre toutes les apps.
+ *
+ * Volontairement minimal côté state : Ori ne fournit ni validation ni
+ * gestion d'erreurs (chaque app a déjà sa lib préférée — react-hook-form,
+ * Formik, Angular Reactive Forms, signals…). Le DS ne pose que la
+ * structure visuelle et l'a11y, pas la logique métier.
+ *
+ * a11y :
+ * - chaque <FormField> lie automatiquement le label au control via
+ *   useId + htmlFor (l'enfant doit recevoir l'id via le contexte ou le
+ *   poser manuellement)
+ * - hint text et erreur sont liés via aria-describedby
+ * - required marker rendu visuel (*) ET annoncé via aria-required sur le
+ *   control (l'enfant doit lire la prop)
+ *
+ * Pattern composé : Form + FormSection + FormField + FormActions.
+ */
+
+export interface FormProps extends FormHTMLAttributes<HTMLFormElement> {
+  children?: ReactNode;
+}
+
+export const Form = forwardRef<HTMLFormElement, FormProps>(function Form(
+  { className, children, ...rest },
+  ref,
+) {
+  return (
+    <form ref={ref} className={clsx('ori-form', className)} noValidate {...rest}>
+      {children}
+    </form>
+  );
+});
+
+export interface FormSectionProps extends HTMLAttributes<HTMLElement> {
+  /** Titre de la section. */
+  title?: ReactNode;
+  /** Description courte (1-2 phrases). */
+  description?: ReactNode;
+  children?: ReactNode;
+}
+
+export const FormSection = forwardRef<HTMLElement, FormSectionProps>(function FormSection(
+  { title, description, className, children, ...rest },
+  ref,
+) {
+  const reactId = useId();
+  const titleId = title ? `pf-form-section-${reactId}` : undefined;
+  return (
+    <section
+      ref={ref}
+      aria-labelledby={titleId}
+      className={clsx('ori-form-section', className)}
+      {...rest}
+    >
+      {(title || description) && (
+        <header className="ori-form-section__header">
+          {title && (
+            <h3 id={titleId} className="ori-form-section__title">
+              {title}
+            </h3>
+          )}
+          {description && <p className="ori-form-section__description">{description}</p>}
+        </header>
+      )}
+      <div className="ori-form-section__fields">{children}</div>
+    </section>
+  );
+});
+
+export interface FormFieldProps {
+  /** Label du champ (obligatoire pour l'a11y). */
+  label: ReactNode;
+  /** Texte d'aide affiché sous le champ, lié via aria-describedby. */
+  hint?: ReactNode;
+  /** Message d'erreur affiché sous le champ, lié via aria-describedby. */
+  error?: ReactNode;
+  /** Affiche le marker visuel (*) et expose required à l'enfant. */
+  required?: boolean;
+  /** Render-prop : reçoit l'id, aria-describedby, aria-invalid à appliquer
+   *  sur le control. */
+  children: (renderProps: FormFieldRenderProps) => ReactNode;
+  className?: string;
+}
+
+export interface FormFieldRenderProps {
+  id: string;
+  'aria-describedby'?: string;
+  'aria-invalid'?: boolean;
+  required?: boolean;
+}
+
+export function FormField({ label, hint, error, required, children, className }: FormFieldProps) {
+  const reactId = useId();
+  const id = `pf-form-field-${reactId}`;
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <div className={clsx('ori-form-field', error && 'ori-form-field--invalid', className)}>
+      <label htmlFor={id} className="ori-form-field__label">
+        {label}
+        {required && (
+          <span className="ori-form-field__required" aria-hidden="true">
+            {' '}
+            *
+          </span>
+        )}
+      </label>
+      {children({
+        id,
+        'aria-describedby': describedBy,
+        'aria-invalid': error ? true : undefined,
+        required,
+      })}
+      {hint && (
+        <p id={hintId} className="ori-form-field__hint">
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className="ori-form-field__error" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export interface FormActionsProps extends HTMLAttributes<HTMLDivElement> {
+  /** Aligne les boutons à gauche, centre ou droite (défaut). */
+  align?: 'start' | 'center' | 'end';
+  children?: ReactNode;
+}
+
+export const FormActions = forwardRef<HTMLDivElement, FormActionsProps>(function FormActions(
+  { align = 'end', className, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      className={clsx('ori-form-actions', `ori-form-actions--${align}`, className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+});

--- a/packages/react/src/components/Form/Form.tsx
+++ b/packages/react/src/components/Form/Form.tsx
@@ -45,8 +45,8 @@ export const Form = forwardRef<HTMLFormElement, FormProps>(function Form(
   );
 });
 
-export interface FormSectionProps extends HTMLAttributes<HTMLElement> {
-  /** Titre de la section. */
+export interface FormSectionProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  /** Titre de la section (peut être un ReactNode, pas seulement une string). */
   title?: ReactNode;
   /** Description courte (1-2 phrases). */
   description?: ReactNode;

--- a/packages/react/src/components/Form/index.ts
+++ b/packages/react/src/components/Form/index.ts
@@ -1,0 +1,8 @@
+export { Form, FormSection, FormField, FormActions } from './Form.js';
+export type {
+  FormProps,
+  FormSectionProps,
+  FormFieldProps,
+  FormFieldRenderProps,
+  FormActionsProps,
+} from './Form.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,6 +31,7 @@ export * from './components/Skeleton/index.js';
 export * from './components/Spinner/index.js';
 export * from './components/EmptyState/index.js';
 export * from './components/AppShell/index.js';
+export * from './components/Form/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1703,6 +1703,84 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       },
     },
 
+    // ─── Form layout ────────────────────────────────────────────────────────
+    // Espacement vertical cohérent entre sections, fields et actions. La
+    // hiérarchie visuelle vit dans le titre h3 + description courte de chaque
+    // section ; les champs eux-mêmes restent neutres pour ne pas concurrencer
+    // le contenu de l'input projeté.
+    '.ori-form': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.8'),
+    },
+    '.ori-form-section': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.4'),
+    },
+    '.ori-form-section__header': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.1'),
+    },
+    '.ori-form-section__title': {
+      margin: '0',
+      fontSize: theme('fontSize.base'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: v('text-primary'),
+    },
+    '.ori-form-section__description': {
+      margin: '0',
+      fontSize: theme('fontSize.sm'),
+      color: v('text-secondary'),
+      lineHeight: theme('lineHeight.relaxed'),
+    },
+    '.ori-form-section__fields': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.4'),
+    },
+    '.ori-form-field': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.1'),
+    },
+    '.ori-form-field__label': {
+      fontSize: theme('fontSize.sm'),
+      fontWeight: theme('fontWeight.medium'),
+      color: v('text-primary'),
+    },
+    '.ori-form-field__required': {
+      color: v('feedback-danger'),
+    },
+    '.ori-form-field__hint': {
+      margin: '0',
+      fontSize: theme('fontSize.xs'),
+      color: v('text-secondary'),
+      lineHeight: theme('lineHeight.relaxed'),
+    },
+    '.ori-form-field__error': {
+      margin: '0',
+      fontSize: theme('fontSize.xs'),
+      color: v('feedback-danger'),
+      lineHeight: theme('lineHeight.relaxed'),
+    },
+    '.ori-form-actions': {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme('spacing.2'),
+      paddingTop: theme('spacing.2'),
+    },
+    '.ori-form-actions--start': {
+      justifyContent: 'flex-start',
+    },
+    '.ori-form-actions--center': {
+      justifyContent: 'center',
+    },
+    '.ori-form-actions--end': {
+      justifyContent: 'flex-end',
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Troisième Composition de la roadmap. Pose la structure standard d'un formulaire administratif (sections + champs + actions) avec ARIA câblé, sans imposer de stack de validation.

## Choix techniques

- **Pas de validation ni de gestion d'état** : chaque app a déjà ses propres tools (react-hook-form, Reactive Forms, signals, …). Le DS ne pose que la structure visuelle et l'a11y, pas la logique métier. Décision standard pour ne pas dupliquer les frameworks.
- **API React** : render-prop sur \`<FormField>\` qui passe \`{ id, aria-describedby, aria-invalid, required }\` à appliquer sur le control. Câblage automatique en une ligne.
- **API Angular** : variables locales (\`#field.controlId\`, \`#field.describedById\`) à brancher manuellement via \`[id]\` et \`[attr.aria-describedby]\`. Pattern idiomatique Angular vs render-prop React.

## a11y

- Label lié au control via \`htmlFor\` / \`id\` (auto en React, manuel en Angular)
- Hint et erreur liés via \`aria-describedby\` (les deux peuvent cohabiter)
- Erreur en \`role=\"alert\"\` pour annonce immédiate par les SR
- Required marker visuel (*) ET \`aria-required=true\` sur le control
- \`<form noValidate>\` : la validation native HTML est désactivée, on laisse l'app gérer

## API React

\`\`\`tsx
<Form onSubmit={handleSubmit}>
  <FormSection title=\"Identité\" description=\"...\">
    <FormField label=\"Nom\" required error={errors.nom}>
      {(p) => <Input {...p} />}
    </FormField>
  </FormSection>
  <FormActions>
    <Button variant=\"secondary\" type=\"button\">Annuler</Button>
    <Button type=\"submit\">Enregistrer</Button>
  </FormActions>
</Form>
\`\`\`

## API Angular

\`\`\`html
<ori-form (formSubmit)=\"handleSubmit($event)\">
  <ori-form-section title=\"Identité\">
    <ori-form-field #nom label=\"Nom\" [required]=\"true\">
      <ori-input [id]=\"nom.controlId\" [attr.aria-describedby]=\"nom.describedById\"></ori-input>
    </ori-form-field>
  </ori-form-section>
  <ori-form-actions>
    <ori-button type=\"submit\">Enregistrer</ori-button>
  </ori-form-actions>
</ori-form>
\`\`\`

## Tests

- 14 tests Vitest React (Form, FormSection, FormField, FormActions) — 162/162 verts
- 4 stories par framework (Default, MultipleSections, WithErrors, ActionsAlignedStart)
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. Troisième Composition sur 6. Débloque les Compositions à venir Wizard et Login layout (qui réutilisent Form).