### PR TITLE
feat(login-layout): composition LoginLayout générique (React + Angular)

### DIFF
--- a/packages/angular/src/components/login-layout/index.ts
+++ b/packages/angular/src/components/login-layout/index.ts
@@ -1,0 +1,1 @@
+export { OriLoginLayoutComponent } from './login-layout.component';

--- a/packages/angular/src/components/login-layout/login-layout.component.ts
+++ b/packages/angular/src/components/login-layout/login-layout.component.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+
+/**
+ * Login layout générique.
+ *
+ * Page d'authentification : logo + carte centrée contenant titre /
+ * description / contenu (formulaire, AuthButton, etc.) + footer optionnel.
+ *
+ * Volontairement agnostique : le DS pose le layout, l'app projette son
+ * contenu d'authentification (formulaire de mot de passe, bouton fournisseur
+ * d'identité, sélecteur d'IdP). Pour brancher GOV Connect, glisser un
+ * `<ori-auth-button>` dans le slot principal.
+ *
+ * Slots :
+ * - `slot="logo"` : logo au-dessus de la carte
+ * - `slot="cardFooter"` : pied de carte (mot de passe oublié, créer un compte)
+ * - `slot="footer"` : pied de page (mentions légales, copyright)
+ * - projection par défaut : contenu principal de la carte (formulaire, boutons)
+ */
+@Component({
+  selector: 'ori-login-layout',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div class="ori-login-layout">
+      <div class="ori-login-layout__inner">
+        @if (hasLogo) {
+          <div class="ori-login-layout__logo">
+            <ng-content select="[slot=logo]"></ng-content>
+          </div>
+        }
+        <div class="ori-login-layout__card">
+          <header class="ori-login-layout__header">
+            <h1 class="ori-login-layout__title">{{ title }}</h1>
+            @if (description) {
+              <p class="ori-login-layout__description">{{ description }}</p>
+            }
+          </header>
+          <div class="ori-login-layout__body">
+            <ng-content></ng-content>
+          </div>
+          @if (hasCardFooter) {
+            <div class="ori-login-layout__card-footer">
+              <ng-content select="[slot=cardFooter]"></ng-content>
+            </div>
+          }
+        </div>
+        @if (hasFooter) {
+          <div class="ori-login-layout__footer">
+            <ng-content select="[slot=footer]"></ng-content>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+export class OriLoginLayoutComponent {
+  @Input() title: string = '';
+  @Input() description: string = '';
+  /** Indique si le slot logo est utilisé. Default: false. */
+  @Input() hasLogo: boolean = false;
+  /** Indique si le slot cardFooter est utilisé. Default: false. */
+  @Input() hasCardFooter: boolean = false;
+  /** Indique si le slot footer est utilisé. Default: false. */
+  @Input() hasFooter: boolean = false;
+}

--- a/packages/angular/src/components/login-layout/login-layout.stories.ts
+++ b/packages/angular/src/components/login-layout/login-layout.stories.ts
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { OriLoginLayoutComponent } from './login-layout.component';
+import {
+  OriFormComponent,
+  OriFormSectionComponent,
+  OriFormFieldComponent,
+  OriFormActionsComponent,
+} from '../form/form.component';
+import { OriInputComponent } from '../input/input.component';
+import { OriButtonComponent } from '../button/button.component';
+import { OriLogoComponent } from '../logo/logo.component';
+import { OriLinkComponent } from '../link/link.component';
+
+const meta: Meta<OriLoginLayoutComponent> = {
+  title: 'Composants/Layout/LoginLayout',
+  component: OriLoginLayoutComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [
+        OriLoginLayoutComponent,
+        OriFormComponent,
+        OriFormSectionComponent,
+        OriFormFieldComponent,
+        OriFormActionsComponent,
+        OriInputComponent,
+        OriButtonComponent,
+        OriLogoComponent,
+        OriLinkComponent,
+      ],
+    }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          "Page d'authentification : logo + carte centrée + slots pour le contenu de connexion (formulaire, AuthButton GOV Connect, …) et le footer.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriLoginLayoutComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    template: `
+      <ori-login-layout
+        title="Se connecter"
+        description="Accédez à votre espace personnel."
+        [hasLogo]="true"
+        [hasCardFooter]="true"
+        [hasFooter]="true"
+      >
+        <ori-logo slot="logo"></ori-logo>
+        <ori-form>
+          <ori-form-section>
+            <ori-form-field #email label="Adresse électronique" [required]="true">
+              <ori-input [id]="email.controlId" [attr.aria-describedby]="email.describedById" type="email" placeholder="exemple@administration.gov.pf"></ori-input>
+            </ori-form-field>
+            <ori-form-field #pwd label="Mot de passe" [required]="true">
+              <ori-input [id]="pwd.controlId" [attr.aria-describedby]="pwd.describedById" type="password"></ori-input>
+            </ori-form-field>
+          </ori-form-section>
+          <ori-form-actions align="end">
+            <ori-button type="submit">Se connecter</ori-button>
+          </ori-form-actions>
+        </ori-form>
+        <ng-container slot="cardFooter">
+          <ori-link href="#">Mot de passe oublié ?</ori-link>
+          <span>Pas encore de compte ? <ori-link href="#">Créer un compte</ori-link></span>
+        </ng-container>
+        <ng-container slot="footer">
+          <ori-link href="#" variant="quiet">Mentions légales</ori-link>
+          <ori-link href="#" variant="quiet">Accessibilité</ori-link>
+          <ori-link href="#" variant="quiet">Aide</ori-link>
+          <span>© 2026 Polynésie française</span>
+        </ng-container>
+      </ori-login-layout>
+    `,
+  }),
+};
+
+export const WithAuthProvider: Story = {
+  render: () => ({
+    template: `
+      <ori-login-layout
+        title="Connexion administration"
+        description="Cette application est réservée aux agents de la fonction publique. Authentifiez-vous via GOV Connect."
+        [hasLogo]="true"
+        [hasFooter]="true"
+      >
+        <ori-logo slot="logo"></ori-logo>
+        <div style="display: flex; flex-direction: column; gap: 12px;">
+          <ori-button>Se connecter avec GOV Connect</ori-button>
+          <ori-button variant="secondary">Connexion alternative (Microsoft)</ori-button>
+        </div>
+        <ng-container slot="footer">
+          <span>© 2026 Polynésie française</span>
+        </ng-container>
+      </ori-login-layout>
+    `,
+  }),
+};
+
+export const Minimal: Story = {
+  render: () => ({
+    template: `
+      <ori-login-layout title="Se connecter">
+        <ori-form>
+          <ori-form-section>
+            <ori-form-field #id label="Identifiant" [required]="true">
+              <ori-input [id]="id.controlId" [attr.aria-describedby]="id.describedById"></ori-input>
+            </ori-form-field>
+            <ori-form-field #pwd label="Mot de passe" [required]="true">
+              <ori-input [id]="pwd.controlId" [attr.aria-describedby]="pwd.describedById" type="password"></ori-input>
+            </ori-form-field>
+          </ori-form-section>
+          <ori-form-actions>
+            <ori-button type="submit">Connexion</ori-button>
+          </ori-form-actions>
+        </ori-form>
+      </ori-login-layout>
+    `,
+  }),
+};

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -32,6 +32,7 @@ export * from './components/spinner';
 export * from './components/empty-state';
 export * from './components/app-shell';
 export * from './components/form';
+export * from './components/login-layout';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LoginLayout } from './LoginLayout.js';
+import { Form, FormSection, FormField, FormActions } from '../Form/Form.js';
+import { Input } from '../Input/Input.js';
+import { Button } from '../Button/Button.js';
+import { Link } from '../Link/Link.js';
+import { Logo } from '../Logo/Logo.js';
+
+const meta = {
+  title: 'Composants/Layout/LoginLayout',
+  component: LoginLayout,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof LoginLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sharedFooter = (
+  <>
+    <Link href="#" variant="quiet">
+      Mentions légales
+    </Link>
+    <Link href="#" variant="quiet">
+      Accessibilité
+    </Link>
+    <Link href="#" variant="quiet">
+      Aide
+    </Link>
+    <span>© 2026 Polynésie française</span>
+  </>
+);
+
+/** Cas standard : login email + mot de passe + lien d'aide. */
+export const Default: Story = {
+  render: () => (
+    <LoginLayout
+      logo={<Logo />}
+      title="Se connecter"
+      description="Accédez à votre espace personnel."
+      cardFooter={
+        <>
+          <Link href="#">Mot de passe oublié ?</Link>
+          <span>
+            Pas encore de compte ? <Link href="#">Créer un compte</Link>
+          </span>
+        </>
+      }
+      footer={sharedFooter}
+    >
+      <Form>
+        <FormSection>
+          <FormField label="Adresse électronique" required>
+            {(p) => <Input {...p} type="email" placeholder="exemple@administration.gov.pf" />}
+          </FormField>
+          <FormField label="Mot de passe" required>
+            {(p) => <Input {...p} type="password" />}
+          </FormField>
+        </FormSection>
+        <FormActions align="end">
+          <Button type="submit">Se connecter</Button>
+        </FormActions>
+      </Form>
+    </LoginLayout>
+  ),
+};
+
+/** Avec AuthButton (GOV Connect / Rumia / Microsoft) : pas de formulaire local. */
+export const WithAuthProvider: Story = {
+  render: () => (
+    <LoginLayout
+      logo={<Logo />}
+      title="Connexion administration"
+      description="Cette application est réservée aux agents de la fonction publique. Authentifiez-vous via GOV Connect."
+      footer={sharedFooter}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <Button>Se connecter avec GOV Connect</Button>
+        <Button variant="secondary">Connexion alternative (Microsoft)</Button>
+      </div>
+    </LoginLayout>
+  ),
+};
+
+/** Sans cardFooter ni footer : login minimal. */
+export const Minimal: Story = {
+  render: () => (
+    <LoginLayout title="Se connecter">
+      <Form>
+        <FormSection>
+          <FormField label="Identifiant" required>
+            {(p) => <Input {...p} />}
+          </FormField>
+          <FormField label="Mot de passe" required>
+            {(p) => <Input {...p} type="password" />}
+          </FormField>
+        </FormSection>
+        <FormActions>
+          <Button type="submit">Connexion</Button>
+        </FormActions>
+      </Form>
+    </LoginLayout>
+  ),
+};

--- a/packages/react/src/components/LoginLayout/LoginLayout.test.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LoginLayout } from './LoginLayout';
+
+describe('LoginLayout', () => {
+  it('rend un h1 avec le titre', () => {
+    render(<LoginLayout title="Se connecter">x</LoginLayout>);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Se connecter');
+  });
+
+  it('rend la description quand fournie', () => {
+    render(
+      <LoginLayout title="x" description="Accédez à votre espace.">
+        y
+      </LoginLayout>,
+    );
+    expect(screen.getByText('Accédez à votre espace.')).toBeInTheDocument();
+  });
+
+  it('ne rend pas de paragraphe sans description', () => {
+    const { container } = render(<LoginLayout title="x">y</LoginLayout>);
+    expect(container.querySelector('.ori-login-layout__description')).toBeNull();
+  });
+
+  it('rend le logo quand fourni', () => {
+    render(
+      <LoginLayout logo={<span data-testid="logo">L</span>} title="x">
+        y
+      </LoginLayout>,
+    );
+    expect(screen.getByTestId('logo')).toBeInTheDocument();
+  });
+
+  it('ne rend pas de zone logo sans prop logo', () => {
+    const { container } = render(<LoginLayout title="x">y</LoginLayout>);
+    expect(container.querySelector('.ori-login-layout__logo')).toBeNull();
+  });
+
+  it('rend le cardFooter quand fourni', () => {
+    render(
+      <LoginLayout title="x" cardFooter={<a href="#">Aide</a>}>
+        y
+      </LoginLayout>,
+    );
+    expect(screen.getByRole('link', { name: 'Aide' })).toBeInTheDocument();
+  });
+
+  it('rend le footer quand fourni', () => {
+    render(
+      <LoginLayout title="x" footer={<span>© 2026</span>}>
+        y
+      </LoginLayout>,
+    );
+    expect(screen.getByText('© 2026')).toBeInTheDocument();
+  });
+
+  it('rend le contenu principal', () => {
+    render(
+      <LoginLayout title="x">
+        <button>Se connecter</button>
+      </LoginLayout>,
+    );
+    expect(screen.getByRole('button', { name: 'Se connecter' })).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/LoginLayout/LoginLayout.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.tsx
@@ -1,0 +1,58 @@
+import { forwardRef } from 'react';
+import type { ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+/**
+ * Login layout générique.
+ *
+ * Page d'authentification : logo + carte centrée verticalement et
+ * horizontalement contenant titre / description / contenu (formulaire,
+ * AuthButton GOV Connect, etc.) + footer optionnel.
+ *
+ * Volontairement agnostique : le DS pose le layout, l'app projette son
+ * contenu d'authentification (formulaire de mot de passe, bouton fournisseur
+ * d'identité, sélecteur d'IdP, …). Pour brancher GOV Connect, glisser un
+ * `<AuthButton>` dans le slot principal.
+ *
+ * Pas de role ARIA dédié sur la carte : c'est un layout, pas une région
+ * sémantique. Le titre est en h1 (par défaut une page de login = page
+ * autonome avec son propre h1).
+ */
+
+export interface LoginLayoutProps {
+  /** Logo affiché au-dessus de la carte (typiquement <Logo>). */
+  logo?: ReactNode;
+  /** Titre de la page (h1). */
+  title: ReactNode;
+  /** Description courte sous le titre. */
+  description?: ReactNode;
+  /** Contenu principal (formulaire, AuthButton, mix). */
+  children?: ReactNode;
+  /** Pied de carte : liens secondaires (mot de passe oublié, créer un compte). */
+  cardFooter?: ReactNode;
+  /** Pied de page sous la carte : mentions légales, copyright. */
+  footer?: ReactNode;
+  className?: string;
+}
+
+export const LoginLayout = forwardRef<HTMLDivElement, LoginLayoutProps>(function LoginLayout(
+  { logo, title, description, children, cardFooter, footer, className },
+  ref,
+) {
+  return (
+    <div ref={ref} className={clsx('ori-login-layout', className)}>
+      <div className="ori-login-layout__inner">
+        {logo && <div className="ori-login-layout__logo">{logo}</div>}
+        <div className="ori-login-layout__card">
+          <header className="ori-login-layout__header">
+            <h1 className="ori-login-layout__title">{title}</h1>
+            {description && <p className="ori-login-layout__description">{description}</p>}
+          </header>
+          <div className="ori-login-layout__body">{children}</div>
+          {cardFooter && <div className="ori-login-layout__card-footer">{cardFooter}</div>}
+        </div>
+        {footer && <div className="ori-login-layout__footer">{footer}</div>}
+      </div>
+    </div>
+  );
+});

--- a/packages/react/src/components/LoginLayout/index.ts
+++ b/packages/react/src/components/LoginLayout/index.ts
@@ -1,0 +1,2 @@
+export { LoginLayout } from './LoginLayout.js';
+export type { LoginLayoutProps } from './LoginLayout.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/Spinner/index.js';
 export * from './components/EmptyState/index.js';
 export * from './components/AppShell/index.js';
 export * from './components/Form/index.js';
+export * from './components/LoginLayout/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1781,6 +1781,88 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       justifyContent: 'flex-end',
     },
 
+    // ─── LoginLayout ────────────────────────────────────────────────────────
+    // Page d'authentification : centrage vertical/horizontal d'une carte
+    // contenant le titre + contenu + footer optionnel. Le logo et le footer
+    // de page restent en dehors de la carte.
+    '.ori-login-layout': {
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingBlock: theme('spacing.10'),
+      paddingInline: theme('spacing.4'),
+      backgroundColor: v('surface-muted'),
+    },
+    '.ori-login-layout__inner': {
+      width: '100%',
+      maxWidth: '28rem',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.6'),
+      alignItems: 'center',
+    },
+    '.ori-login-layout__logo': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    '.ori-login-layout__card': {
+      width: '100%',
+      backgroundColor: v('surface-base'),
+      borderRadius: theme('borderRadius.lg'),
+      boxShadow: theme('boxShadow.lg'),
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: v('border-subtle'),
+      padding: theme('spacing.6'),
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.5'),
+    },
+    '.ori-login-layout__header': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.1'),
+    },
+    '.ori-login-layout__title': {
+      margin: '0',
+      fontSize: theme('fontSize.xl'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: v('text-primary'),
+    },
+    '.ori-login-layout__description': {
+      margin: '0',
+      fontSize: theme('fontSize.sm'),
+      color: v('text-secondary'),
+      lineHeight: theme('lineHeight.relaxed'),
+    },
+    '.ori-login-layout__body': {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    '.ori-login-layout__card-footer': {
+      paddingTop: theme('spacing.4'),
+      borderTopWidth: '1px',
+      borderTopStyle: 'solid',
+      borderTopColor: v('border-subtle'),
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.2'),
+      fontSize: theme('fontSize.sm'),
+      color: v('text-secondary'),
+      textAlign: 'center',
+    },
+    '.ori-login-layout__footer': {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'center',
+      gap: theme('spacing.4'),
+      fontSize: theme('fontSize.xs'),
+      color: v('text-muted'),
+      textAlign: 'center',
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Quatrième Composition de la roadmap. Page d'authentification générique : logo + carte centrée + slots pour le contenu de connexion. Réutilise \`<Form>\` pour le formulaire de mot de passe, et peut héberger un \`<AuthButton>\` GOV Connect / Rumia / Microsoft.

## API

\`\`\`tsx
<LoginLayout
  logo={<Logo />}
  title=\"Se connecter\"
  description=\"Accédez à votre espace personnel.\"
  cardFooter={<Link>Mot de passe oublié ?</Link>}
  footer={<>© 2026 Polynésie française</>}
>
  <Form>...</Form>
</LoginLayout>
\`\`\`

\`\`\`html
<ori-login-layout
  title=\"Se connecter\"
  description=\"...\"
  [hasLogo]=\"true\"
  [hasCardFooter]=\"true\"
  [hasFooter]=\"true\"
>
  <ori-logo slot=\"logo\"></ori-logo>
  <ori-form>…</ori-form>
  <ng-container slot=\"cardFooter\">…</ng-container>
  <ng-container slot=\"footer\">…</ng-container>
</ori-login-layout>
\`\`\`

## a11y

- Titre en \`<h1>\` (page de login = page autonome avec sa propre hiérarchie)
- Pas de role ARIA dédié sur la carte (c'est un layout, pas une région sémantique)
- Le contenu projeté gère sa propre accessibilité (Form + FormField pour les inputs)

## Choix techniques

- **Volontairement agnostique côté contenu** : pas de formulaire pré-rempli, pas de logique de soumission. L'app projette son Form ou son AuthButton.
- **Stories** illustrent les 3 cas standards : login email+password (avec Form), connexion fournisseur d'identité (AuthButton), variant minimal sans logo ni footer.

## Tests

- 8 tests Vitest React (170/170 verts)
- 3 stories par framework (Default, WithAuthProvider, Minimal)
- Build Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. Quatrième Composition sur 6.