### PR TITLE
feat(wizard): composition Wizard multi-étapes (React + Angular)

### DIFF
--- a/packages/angular/src/components/wizard/index.ts
+++ b/packages/angular/src/components/wizard/index.ts
@@ -1,0 +1,1 @@
+export { OriWizardComponent, OriWizardStepComponent } from './wizard.component';

--- a/packages/angular/src/components/wizard/wizard.component.ts
+++ b/packages/angular/src/components/wizard/wizard.component.ts
@@ -1,0 +1,171 @@
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  EventEmitter,
+  Input,
+  Output,
+  QueryList,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import { OriStepsComponent, type OriStepItem } from '../steps/steps.component';
+import { OriButtonComponent } from '../button/button.component';
+
+let nextUid = 0;
+
+/**
+ * Étape déclarative d'un Wizard. Doit être enfant direct d'<ori-wizard>.
+ *
+ * L'étape rend son contenu (`ng-content`) en permanence dans le DOM mais
+ * masquée via `[hidden]` quand non active. Ça évite de réinitialiser les
+ * formulaires Reactive Forms à chaque changement d'étape (perte de saisie),
+ * tout en gardant l'a11y propre (l'élément non actif n'apparaît pas à l'AT).
+ */
+@Component({
+  selector: 'ori-wizard-step',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div [hidden]="!active" class="ori-wizard__step-body">
+      <ng-content></ng-content>
+    </div>
+  `,
+})
+export class OriWizardStepComponent {
+  @Input() title: string = '';
+  @Input() description: string = '';
+
+  /** Activé par le parent <ori-wizard> via le query ContentChildren. */
+  active: boolean = false;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  setActive(active: boolean): void {
+    if (this.active === active) return;
+    this.active = active;
+    this.cdr.markForCheck();
+  }
+}
+
+/**
+ * Wizard multi-étapes.
+ *
+ * Assemble Steps + contenu actif + actions Précédent / Suivant / Soumettre.
+ * Chaque étape est déclarée via un <ori-wizard-step> enfant.
+ *
+ * Validation : Ori ne pose aucune logique. L'app gère côté Reactive Forms /
+ * signals et désactive l'avancement via `[canProceed]="false"`.
+ *
+ * Parité avec la version React : même API publique (currentStep,
+ * canProceed, onComplete, allowGoBack), mêmes labels par défaut.
+ */
+@Component({
+  selector: 'ori-wizard',
+  standalone: true,
+  imports: [OriStepsComponent, OriButtonComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div class="ori-wizard">
+      <ori-steps
+        class="ori-wizard__steps"
+        [steps]="stepItems"
+        [current]="clampedCurrent"
+        [clickable]="allowGoBack"
+        (stepClick)="onStepClick($event)"
+      ></ori-steps>
+      <section class="ori-wizard__panel" [attr.aria-labelledby]="titleId">
+        <h2 [id]="titleId" class="ori-wizard__step-title">{{ activeStepTitle }}</h2>
+        <ng-content></ng-content>
+      </section>
+      <div class="ori-wizard__actions">
+        <ori-button variant="secondary" [disabled]="isFirst" (click)="goToPrevious()">
+          {{ previousLabel }}
+        </ori-button>
+        @if (isLast) {
+          <ori-button [disabled]="!canProceed" (click)="handleSubmit()">{{
+            submitLabel
+          }}</ori-button>
+        } @else {
+          <ori-button [disabled]="!canProceed" (click)="goToNext()">{{ nextLabel }}</ori-button>
+        }
+      </div>
+    </div>
+  `,
+})
+export class OriWizardComponent implements AfterContentInit {
+  @Input() set currentStep(value: number) {
+    this._currentStep = value;
+    this.refreshActive();
+  }
+  get currentStep(): number {
+    return this._currentStep;
+  }
+
+  @Input() canProceed: boolean = true;
+  @Input() allowGoBack: boolean = true;
+  @Input() previousLabel: string = 'Précédent';
+  @Input() nextLabel: string = 'Suivant';
+  @Input() submitLabel: string = 'Soumettre';
+
+  @Output() stepChange = new EventEmitter<number>();
+  @Output() complete = new EventEmitter<void>();
+
+  @ContentChildren(OriWizardStepComponent)
+  protected stepsRef?: QueryList<OriWizardStepComponent>;
+
+  protected readonly titleId = `pf-wizard-title-${++nextUid}`;
+  protected stepItems: OriStepItem[] = [];
+  protected activeStepTitle: string = '';
+  protected clampedCurrent: number = 0;
+  protected isFirst: boolean = true;
+  protected isLast: boolean = false;
+
+  private _currentStep: number = 0;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  ngAfterContentInit(): void {
+    this.refreshActive();
+    this.stepsRef?.changes.subscribe(() => this.refreshActive());
+  }
+
+  protected onStepClick(index: number): void {
+    if (!this.allowGoBack) return;
+    this.stepChange.emit(index);
+  }
+
+  protected goToPrevious(): void {
+    if (!this.isFirst) this.stepChange.emit(this.clampedCurrent - 1);
+  }
+
+  protected goToNext(): void {
+    if (!this.isLast && this.canProceed) this.stepChange.emit(this.clampedCurrent + 1);
+  }
+
+  protected handleSubmit(): void {
+    if (this.canProceed) this.complete.emit();
+  }
+
+  private refreshActive(): void {
+    if (!this.stepsRef) return;
+    const total = this.stepsRef.length;
+    if (total === 0) {
+      throw new Error('OriWizard doit contenir au moins un <ori-wizard-step>.');
+    }
+    this.clampedCurrent = Math.max(0, Math.min(this._currentStep, total - 1));
+    this.isFirst = this.clampedCurrent === 0;
+    this.isLast = this.clampedCurrent === total - 1;
+    this.stepItems = this.stepsRef.toArray().map((s) => ({
+      title: s.title,
+      description: s.description || undefined,
+    }));
+    this.activeStepTitle = this.stepItems[this.clampedCurrent]?.title ?? '';
+    this.stepsRef.forEach((step, idx) => step.setActive(idx === this.clampedCurrent));
+    this.cdr.markForCheck();
+  }
+}

--- a/packages/angular/src/components/wizard/wizard.stories.ts
+++ b/packages/angular/src/components/wizard/wizard.stories.ts
@@ -1,0 +1,183 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { OriWizardComponent, OriWizardStepComponent } from './wizard.component';
+import {
+  OriFormComponent,
+  OriFormSectionComponent,
+  OriFormFieldComponent,
+} from '../form/form.component';
+import { OriInputComponent } from '../input/input.component';
+import { OriTextareaComponent } from '../textarea/textarea.component';
+
+const meta: Meta<OriWizardComponent> = {
+  title: 'Composants/Layout/Wizard',
+  component: OriWizardComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({
+      imports: [
+        OriWizardComponent,
+        OriWizardStepComponent,
+        OriFormComponent,
+        OriFormSectionComponent,
+        OriFormFieldComponent,
+        OriInputComponent,
+        OriTextareaComponent,
+      ],
+    }),
+  ],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "Wizard multi-étapes : assemble Steps + contenu actif + actions Précédent / Suivant / Soumettre. Validation laissée à l'app via la prop [canProceed].",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriWizardComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    props: {
+      step: 0,
+      nom: '',
+      email: '',
+      details: '',
+      get canProceed(): boolean {
+        const s = this as any;
+        if (s.step === 0) return s.nom?.trim().length > 0;
+        if (s.step === 1) return s.email?.includes('@');
+        return true;
+      },
+      onStep(value: number) {
+        (this as any).step = value;
+      },
+      onNom(event: Event) {
+        (this as any).nom = (event.target as HTMLInputElement).value;
+      },
+      onEmail(event: Event) {
+        (this as any).email = (event.target as HTMLInputElement).value;
+      },
+      onComplete() {
+        alert('Démarche soumise');
+      },
+    },
+    template: `
+      <div style="max-width: 640px;">
+        <ori-wizard
+          [currentStep]="step"
+          [canProceed]="canProceed"
+          (stepChange)="onStep($event)"
+          (complete)="onComplete()"
+        >
+          <ori-wizard-step title="Identité" description="Vos informations personnelles">
+            <ori-form>
+              <ori-form-section>
+                <ori-form-field #nomF label="Nom complet" [required]="true">
+                  <ori-input
+                    [id]="nomF.controlId"
+                    [attr.aria-describedby]="nomF.describedById"
+                    [value]="nom"
+                    (input)="onNom($event)"
+                  ></ori-input>
+                </ori-form-field>
+              </ori-form-section>
+            </ori-form>
+          </ori-wizard-step>
+          <ori-wizard-step title="Coordonnées" description="Comment vous joindre">
+            <ori-form>
+              <ori-form-section>
+                <ori-form-field #emailF label="Adresse électronique" [required]="true">
+                  <ori-input
+                    [id]="emailF.controlId"
+                    [attr.aria-describedby]="emailF.describedById"
+                    type="email"
+                    placeholder="exemple@administration.gov.pf"
+                    [value]="email"
+                    (input)="onEmail($event)"
+                  ></ori-input>
+                </ori-form-field>
+              </ori-form-section>
+            </ori-form>
+          </ori-wizard-step>
+          <ori-wizard-step title="Détails" description="Décrivez votre demande">
+            <ori-form>
+              <ori-form-section>
+                <ori-form-field #detF label="Détails (optionnel)">
+                  <ori-textarea
+                    [id]="detF.controlId"
+                    [attr.aria-describedby]="detF.describedById"
+                    [rows]="4"
+                  ></ori-textarea>
+                </ori-form-field>
+              </ori-form-section>
+            </ori-form>
+          </ori-wizard-step>
+        </ori-wizard>
+      </div>
+    `,
+  }),
+};
+
+export const FiveSteps: Story = {
+  render: () => ({
+    props: {
+      step: 0,
+      onStep(value: number) {
+        (this as any).step = value;
+      },
+      titles: ['Identité', 'Coordonnées', 'Pièces jointes', 'Récapitulatif', 'Confirmation'],
+    },
+    template: `
+      <div style="max-width: 720px;">
+        <ori-wizard
+          [currentStep]="step"
+          (stepChange)="onStep($event)"
+          (complete)="alert('Soumis')"
+        >
+          <ori-wizard-step *ngFor="let title of titles" [title]="title">
+            <p>Contenu de l'étape « {{ title }} »</p>
+            <p>Vous pouvez avancer librement dans cette démo.</p>
+          </ori-wizard-step>
+        </ori-wizard>
+      </div>
+    `,
+  }),
+};
+
+export const NoGoBack: Story = {
+  render: () => ({
+    props: {
+      step: 0,
+      onStep(value: number) {
+        (this as any).step = value;
+      },
+    },
+    template: `
+      <div style="max-width: 640px;">
+        <ori-wizard
+          [currentStep]="step"
+          [allowGoBack]="false"
+          (stepChange)="onStep($event)"
+        >
+          <ori-wizard-step title="Étape 1">
+            <p>
+              Cette story désactive le retour arrière via clic sur les marches
+              complétées de Steps. Le bouton « Précédent » reste actif.
+            </p>
+          </ori-wizard-step>
+          <ori-wizard-step title="Étape 2">
+            <p>Contenu étape 2.</p>
+          </ori-wizard-step>
+          <ori-wizard-step title="Étape 3">
+            <p>Dernière étape.</p>
+          </ori-wizard-step>
+        </ori-wizard>
+      </div>
+    `,
+  }),
+};

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -33,6 +33,7 @@ export * from './components/empty-state';
 export * from './components/app-shell';
 export * from './components/form';
 export * from './components/login-layout';
+export * from './components/wizard';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/Wizard/Wizard.stories.tsx
+++ b/packages/react/src/components/Wizard/Wizard.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Wizard, WizardStep } from './Wizard.js';
+import { Form, FormSection, FormField, FormActions } from '../Form/Form.js';
+import { Input } from '../Input/Input.js';
+import { Textarea } from '../Textarea/Textarea.js';
+import { Button } from '../Button/Button.js';
+
+const meta = {
+  title: 'Composants/Layout/Wizard',
+  component: Wizard,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof Wizard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Démarche en 3 étapes avec validation simple par étape. */
+export const Default: Story = {
+  render: () => {
+    const [step, setStep] = useState(0);
+    const [nom, setNom] = useState('');
+    const [email, setEmail] = useState('');
+    const [details, setDetails] = useState('');
+
+    // Validation : chaque étape exige ses champs renseignés.
+    const canProceed =
+      (step === 0 && nom.trim().length > 0) || (step === 1 && email.includes('@')) || step === 2;
+
+    return (
+      <div style={{ maxWidth: 640 }}>
+        <Wizard
+          currentStep={step}
+          onStepChange={setStep}
+          canProceed={canProceed}
+          onComplete={() => alert('Démarche soumise')}
+        >
+          <WizardStep title="Identité" description="Vos informations personnelles">
+            <Form>
+              <FormSection>
+                <FormField label="Nom complet" required>
+                  {(p) => <Input {...p} value={nom} onChange={(e) => setNom(e.target.value)} />}
+                </FormField>
+              </FormSection>
+            </Form>
+          </WizardStep>
+          <WizardStep title="Coordonnées" description="Comment vous joindre">
+            <Form>
+              <FormSection>
+                <FormField label="Adresse électronique" required>
+                  {(p) => (
+                    <Input
+                      {...p}
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      placeholder="exemple@administration.gov.pf"
+                    />
+                  )}
+                </FormField>
+              </FormSection>
+            </Form>
+          </WizardStep>
+          <WizardStep title="Détails" description="Décrivez votre demande">
+            <Form>
+              <FormSection>
+                <FormField label="Détails (optionnel)">
+                  {(p) => (
+                    <Textarea
+                      {...p}
+                      value={details}
+                      onChange={(e) => setDetails(e.target.value)}
+                      rows={4}
+                    />
+                  )}
+                </FormField>
+              </FormSection>
+            </Form>
+          </WizardStep>
+        </Wizard>
+      </div>
+    );
+  },
+};
+
+/** Wizard avec 5 étapes : démontre le rendu de Steps avec plus de marches. */
+export const FiveSteps: Story = {
+  render: () => {
+    const [step, setStep] = useState(0);
+    return (
+      <div style={{ maxWidth: 720 }}>
+        <Wizard currentStep={step} onStepChange={setStep} onComplete={() => alert('Soumis')}>
+          {['Identité', 'Coordonnées', 'Pièces jointes', 'Récapitulatif', 'Confirmation'].map(
+            (title) => (
+              <WizardStep key={title} title={title}>
+                <p>Contenu de l'étape « {title} »</p>
+                <p>Vous pouvez avancer librement dans cette démo.</p>
+              </WizardStep>
+            ),
+          )}
+        </Wizard>
+      </div>
+    );
+  },
+};
+
+/** allowGoBack=false : retour aux étapes précédentes désactivé via Steps. */
+export const NoGoBack: Story = {
+  render: () => {
+    const [step, setStep] = useState(0);
+    return (
+      <div style={{ maxWidth: 640 }}>
+        <Wizard
+          currentStep={step}
+          onStepChange={setStep}
+          allowGoBack={false}
+          onComplete={() => alert('Soumis')}
+        >
+          <WizardStep title="Étape 1">
+            <p>
+              Cette story désactive le retour arrière via clic sur les marches complétées de Steps.
+              Le bouton « Précédent » reste actif.
+            </p>
+          </WizardStep>
+          <WizardStep title="Étape 2">
+            <p>Contenu étape 2.</p>
+          </WizardStep>
+          <WizardStep title="Étape 3">
+            <p>Dernière étape.</p>
+          </WizardStep>
+        </Wizard>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/Wizard/Wizard.test.tsx
+++ b/packages/react/src/components/Wizard/Wizard.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { Wizard, WizardStep } from './Wizard';
+
+function ControlledWizard({
+  initial = 0,
+  canProceed = true,
+  allowGoBack,
+  onComplete,
+}: {
+  initial?: number;
+  canProceed?: boolean;
+  allowGoBack?: boolean;
+  onComplete?: () => void;
+}) {
+  const [step, setStep] = useState(initial);
+  return (
+    <Wizard
+      currentStep={step}
+      onStepChange={setStep}
+      canProceed={canProceed}
+      allowGoBack={allowGoBack}
+      onComplete={onComplete}
+    >
+      <WizardStep title="Identité">
+        <p>Contenu identité</p>
+      </WizardStep>
+      <WizardStep title="Coordonnées">
+        <p>Contenu coordonnées</p>
+      </WizardStep>
+      <WizardStep title="Détails">
+        <p>Contenu détails</p>
+      </WizardStep>
+    </Wizard>
+  );
+}
+
+describe('Wizard', () => {
+  describe('rendu', () => {
+    it('rend la première étape par défaut', () => {
+      render(<ControlledWizard />);
+      expect(screen.getByText('Contenu identité')).toBeInTheDocument();
+      expect(screen.queryByText('Contenu coordonnées')).not.toBeInTheDocument();
+    });
+
+    it("rend un h2 avec le titre de l'étape active", () => {
+      render(<ControlledWizard />);
+      expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Identité');
+    });
+
+    it("rend Steps avec aria-current=step sur l'étape active", () => {
+      render(<ControlledWizard />);
+      // Steps rend une <ol> avec <li>; on vérifie aria-current sur l'item courant.
+      const currentItem = document.querySelector('[aria-current="step"]');
+      expect(currentItem).toHaveTextContent('Identité');
+    });
+
+    it('désactive le bouton Précédent sur la 1ère étape', () => {
+      render(<ControlledWizard />);
+      expect(screen.getByRole('button', { name: 'Précédent' })).toBeDisabled();
+    });
+
+    it("affiche le bouton Suivant tant qu'on n'est pas sur la dernière étape", () => {
+      render(<ControlledWizard />);
+      expect(screen.getByRole('button', { name: 'Suivant' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Soumettre' })).not.toBeInTheDocument();
+    });
+
+    it('affiche le bouton Soumettre sur la dernière étape', () => {
+      render(<ControlledWizard initial={2} />);
+      expect(screen.getByRole('button', { name: 'Soumettre' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Suivant' })).not.toBeInTheDocument();
+    });
+
+    it("throw quand aucun WizardStep n'est fourni", () => {
+      // On supprime le warning React inutile pour ce test.
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() =>
+        render(
+          <Wizard currentStep={0}>
+            <span>pas une étape</span>
+          </Wizard>,
+        ),
+      ).toThrow(/au moins un.*WizardStep/i);
+      spy.mockRestore();
+    });
+  });
+
+  describe('navigation', () => {
+    it('avance au clic sur Suivant', async () => {
+      const user = userEvent.setup();
+      render(<ControlledWizard />);
+      await user.click(screen.getByRole('button', { name: 'Suivant' }));
+      expect(screen.getByText('Contenu coordonnées')).toBeInTheDocument();
+    });
+
+    it('recule au clic sur Précédent', async () => {
+      const user = userEvent.setup();
+      render(<ControlledWizard initial={1} />);
+      await user.click(screen.getByRole('button', { name: 'Précédent' }));
+      expect(screen.getByText('Contenu identité')).toBeInTheDocument();
+    });
+
+    it('appelle onComplete au clic sur Soumettre', async () => {
+      const user = userEvent.setup();
+      const onComplete = vi.fn();
+      render(<ControlledWizard initial={2} onComplete={onComplete} />);
+      await user.click(screen.getByRole('button', { name: 'Soumettre' }));
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  describe('canProceed', () => {
+    it('désactive Suivant quand canProceed=false', () => {
+      render(<ControlledWizard canProceed={false} />);
+      expect(screen.getByRole('button', { name: 'Suivant' })).toBeDisabled();
+    });
+
+    it('désactive Soumettre quand canProceed=false sur la dernière étape', () => {
+      render(<ControlledWizard initial={2} canProceed={false} />);
+      expect(screen.getByRole('button', { name: 'Soumettre' })).toBeDisabled();
+    });
+
+    it("n'appelle pas onComplete si canProceed=false", async () => {
+      const user = userEvent.setup();
+      const onComplete = vi.fn();
+      render(<ControlledWizard initial={2} canProceed={false} onComplete={onComplete} />);
+      await user.click(screen.getByRole('button', { name: 'Soumettre' }));
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/components/Wizard/Wizard.tsx
+++ b/packages/react/src/components/Wizard/Wizard.tsx
@@ -1,0 +1,152 @@
+import { Children, forwardRef, isValidElement, type ReactElement, type ReactNode } from 'react';
+import { clsx } from 'clsx';
+import { Steps, type StepItem } from '../Steps/Steps.js';
+import { Button } from '../Button/Button.js';
+
+/**
+ * Wizard multi-étapes.
+ *
+ * Assemble Steps + contenu actif + actions Précédent / Suivant / Soumettre.
+ * Chaque étape est déclarée via un <WizardStep> enfant qui porte un titre,
+ * une description optionnelle, et son contenu (typiquement un <Form>).
+ *
+ * Validation : Ori ne pose aucune logique de validation. L'app la gère
+ * elle-même et désactive l'avancement via `canProceed` (boolean prop sur
+ * <Wizard>) quand l'étape courante n'est pas valide.
+ *
+ * Pas de skip / step direct par défaut : l'utilisateur peut revenir aux
+ * étapes complétées via Steps `clickable` activable côté props.
+ *
+ * a11y :
+ * - Steps porte aria-current="step" sur l'étape courante (cf. composant Steps)
+ * - chaque WizardStep est rendu dans un <section> avec aria-labelledby
+ *   pointant sur son titre
+ * - les boutons d'action sont des `<button>` standard
+ */
+
+export interface WizardStepProps {
+  /** Titre court de l'étape, affiché dans Steps et en h2 du contenu. */
+  title: string;
+  /** Description courte optionnelle (Steps). */
+  description?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Marqueur déclaratif d'une étape de Wizard. Doit être un enfant direct
+ * de <Wizard>. Le rendu effectif est piloté par le parent.
+ */
+export function WizardStep(_props: WizardStepProps): null {
+  return null;
+}
+WizardStep.displayName = 'WizardStep';
+
+export interface WizardProps {
+  /** Index 0-based de l'étape courante (contrôlé). */
+  currentStep: number;
+  onStepChange?: (index: number) => void;
+  /** Si false, le bouton Suivant est désactivé. Default: true. */
+  canProceed?: boolean;
+  /** Callback déclenché au clic sur Soumettre (sur la dernière étape). */
+  onComplete?: () => void;
+  /** Permet de re-cliquer sur une étape déjà complétée pour y revenir. Default: true. */
+  allowGoBack?: boolean;
+  /** Labels des boutons (i18n). */
+  previousLabel?: string;
+  nextLabel?: string;
+  submitLabel?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export const Wizard = forwardRef<HTMLDivElement, WizardProps>(function Wizard(
+  {
+    currentStep,
+    onStepChange,
+    canProceed = true,
+    onComplete,
+    allowGoBack = true,
+    previousLabel = 'Précédent',
+    nextLabel = 'Suivant',
+    submitLabel = 'Soumettre',
+    children,
+    className,
+  },
+  ref,
+) {
+  // Collecte des étapes via Children + filtrage des WizardStep
+  const stepElements = Children.toArray(children).filter(
+    (child): child is ReactElement<WizardStepProps> =>
+      isValidElement(child) &&
+      // @ts-expect-error - displayName peut ne pas être typé
+      (child.type === WizardStep || child.type?.displayName === 'WizardStep'),
+  );
+
+  if (stepElements.length === 0) {
+    throw new Error('Wizard doit contenir au moins un <WizardStep>.');
+  }
+
+  const clampedCurrent = Math.max(0, Math.min(currentStep, stepElements.length - 1));
+  const isFirst = clampedCurrent === 0;
+  const isLast = clampedCurrent === stepElements.length - 1;
+  const activeStep = stepElements[clampedCurrent];
+  // stepElements.length > 0 garanti par le throw plus haut, donc activeStep est défini.
+  if (!activeStep) {
+    throw new Error('Wizard : index courant hors limites.');
+  }
+
+  const stepsItems: StepItem[] = stepElements.map((el) => ({
+    title: el.props.title,
+    description: el.props.description,
+  }));
+
+  const goToPrevious = () => {
+    if (!isFirst) onStepChange?.(clampedCurrent - 1);
+  };
+
+  const goToNext = () => {
+    if (!isLast && canProceed) onStepChange?.(clampedCurrent + 1);
+  };
+
+  const handleSubmit = () => {
+    if (canProceed) onComplete?.();
+  };
+
+  // Garantir un id stable pour l'aria-labelledby de chaque section
+  const baseId = 'pf-wizard';
+
+  return (
+    <div ref={ref} className={clsx('ori-wizard', className)}>
+      <Steps
+        steps={stepsItems}
+        current={clampedCurrent}
+        clickable={allowGoBack}
+        onStepClick={(index) => onStepChange?.(index)}
+        className="ori-wizard__steps"
+      />
+      <section
+        className="ori-wizard__panel"
+        aria-labelledby={`${baseId}-step-title-${clampedCurrent}`}
+      >
+        <h2 id={`${baseId}-step-title-${clampedCurrent}`} className="ori-wizard__step-title">
+          {activeStep.props.title}
+        </h2>
+        <div className="ori-wizard__step-body">{activeStep.props.children}</div>
+      </section>
+      <div className="ori-wizard__actions">
+        <Button variant="secondary" onClick={goToPrevious} disabled={isFirst}>
+          {previousLabel}
+        </Button>
+        {isLast ? (
+          <Button onClick={handleSubmit} disabled={!canProceed}>
+            {submitLabel}
+          </Button>
+        ) : (
+          <Button onClick={goToNext} disabled={!canProceed}>
+            {nextLabel}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/packages/react/src/components/Wizard/index.ts
+++ b/packages/react/src/components/Wizard/index.ts
@@ -1,0 +1,2 @@
+export { Wizard, WizardStep } from './Wizard.js';
+export type { WizardProps, WizardStepProps } from './Wizard.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -33,6 +33,7 @@ export * from './components/EmptyState/index.js';
 export * from './components/AppShell/index.js';
 export * from './components/Form/index.js';
 export * from './components/LoginLayout/index.js';
+export * from './components/Wizard/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1863,6 +1863,43 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       textAlign: 'center',
     },
 
+    // ─── Wizard ─────────────────────────────────────────────────────────────
+    // Steps en haut + panneau de l'étape active + actions en pied. Espacement
+    // vertical aligné sur Form pour permettre une intégration cohérente.
+    '.ori-wizard': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.6'),
+    },
+    '.ori-wizard__steps': {
+      display: 'block',
+    },
+    '.ori-wizard__panel': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.4'),
+    },
+    '.ori-wizard__step-title': {
+      margin: '0',
+      fontSize: theme('fontSize.lg'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: v('text-primary'),
+    },
+    '.ori-wizard__step-body': {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+    '.ori-wizard__actions': {
+      display: 'flex',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      gap: theme('spacing.2'),
+      paddingTop: theme('spacing.4'),
+      borderTopWidth: '1px',
+      borderTopStyle: 'solid',
+      borderTopColor: v('border-subtle'),
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Cinquième Composition de la roadmap. Assemble Steps + contenu actif + actions Précédent / Suivant / Soumettre. Réutilise les Primitives existantes (Steps, Button) et les Compositions précédentes (Form / FormSection / FormField pour le contenu de chaque étape).

## API

\`\`\`tsx
<Wizard currentStep={step} onStepChange={setStep} canProceed={isStepValid} onComplete={submit}>
  <WizardStep title=\"Identité\" description=\"...\">
    <Form>…</Form>
  </WizardStep>
  <WizardStep title=\"Coordonnées\">…</WizardStep>
</Wizard>
\`\`\`

\`\`\`html
<ori-wizard
  [currentStep]=\"step\"
  [canProceed]=\"isStepValid\"
  (stepChange)=\"step = $event\"
  (complete)=\"submit()\"
>
  <ori-wizard-step title=\"Identité\">…</ori-wizard-step>
  <ori-wizard-step title=\"Coordonnées\">…</ori-wizard-step>
</ori-wizard>
\`\`\`

## Choix techniques

- **Validation laissée à l'app** : prop \`canProceed\` désactive Suivant / Soumettre. Cohérent avec Form (pas de logique de validation dans Ori).
- **React** : \`<WizardStep>\` est un marqueur déclaratif qui retourne null. Le parent collecte les props via \`React.Children\` et n'affiche que l'étape active.
- **Angular** : \`<ori-wizard-step>\` rend son contenu en permanence dans le DOM mais le masque via \`[hidden]\` quand non actif. Évite la perte de saisie Reactive Forms à chaque changement d'étape (différence assumée vs React où le contenu est démonté).

## a11y

- Steps porte \`aria-current=\"step\"\` sur l'étape courante
- Le panneau actif est dans un \`<section>\` avec \`aria-labelledby\` pointant sur son h2
- Actions standard \`<button>\`, désactivés via prop \`canProceed\` ou navigation impossible (Précédent en 1ère étape, Suivant en dernière)

## Tests

- 14 tests Vitest React (rendu, navigation, canProceed, onComplete, throw si pas d'étape) — 183/183 verts
- 3 stories par framework (Default avec validation, FiveSteps, NoGoBack)
- Build React + Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. Cinquième Composition sur 6. Reste DataTable (XL) qui clôt les Compositions.