### PR TITLE
feat(data-table): composition DataTable complet (React + Angular)

### DIFF
--- a/packages/angular/src/components/data-table/data-table.component.ts
+++ b/packages/angular/src/components/data-table/data-table.component.ts
@@ -1,0 +1,341 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  TemplateRef,
+  ViewChild,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LucideAngularModule, MoreVertical, Search } from 'lucide-angular';
+import {
+  OriTableComponent,
+  type OriTableColumn,
+  type OriTableSort,
+} from '../table/table.component';
+import { OriPaginationComponent } from '../pagination/pagination.component';
+import {
+  OriDropdownMenuComponent,
+  type OriDropdownMenuItem,
+} from '../dropdown-menu/dropdown-menu.component';
+
+type LucideIconData = typeof MoreVertical;
+
+let nextUid = 0;
+
+export interface OriDataTableColumn<TRow = Record<string, unknown>> extends OriTableColumn<TRow> {
+  /** Si true, cette colonne est incluse dans le filtre global. */
+  filterable?: boolean;
+  /** Fonction de comparaison custom pour le tri. Default : compare strings. */
+  sortFn?: (a: TRow, b: TRow) => number;
+}
+
+export interface OriDataTableRowAction {
+  id: string;
+  label: string;
+  icon?: LucideIconData;
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Insère un séparateur AVANT cet item dans le menu. */
+  separatorBefore?: boolean;
+}
+
+export interface OriDataTableRowActionEvent<TRow> {
+  action: string;
+  row: TRow;
+}
+
+/**
+ * DataTable : Table + Pagination + filtre global + actions de ligne.
+ *
+ * Composition au-dessus de Table, Pagination et DropdownMenu. Gère l'état
+ * (page courante, filtre, tri) en interne. Pour les très grosses tables
+ * server-paginées, utiliser directement <ori-table> + <ori-pagination> et
+ * piloter pagination/sort/filter côté app.
+ *
+ * Volontairement v1 :
+ * - tri sur une seule colonne (pas multi-tri)
+ * - filtre global texte uniquement (pas de filtres par colonne)
+ * - actions de ligne via DropdownMenu (3-dots) ; pas de checkbox sélection
+ */
+@Component({
+  selector: 'ori-data-table',
+  standalone: true,
+  imports: [
+    CommonModule,
+    LucideAngularModule,
+    OriTableComponent,
+    OriPaginationComponent,
+    OriDropdownMenuComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <div class="ori-data-table">
+      @if (globalFilter) {
+        <div class="ori-data-table__toolbar">
+          <label [attr.for]="filterInputId" class="ori-data-table__filter-label">
+            <span class="ori-data-table__filter-icon" aria-hidden="true">
+              <lucide-icon [img]="SearchIcon" [size]="16"></lucide-icon>
+            </span>
+            <input
+              [id]="filterInputId"
+              type="search"
+              class="ori-data-table__filter-input"
+              [placeholder]="filterPlaceholder"
+              [value]="query"
+              (input)="onFilterInput($event)"
+            />
+          </label>
+          <span class="ori-data-table__count" aria-live="polite">
+            {{ sortedFiltered.length }} résultat{{ sortedFiltered.length > 1 ? 's' : '' }}
+          </span>
+        </div>
+      }
+      <ori-table
+        [columns]="augmentedColumns"
+        [rows]="paginatedRows"
+        [sort]="sort"
+        [rowKey]="rowKey"
+        [loading]="loading"
+        [emptyMessage]="emptyMessage"
+        [caption]="caption"
+        (sortChange)="onSortChange($event)"
+      ></ori-table>
+      @if (!noPagination && totalPages > 1) {
+        <div class="ori-data-table__footer">
+          <ori-pagination
+            [page]="clampedPage"
+            [totalPages]="totalPages"
+            (pageChange)="onPageChange($event)"
+            ariaLabel="Pagination du tableau"
+          ></ori-pagination>
+        </div>
+      }
+      <ng-template #actionsTpl let-row>
+        @if (rowActions) {
+          @let actions = rowActions(row);
+          @if (actions.length > 0) {
+            <ori-dropdown-menu
+              [items]="actionsToMenuItems(actions)"
+              align="end"
+              [ariaLabel]="rowActionsLabel"
+              (select)="onMenuSelect($event, row)"
+            >
+              <button
+                type="button"
+                slot="trigger"
+                class="ori-data-table__row-actions-trigger"
+                [attr.aria-label]="rowActionsLabel"
+              >
+                <lucide-icon [img]="MoreVerticalIcon" [size]="16" aria-hidden="true"></lucide-icon>
+              </button>
+            </ori-dropdown-menu>
+          }
+        }
+      </ng-template>
+    </div>
+  `,
+})
+export class OriDataTableComponent<TRow = Record<string, unknown>> implements AfterViewInit {
+  @Input() set columns(value: OriDataTableColumn<TRow>[]) {
+    this._columns = value ?? [];
+    this.recompute();
+  }
+  get columns(): OriDataTableColumn<TRow>[] {
+    return this._columns;
+  }
+
+  @Input() set data(value: TRow[]) {
+    this._data = value ?? [];
+    this.recompute();
+  }
+  get data(): TRow[] {
+    return this._data;
+  }
+
+  @Input() rowKey: ((row: TRow, index: number) => string) | null = null;
+
+  @Input() globalFilter: boolean = true;
+  @Input() filterPlaceholder: string = 'Rechercher…';
+  @Input() filterFn: ((row: TRow, query: string) => boolean) | null = null;
+
+  @Input() pageSize: number = 10;
+  @Input() noPagination: boolean = false;
+
+  @Input() set rowActions(value: ((row: TRow) => OriDataTableRowAction[]) | null) {
+    this._rowActions = value;
+    this.recompute();
+  }
+  get rowActions(): ((row: TRow) => OriDataTableRowAction[]) | null {
+    return this._rowActions;
+  }
+
+  @Input() rowActionsLabel: string = 'Actions';
+
+  @Input() loading: boolean = false;
+  @Input() emptyMessage: string = 'Aucune donnée à afficher.';
+  @Input() caption: string = '';
+
+  @Output() rowAction = new EventEmitter<OriDataTableRowActionEvent<TRow>>();
+
+  @ViewChild('actionsTpl', { static: false })
+  protected actionsTpl?: TemplateRef<{ $implicit: TRow; index: number }>;
+
+  protected readonly SearchIcon: LucideIconData = Search;
+  protected readonly MoreVerticalIcon: LucideIconData = MoreVertical;
+
+  protected readonly filterInputId = `pf-data-table-filter-${++nextUid}`;
+
+  protected query: string = '';
+  protected page: number = 1;
+  protected sort: OriTableSort | null = null;
+
+  protected sortedFiltered: TRow[] = [];
+  protected paginatedRows: TRow[] = [];
+  protected augmentedColumns: OriTableColumn<TRow>[] = [];
+
+  private _columns: OriDataTableColumn<TRow>[] = [];
+  private _data: TRow[] = [];
+  private _rowActions: ((row: TRow) => OriDataTableRowAction[]) | null = null;
+
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  ngAfterViewInit(): void {
+    // Une fois la TemplateRef disponible, on rebranche les colonnes augmentées
+    // pour que la cellule d'actions utilise le template du dropdown.
+    this.recompute();
+  }
+
+  protected get totalPages(): number {
+    if (this.noPagination) return 1;
+    return Math.max(1, Math.ceil(this.sortedFiltered.length / this.pageSize));
+  }
+
+  protected get clampedPage(): number {
+    return Math.min(this.page, this.totalPages);
+  }
+
+  protected onFilterInput(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    this.query = target.value;
+    this.page = 1;
+    this.recompute();
+  }
+
+  protected onSortChange(newSort: OriTableSort): void {
+    if (this.sort && this.sort.column === newSort.column) {
+      // Toggle : asc → desc → off
+      if (this.sort.direction === 'asc') {
+        this.sort = { column: newSort.column, direction: 'desc' };
+      } else {
+        this.sort = null;
+      }
+    } else {
+      this.sort = newSort;
+    }
+    this.recompute();
+  }
+
+  protected onPageChange(page: number): void {
+    this.page = page;
+    this.recompute();
+  }
+
+  protected onMenuSelect(item: OriDropdownMenuItem, row: TRow): void {
+    if (!item.id) return;
+    this.rowAction.emit({ action: item.id, row });
+  }
+
+  protected actionsToMenuItems(actions: OriDataTableRowAction[]): OriDropdownMenuItem[] {
+    const items: OriDropdownMenuItem[] = [];
+    actions.forEach((a, idx) => {
+      if (a.separatorBefore && idx > 0) {
+        items.push({ separator: true });
+      }
+      items.push({
+        id: a.id,
+        label: a.label,
+        icon: a.icon,
+        destructive: a.destructive,
+        disabled: a.disabled,
+      });
+    });
+    return items;
+  }
+
+  private recompute(): void {
+    // Filtrage
+    const filterableKeys = this._columns.filter((c) => c.filterable).map((c) => c.key);
+    let filtered: TRow[];
+    if (!this.query) {
+      filtered = this._data.slice();
+    } else if (this.filterFn) {
+      filtered = this._data.filter((row) => this.filterFn!(row, this.query));
+    } else {
+      const q = this.query.toLocaleLowerCase();
+      filtered = this._data.filter((row) =>
+        filterableKeys.some((key) => {
+          const value = (row as Record<string, unknown>)[key];
+          return value != null && String(value).toLocaleLowerCase().includes(q);
+        }),
+      );
+    }
+
+    // Tri
+    if (this.sort) {
+      const col = this._columns.find((c) => c.key === this.sort!.column);
+      if (col) {
+        const direction = this.sort.direction;
+        const sortFn = col.sortFn;
+        filtered = filtered.slice().sort((a, b) => {
+          let cmp: number;
+          if (sortFn) {
+            cmp = sortFn(a, b);
+          } else {
+            const aVal = (a as Record<string, unknown>)[col.key];
+            const bVal = (b as Record<string, unknown>)[col.key];
+            const aStr = aVal == null ? '' : String(aVal);
+            const bStr = bVal == null ? '' : String(bVal);
+            cmp = aStr.localeCompare(bStr);
+          }
+          return direction === 'desc' ? -cmp : cmp;
+        });
+      }
+    }
+
+    this.sortedFiltered = filtered;
+
+    // Pagination
+    if (this.noPagination) {
+      this.paginatedRows = filtered;
+    } else {
+      const start = (this.clampedPage - 1) * this.pageSize;
+      this.paginatedRows = filtered.slice(start, start + this.pageSize);
+    }
+
+    // Colonnes augmentées : ajout d'une colonne actions si rowActions fourni,
+    // utilisant la TemplateRef interne actionsTpl pour rendre le DropdownMenu.
+    if (this._rowActions) {
+      this.augmentedColumns = [
+        ...this._columns,
+        {
+          key: '__actions',
+          label: '',
+          width: '3rem',
+          align: 'end',
+          cellTemplate: this.actionsTpl,
+        },
+      ];
+    } else {
+      this.augmentedColumns = this._columns.slice();
+    }
+
+    this.cdr.markForCheck();
+  }
+}

--- a/packages/angular/src/components/data-table/data-table.stories.ts
+++ b/packages/angular/src/components/data-table/data-table.stories.ts
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { Edit, Eye, Trash2, Mail, Archive } from 'lucide-angular';
+import {
+  OriDataTableComponent,
+  type OriDataTableColumn,
+  type OriDataTableRowAction,
+} from './data-table.component';
+import { OriTagComponent } from '../tag/tag.component';
+
+interface Demande {
+  id: string;
+  numero: string;
+  objet: string;
+  service: string;
+  statut: 'envoyee' | 'en-cours' | 'cloturee' | 'rejetee';
+  date: string;
+}
+
+const objets = [
+  'Demande de carte grise',
+  'Demande de permis maritime',
+  'Inscription scolaire',
+  'Subvention culturelle',
+  "Renouvellement de pièce d'identité",
+  'Déclaration fiscale',
+  "Demande d'extrait d'acte",
+  "Réservation d'équipement sportif",
+];
+
+const demandes: Demande[] = Array.from({ length: 47 }, (_, i) => {
+  const statuts: Demande['statut'][] = ['envoyee', 'en-cours', 'cloturee', 'rejetee'];
+  const services = ['DGI', 'DASS', 'DPAC', 'DTT', 'DRE', 'DAM', 'DJS'];
+  return {
+    id: `d-${i + 1}`,
+    numero: `DEM-2026-${(1000 + i).toString()}`,
+    objet: objets[i % objets.length] ?? 'Demande administrative',
+    service: services[i % services.length] ?? 'DGI',
+    statut: statuts[i % statuts.length] ?? 'envoyee',
+    date: `2026-${String((i % 12) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
+  };
+});
+
+const columns: OriDataTableColumn<Demande>[] = [
+  { key: 'numero', label: 'Numéro', sortable: true, filterable: true, width: '12rem' },
+  { key: 'objet', label: 'Objet', sortable: true, filterable: true },
+  { key: 'service', label: 'Service', sortable: true, filterable: true, width: '6rem' },
+  { key: 'statut', label: 'Statut', sortable: true, width: '8rem' },
+  { key: 'date', label: 'Date', sortable: true, width: '8rem' },
+];
+
+const rowActions = (row: Demande): OriDataTableRowAction[] => [
+  { id: 'view', label: 'Voir le détail', icon: Eye },
+  { id: 'edit', label: 'Modifier', icon: Edit, disabled: row.statut === 'cloturee' },
+  { id: 'mail', label: 'Notifier le demandeur', icon: Mail },
+  { id: 'archive', label: 'Archiver', icon: Archive, separatorBefore: true },
+  {
+    id: 'delete',
+    label: 'Supprimer',
+    icon: Trash2,
+    destructive: true,
+    disabled: row.statut === 'cloturee',
+  },
+];
+
+const meta: Meta<OriDataTableComponent<Demande>> = {
+  title: 'Composants/Data/DataTable',
+  component: OriDataTableComponent,
+  tags: ['autodocs'],
+  decorators: [moduleMetadata({ imports: [OriDataTableComponent, OriTagComponent] })],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Composition Table + Pagination + filtre + actions de ligne. Pour les très grosses tables server-paginées, utiliser <ori-table> + <ori-pagination> directement et piloter pagination/sort/filter côté app.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<OriDataTableComponent<Demande>>;
+
+export const Default: Story = {
+  render: () => ({
+    props: {
+      columns,
+      data: demandes,
+      rowKey: (row: Demande) => row.id,
+      pageSize: 10,
+      rowActions,
+      onRowAction: (event: { action: string; row: Demande }) => {
+        // eslint-disable-next-line no-console
+        console.log('Action', event.action, 'sur', event.row.numero);
+      },
+    },
+    template: `
+      <ori-data-table
+        [columns]="columns"
+        [data]="data"
+        [rowKey]="rowKey"
+        [pageSize]="pageSize"
+        [rowActions]="rowActions"
+        (rowAction)="onRowAction($event)"
+      ></ori-data-table>
+    `,
+  }),
+};
+
+export const ReadOnly: Story = {
+  render: () => ({
+    props: {
+      columns,
+      data: demandes.slice(0, 15),
+      rowKey: (row: Demande) => row.id,
+      pageSize: 5,
+    },
+    template: `
+      <ori-data-table
+        [columns]="columns"
+        [data]="data"
+        [rowKey]="rowKey"
+        [pageSize]="pageSize"
+      ></ori-data-table>
+    `,
+  }),
+};
+
+export const NoPagination: Story = {
+  render: () => ({
+    props: {
+      columns,
+      data: demandes.slice(0, 8),
+      rowKey: (row: Demande) => row.id,
+      rowActions,
+    },
+    template: `
+      <ori-data-table
+        [columns]="columns"
+        [data]="data"
+        [rowKey]="rowKey"
+        [noPagination]="true"
+        [rowActions]="rowActions"
+      ></ori-data-table>
+    `,
+  }),
+};
+
+export const Loading: Story = {
+  render: () => ({
+    props: {
+      columns,
+      rowKey: (row: Demande) => row.id,
+    },
+    template: `
+      <ori-data-table
+        [columns]="columns"
+        [data]="[]"
+        [rowKey]="rowKey"
+        [loading]="true"
+      ></ori-data-table>
+    `,
+  }),
+};

--- a/packages/angular/src/components/data-table/index.ts
+++ b/packages/angular/src/components/data-table/index.ts
@@ -1,0 +1,6 @@
+export {
+  OriDataTableComponent,
+  type OriDataTableColumn,
+  type OriDataTableRowAction,
+  type OriDataTableRowActionEvent,
+} from './data-table.component';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -34,6 +34,7 @@ export * from './components/app-shell';
 export * from './components/form';
 export * from './components/login-layout';
 export * from './components/wizard';
+export * from './components/data-table';
 export * from './components/timeline';
 export * from './components/toast';
 export * from './components/notification';

--- a/packages/react/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/react/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DataTable, type DataTableColumn, type DataTableRowAction } from './DataTable.js';
+import { Tag } from '../Tag/Tag.js';
+import { Edit, Eye, Trash2, Mail, Archive } from 'lucide-react';
+
+interface Demande {
+  id: string;
+  numero: string;
+  objet: string;
+  service: string;
+  statut: 'envoyee' | 'en-cours' | 'cloturee' | 'rejetee';
+  date: string;
+}
+
+const demandes: Demande[] = Array.from({ length: 47 }, (_, i) => {
+  const statuts: Demande['statut'][] = ['envoyee', 'en-cours', 'cloturee', 'rejetee'];
+  const statutsLabel = ['envoyée', 'en cours', 'clôturée', 'rejetée'];
+  const services = ['DGI', 'DASS', 'DPAC', 'DTT', 'DRE', 'DAM', 'DJS'];
+  const objets = [
+    'Demande de carte grise',
+    'Demande de permis maritime',
+    'Inscription scolaire',
+    'Subvention culturelle',
+    "Renouvellement de pièce d'identité",
+    'Déclaration fiscale',
+    "Demande d'extrait d'acte",
+    "Réservation d'équipement sportif",
+  ];
+  return {
+    id: `d-${i + 1}`,
+    numero: `DEM-2026-${(1000 + i).toString()}`,
+    objet: objets[i % objets.length] ?? 'Demande administrative',
+    service: services[i % services.length] ?? 'DGI',
+    statut: statuts[i % statuts.length] ?? 'envoyee',
+    date: `2026-${String((i % 12) + 1).padStart(2, '0')}-${String((i % 28) + 1).padStart(2, '0')}`,
+  };
+});
+
+const statutVariant: Record<Demande['statut'], 'info' | 'warning' | 'success' | 'danger'> = {
+  envoyee: 'info',
+  'en-cours': 'warning',
+  cloturee: 'success',
+  rejetee: 'danger',
+};
+const statutLabel: Record<Demande['statut'], string> = {
+  envoyee: 'Envoyée',
+  'en-cours': 'En cours',
+  cloturee: 'Clôturée',
+  rejetee: 'Rejetée',
+};
+
+const columns: DataTableColumn<Demande>[] = [
+  { key: 'numero', label: 'Numéro', sortable: true, filterable: true, width: '12rem' },
+  { key: 'objet', label: 'Objet', sortable: true, filterable: true },
+  { key: 'service', label: 'Service', sortable: true, filterable: true, width: '6rem' },
+  {
+    key: 'statut',
+    label: 'Statut',
+    sortable: true,
+    width: '8rem',
+    render: (row) => <Tag variant={statutVariant[row.statut]}>{statutLabel[row.statut]}</Tag>,
+  },
+  { key: 'date', label: 'Date', sortable: true, width: '8rem' },
+];
+
+const rowActions = (row: Demande): DataTableRowAction[] => [
+  { id: 'view', label: 'Voir le détail', icon: <Eye size={16} /> },
+  { id: 'edit', label: 'Modifier', icon: <Edit size={16} />, disabled: row.statut === 'cloturee' },
+  { id: 'mail', label: 'Notifier le demandeur', icon: <Mail size={16} /> },
+  { id: 'archive', label: 'Archiver', icon: <Archive size={16} />, separatorBefore: true },
+  {
+    id: 'delete',
+    label: 'Supprimer',
+    icon: <Trash2 size={16} />,
+    destructive: true,
+    disabled: row.statut === 'cloturee',
+  },
+];
+
+const meta = {
+  title: 'Composants/Data/DataTable',
+  component: DataTable,
+  tags: ['autodocs'],
+  parameters: { layout: 'padded' },
+} satisfies Meta<typeof DataTable<Demande>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Cas standard : 47 demandes, filtre + tri + actions + pagination 10 par page. */
+export const Default: Story = {
+  args: {
+    columns,
+    data: demandes,
+    rowKey: (row) => row.id,
+    pageSize: 10,
+    rowActions,
+    onRowAction: (action, row) => {
+      // eslint-disable-next-line no-console
+      console.log('Action', action, 'sur', row.numero);
+    },
+  },
+};
+
+/** Sans actions de ligne : table consultative. */
+export const ReadOnly: Story = {
+  args: {
+    columns,
+    data: demandes.slice(0, 15),
+    rowKey: (row) => row.id,
+    pageSize: 5,
+  },
+};
+
+/** Sans pagination : affichage compact pour listes courtes (≤ 20 lignes typiquement). */
+export const NoPagination: Story = {
+  args: {
+    columns,
+    data: demandes.slice(0, 8),
+    rowKey: (row) => row.id,
+    noPagination: true,
+    rowActions,
+  },
+};
+
+/** État de chargement. */
+export const Loading: Story = {
+  args: {
+    columns,
+    data: [],
+    rowKey: (row) => row.id,
+    loading: true,
+  },
+};
+
+/** Aucune donnée correspondante. */
+export const EmptyAfterFilter: Story = {
+  args: {
+    columns,
+    data: demandes.slice(0, 5),
+    rowKey: (row) => row.id,
+    emptyMessage: "Aucune demande ne correspond aux critères. Essayez d'élargir votre recherche.",
+  },
+  render: (args) => (
+    <div>
+      <p style={{ marginTop: 0 }}>
+        Tapez un texte qui ne correspond à aucune demande pour voir l'état vide (par exemple « xyz
+        »).
+      </p>
+      <DataTable {...args} />
+    </div>
+  ),
+};

--- a/packages/react/src/components/DataTable/DataTable.test.tsx
+++ b/packages/react/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DataTable, type DataTableColumn, type DataTableRowAction } from './DataTable';
+
+interface Row {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+const data: Row[] = [
+  { id: '1', name: 'Alice', email: 'alice@example.com', role: 'admin' },
+  { id: '2', name: 'Bob', email: 'bob@example.com', role: 'editor' },
+  { id: '3', name: 'Charlie', email: 'charlie@example.com', role: 'viewer' },
+  { id: '4', name: 'Diana', email: 'diana@example.com', role: 'editor' },
+  { id: '5', name: 'Eve', email: 'eve@example.com', role: 'admin' },
+];
+
+const columns: DataTableColumn<Row>[] = [
+  { key: 'name', label: 'Nom', sortable: true, filterable: true },
+  { key: 'email', label: 'Email', filterable: true },
+  { key: 'role', label: 'Rôle', sortable: true },
+];
+
+describe('DataTable', () => {
+  describe('rendu', () => {
+    it('rend une table avec les colonnes et toutes les lignes (pageSize >= data.length)', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={20} />);
+      expect(screen.getByRole('columnheader', { name: 'Nom' })).toBeInTheDocument();
+      // 5 lignes de données + 1 row de header
+      expect(screen.getAllByRole('row')).toHaveLength(6);
+    });
+
+    it('affiche le compteur de résultats', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} />);
+      expect(screen.getByText(/5 résultats/i)).toBeInTheDocument();
+    });
+
+    it('affiche un input de filtre par défaut', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} />);
+      expect(screen.getByPlaceholderText(/rechercher/i)).toBeInTheDocument();
+    });
+
+    it('masque le filtre si globalFilter=false', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} globalFilter={false} />);
+      expect(screen.queryByPlaceholderText(/rechercher/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('filtrage', () => {
+    it('filtre les lignes au texte saisi', async () => {
+      const user = userEvent.setup();
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={20} />);
+      await user.type(screen.getByPlaceholderText(/rechercher/i), 'alice');
+      expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    });
+
+    it('ne filtre que sur les colonnes filterable=true', async () => {
+      const user = userEvent.setup();
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={20} />);
+      // 'admin' est uniquement dans la colonne 'role' qui n'est pas filterable
+      await user.type(screen.getByPlaceholderText(/rechercher/i), 'admin');
+      // Aucune ligne ne matche : Table rend header + 1 ligne "vide" pour l'emptyMessage.
+      expect(screen.getByText(/aucune donnée/i)).toBeInTheDocument();
+    });
+
+    it('affiche emptyMessage quand aucune ligne ne correspond', async () => {
+      const user = userEvent.setup();
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          rowKey={(r) => r.id}
+          emptyMessage="Aucun résultat custom"
+        />,
+      );
+      await user.type(screen.getByPlaceholderText(/rechercher/i), 'xyz');
+      expect(screen.getByText('Aucun résultat custom')).toBeInTheDocument();
+    });
+  });
+
+  describe('tri', () => {
+    it("trie au clic sur l'en-tête d'une colonne sortable", async () => {
+      const user = userEvent.setup();
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={20} />);
+      // Premier clic = asc → Alice en tête
+      await user.click(screen.getByRole('button', { name: 'Nom' }));
+      const rowsAfter = screen.getAllByRole('row');
+      // index 1 = première ligne après header
+      expect(within(rowsAfter[1]!).getByText('Alice')).toBeInTheDocument();
+    });
+
+    it('toggle asc → desc → off', async () => {
+      const user = userEvent.setup();
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={20} />);
+      const trigger = screen.getByRole('button', { name: 'Nom' });
+      await user.click(trigger); // asc
+      await user.click(trigger); // desc → Eve en tête
+      let rows = screen.getAllByRole('row');
+      expect(within(rows[1]!).getByText('Eve')).toBeInTheDocument();
+      await user.click(trigger); // off → ordre original (Alice en tête car premier)
+      rows = screen.getAllByRole('row');
+      expect(within(rows[1]!).getByText('Alice')).toBeInTheDocument();
+    });
+  });
+
+  describe('pagination', () => {
+    it('paginé : seules pageSize lignes sont visibles', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={2} />);
+      // 2 lignes + header
+      expect(screen.getAllByRole('row')).toHaveLength(3);
+      // 5 / 2 = 3 pages → la pagination est visible
+      expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument();
+    });
+
+    it('noPagination affiche toutes les lignes et masque la pagination', () => {
+      render(<DataTable columns={columns} data={data} rowKey={(r) => r.id} noPagination />);
+      expect(screen.getAllByRole('row')).toHaveLength(6);
+      expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('actions de ligne', () => {
+    const rowActions = (row: Row): DataTableRowAction[] => [
+      { id: 'edit', label: 'Modifier' },
+      { id: 'delete', label: 'Supprimer', destructive: true },
+    ];
+
+    it("rend un bouton d'actions par ligne quand rowActions est fourni", () => {
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          rowKey={(r) => r.id}
+          rowActions={rowActions}
+          pageSize={2}
+        />,
+      );
+      const actions = screen.getAllByRole('button', { name: 'Actions' });
+      expect(actions).toHaveLength(2); // une par ligne visible
+    });
+
+    it('ouvre le menu et appelle onRowAction au clic sur une action', async () => {
+      const user = userEvent.setup();
+      const onRowAction = vi.fn();
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          rowKey={(r) => r.id}
+          rowActions={rowActions}
+          onRowAction={onRowAction}
+          pageSize={1}
+        />,
+      );
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Supprimer' }));
+      expect(onRowAction).toHaveBeenCalledWith('delete', data[0]);
+    });
+  });
+});

--- a/packages/react/src/components/DataTable/DataTable.tsx
+++ b/packages/react/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,301 @@
+import { forwardRef, useId, useMemo, useState, type ReactNode } from 'react';
+import { clsx } from 'clsx';
+import { MoreVertical, Search } from 'lucide-react';
+import { Table, type TableColumn, type TableSort, type SortDirection } from '../Table/Table.js';
+import { Pagination } from '../Pagination/Pagination.js';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from '../DropdownMenu/DropdownMenu.js';
+
+/**
+ * DataTable : Table + Pagination + filtre global + actions de ligne.
+ *
+ * Composition au-dessus de Table, Pagination et DropdownMenu. Gère l'état
+ * (page courante, filtre, tri) en interne par défaut, ou de façon contrôlée
+ * via les props `page` / `onPageChange` / `sort` / `onSortChange` /
+ * `globalFilter` / `onGlobalFilterChange` si l'app veut piloter elle-même.
+ *
+ * Volontairement v1 :
+ * - tri sur une seule colonne (pas multi-tri)
+ * - filtre global texte uniquement (pas de filtres par colonne)
+ * - actions de ligne via DropdownMenu (3-dots) ; pas de checkbox sélection
+ *
+ * Filtre global : applique un `String(value).toLocaleLowerCase().includes(query)`
+ * sur les colonnes marquées `filterable: true`. Override via la prop
+ * `filterFn` pour des règles métier (recherche fuzzy, multi-mots, etc.).
+ *
+ * Tri : par défaut, tri lexicographique sur la valeur retournée par
+ * l'accesseur de colonne (`render` ou `row[key]` si pas de render). Override
+ * via la prop `sortFn` par colonne dans `extendedColumns`.
+ */
+
+export interface DataTableColumn<TRow> extends TableColumn<TRow> {
+  /** Si true, cette colonne est incluse dans le filtre global. */
+  filterable?: boolean;
+  /** Fonction de comparaison custom pour le tri. Default : compare strings. */
+  sortFn?: (a: TRow, b: TRow) => number;
+}
+
+export interface DataTableRowAction {
+  id: string;
+  label: ReactNode;
+  icon?: ReactNode;
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Insère un séparateur AVANT cet item dans le menu. */
+  separatorBefore?: boolean;
+}
+
+export interface DataTableProps<TRow> {
+  columns: DataTableColumn<TRow>[];
+  data: TRow[];
+  /** Identifiant unique d'une row (pour les keys et les actions). */
+  rowKey: (row: TRow) => string;
+
+  /** Affiche un input de filtre global au-dessus de la table. Default: true. */
+  globalFilter?: boolean;
+  /** Placeholder de l'input de filtre. */
+  filterPlaceholder?: string;
+  /** Override de la fonction de filtrage. Default : includes insensible casse. */
+  filterFn?: (row: TRow, query: string) => boolean;
+
+  /** Nombre de lignes par page. Default: 10. */
+  pageSize?: number;
+  /** Désactive la pagination (affiche toutes les lignes). */
+  noPagination?: boolean;
+
+  /** Liste d'actions disponibles par ligne (3-dots menu). */
+  rowActions?: (row: TRow) => DataTableRowAction[];
+  /** Callback déclenché au clic sur une action de ligne. */
+  onRowAction?: (action: string, row: TRow) => void;
+  /** Label aria-label du bouton 3-dots. */
+  rowActionsLabel?: string;
+
+  /** Texte affiché quand aucune ligne ne correspond après filtrage. */
+  emptyMessage?: ReactNode;
+  /** État de chargement (passé à Table). */
+  loading?: boolean;
+  /** Caption de la table (pour les SR). */
+  caption?: ReactNode;
+
+  className?: string;
+}
+
+const defaultFilter = <TRow,>(
+  row: TRow,
+  query: string,
+  filterableKeys: (keyof TRow | string)[],
+): boolean => {
+  if (!query) return true;
+  const q = query.toLocaleLowerCase();
+  return filterableKeys.some((key) => {
+    const value = (row as Record<string, unknown>)[key as string];
+    if (value == null) return false;
+    return String(value).toLocaleLowerCase().includes(q);
+  });
+};
+
+export const DataTable = forwardRef(function DataTable<TRow>(
+  {
+    columns,
+    data,
+    rowKey,
+    globalFilter = true,
+    filterPlaceholder = 'Rechercher…',
+    filterFn,
+    pageSize = 10,
+    noPagination,
+    rowActions,
+    onRowAction,
+    rowActionsLabel = 'Actions',
+    emptyMessage = 'Aucune donnée à afficher.',
+    loading,
+    caption,
+    className,
+  }: DataTableProps<TRow>,
+  ref: React.Ref<HTMLDivElement>,
+) {
+  const reactId = useId();
+  const filterInputId = `pf-data-table-filter-${reactId}`;
+
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<TableSort | undefined>(undefined);
+
+  // Filtrage
+  const filterableKeys = useMemo(
+    () => columns.filter((c) => c.filterable).map((c) => c.key),
+    [columns],
+  );
+  const effectiveFilter =
+    filterFn ?? ((row: TRow, q: string) => defaultFilter(row, q, filterableKeys));
+
+  const filtered = useMemo(() => {
+    if (!query) return data;
+    return data.filter((row) => effectiveFilter(row, query));
+  }, [data, query, effectiveFilter]);
+
+  // Tri
+  const sorted = useMemo(() => {
+    if (!sort) return filtered;
+    const col = columns.find((c) => c.key === sort.column);
+    if (!col) return filtered;
+    const sortFn = (col as DataTableColumn<TRow>).sortFn;
+    const copy = [...filtered];
+    copy.sort((a, b) => {
+      let cmp: number;
+      if (sortFn) {
+        cmp = sortFn(a, b);
+      } else {
+        const aVal = (a as Record<string, unknown>)[col.key];
+        const bVal = (b as Record<string, unknown>)[col.key];
+        const aStr = aVal == null ? '' : String(aVal);
+        const bStr = bVal == null ? '' : String(bVal);
+        cmp = aStr.localeCompare(bStr);
+      }
+      return sort.direction === 'desc' ? -cmp : cmp;
+    });
+    return copy;
+  }, [filtered, sort, columns]);
+
+  // Pagination
+  const totalPages = noPagination ? 1 : Math.max(1, Math.ceil(sorted.length / pageSize));
+  const clampedPage = Math.min(page, totalPages);
+  const paginated = useMemo(() => {
+    if (noPagination) return sorted;
+    const start = (clampedPage - 1) * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, clampedPage, pageSize, noPagination]);
+
+  // Reset page si le filtre/tri change et qu'on dépasse le total
+  if (clampedPage !== page && totalPages > 0) {
+    setPage(clampedPage);
+  }
+
+  const handleSortChange = (newSort: TableSort) => {
+    // Toggle : asc → desc → off
+    if (sort?.column === newSort.column) {
+      const next: SortDirection | undefined = sort.direction === 'asc' ? 'desc' : undefined;
+      setSort(next ? { column: newSort.column, direction: next } : undefined);
+    } else {
+      setSort(newSort);
+    }
+  };
+
+  // Si rowActions fourni, ajoute une colonne d'actions à droite
+  const augmentedColumns: TableColumn<TRow>[] = useMemo(() => {
+    if (!rowActions) return columns;
+    const actionsColumn: TableColumn<TRow> = {
+      key: '__actions',
+      label: '',
+      width: '3rem',
+      align: 'end',
+      render: (row) => {
+        const actions = rowActions(row);
+        if (!actions.length) return null;
+        return (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="ori-data-table__row-actions-trigger"
+                aria-label={rowActionsLabel}
+              >
+                <MoreVertical size={16} aria-hidden="true" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {actions.map((a, idx) => (
+                <DataTableActionItem
+                  key={a.id}
+                  action={a}
+                  onSelect={() => onRowAction?.(a.id, row)}
+                  separatorBefore={a.separatorBefore && idx > 0}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      },
+    };
+    return [...columns, actionsColumn];
+  }, [columns, rowActions, onRowAction, rowActionsLabel]);
+
+  return (
+    <div ref={ref} className={clsx('ori-data-table', className)}>
+      {globalFilter && (
+        <div className="ori-data-table__toolbar">
+          <label htmlFor={filterInputId} className="ori-data-table__filter-label">
+            <span className="ori-data-table__filter-icon" aria-hidden="true">
+              <Search size={16} />
+            </span>
+            <input
+              id={filterInputId}
+              type="search"
+              className="ori-data-table__filter-input"
+              placeholder={filterPlaceholder}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setPage(1);
+              }}
+            />
+          </label>
+          <span className="ori-data-table__count" aria-live="polite">
+            {sorted.length} résultat{sorted.length > 1 ? 's' : ''}
+          </span>
+        </div>
+      )}
+      <Table
+        columns={augmentedColumns}
+        rows={paginated}
+        rowKey={rowKey}
+        sort={sort}
+        onSortChange={handleSortChange}
+        loading={loading}
+        emptyMessage={emptyMessage}
+        caption={caption}
+      />
+      {!noPagination && totalPages > 1 && (
+        <div className="ori-data-table__footer">
+          <Pagination
+            page={clampedPage}
+            totalPages={totalPages}
+            onPageChange={setPage}
+            aria-label="Pagination du tableau"
+          />
+        </div>
+      )}
+    </div>
+  );
+}) as <TRow>(
+  props: DataTableProps<TRow> & { ref?: React.Ref<HTMLDivElement> },
+) => React.ReactElement;
+
+function DataTableActionItem({
+  action,
+  onSelect,
+  separatorBefore,
+}: {
+  action: DataTableRowAction;
+  onSelect: () => void;
+  separatorBefore?: boolean;
+}) {
+  return (
+    <>
+      {separatorBefore && <DropdownMenuSeparator />}
+      <DropdownMenuItem
+        icon={action.icon}
+        destructive={action.destructive}
+        disabled={action.disabled}
+        onSelect={onSelect}
+      >
+        {action.label}
+      </DropdownMenuItem>
+    </>
+  );
+}

--- a/packages/react/src/components/DataTable/index.ts
+++ b/packages/react/src/components/DataTable/index.ts
@@ -1,0 +1,2 @@
+export { DataTable } from './DataTable.js';
+export type { DataTableColumn, DataTableProps, DataTableRowAction } from './DataTable.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,6 +34,7 @@ export * from './components/AppShell/index.js';
 export * from './components/Form/index.js';
 export * from './components/LoginLayout/index.js';
 export * from './components/Wizard/index.js';
+export * from './components/DataTable/index.js';
 export * from './components/Timeline/index.js';
 export * from './components/Toast/index.js';
 export * from './components/Notification/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1900,6 +1900,97 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       borderTopColor: v('border-subtle'),
     },
 
+    // ─── DataTable ──────────────────────────────────────────────────────────
+    // Toolbar avec filtre + compteur, table existante .ori-table en dessous,
+    // pagination en pied. Bouton 3-dots dans la dernière colonne pour les
+    // actions de ligne (rendu via DropdownMenu).
+    '.ori-data-table': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme('spacing.3'),
+    },
+    '.ori-data-table__toolbar': {
+      display: 'flex',
+      flexWrap: 'wrap',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme('spacing.3'),
+    },
+    '.ori-data-table__filter-label': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme('spacing.2'),
+      flex: '1 1 auto',
+      minWidth: '14rem',
+      maxWidth: '24rem',
+      paddingInline: theme('spacing.3'),
+      paddingBlock: theme('spacing.2'),
+      backgroundColor: v('surface-base'),
+      borderRadius: theme('borderRadius.md'),
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: v('border-default'),
+      transitionProperty: 'border-color, box-shadow',
+      transitionDuration: theme('transitionDuration.fast'),
+      transitionTimingFunction: theme('transitionTimingFunction.standard'),
+      '&:focus-within': {
+        borderColor: v('border-focus'),
+        boxShadow: `0 0 0 3px ${v('brand-primary-subtle')}`,
+      },
+    },
+    '.ori-data-table__filter-icon': {
+      display: 'inline-flex',
+      color: v('text-muted'),
+      lineHeight: '0',
+      flexShrink: '0',
+    },
+    '.ori-data-table__filter-input': {
+      flex: '1 1 auto',
+      minWidth: '0',
+      border: 'none',
+      outline: 'none',
+      backgroundColor: 'transparent',
+      fontFamily: theme('fontFamily.sans'),
+      fontSize: theme('fontSize.sm'),
+      color: v('text-primary'),
+      '&::placeholder': { color: v('text-muted') },
+      // Retire la croix du search natif (esthétique inégale entre browsers)
+      '&::-webkit-search-cancel-button': {
+        WebkitAppearance: 'none',
+      },
+    },
+    '.ori-data-table__count': {
+      fontSize: theme('fontSize.sm'),
+      color: v('text-secondary'),
+      whiteSpace: 'nowrap',
+    },
+    '.ori-data-table__footer': {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      paddingTop: theme('spacing.2'),
+    },
+    '.ori-data-table__row-actions-trigger': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '2rem',
+      height: '2rem',
+      padding: '0',
+      background: 'transparent',
+      border: 'none',
+      borderRadius: theme('borderRadius.sm'),
+      color: v('text-secondary'),
+      cursor: 'pointer',
+      '&:hover': {
+        backgroundColor: v('surface-muted'),
+        color: v('text-primary'),
+      },
+      '&:focus-visible': {
+        outline: `2px solid ${v('border-focus')}`,
+        outlineOffset: '2px',
+      },
+    },
+
     // ─── Timeline ──────────────────────────────────────────────────────────
     '.ori-timeline': {
       display: 'flex',


### PR DESCRIPTION
## Contexte

Sixième et dernière Composition de la roadmap. Wrapper Table + Pagination + filtre global + actions de ligne (DropdownMenu 3-dots). **Boucle la roadmap des Compositions.**

## Choix techniques

- **Composition au-dessus de Primitives existantes** (Table, Pagination, DropdownMenu), pas un remplacement. Pour les tables server-paginées avec gros volumes, utiliser \`<Table>\` + \`<Pagination>\` directement et piloter l'état côté app.
- **Pagination client** uniquement (filtrage + tri + slice côté composant).
- **Tri sur une seule colonne** (toggle asc → desc → off), \`localeCompare\` par défaut, override via \`sortFn\` par colonne.
- **Filtre global** \`includes()\` insensible casse sur les colonnes \`filterable: true\`. Override via \`filterFn\` pour règles métier (fuzzy, multi-mots, …).
- **Actions de ligne** via tableau d'actions + colonne dernière auto-ajoutée (3rem, 3-dots qui ouvre le DropdownMenu).
- **Volontairement hors v1** : multi-tri, filtres par colonne, sélection checkbox, server pagination, virtualisation.

## API

\`\`\`tsx
<DataTable
  columns={[
    { key: 'numero', label: 'Numéro', sortable: true, filterable: true },
    { key: 'objet', label: 'Objet', sortable: true, filterable: true },
    { key: 'statut', label: 'Statut', render: (r) => <Tag>{r.statut}</Tag> },
  ]}
  data={demandes}
  rowKey={(r) => r.id}
  pageSize={10}
  rowActions={(row) => [
    { id: 'view', label: 'Voir', icon: <Eye /> },
    { id: 'delete', label: 'Supprimer', destructive: true, separatorBefore: true },
  ]}
  onRowAction={(action, row) => {/* … */}}
/>
\`\`\`

\`\`\`html
<ori-data-table
  [columns]=\"columns\"
  [data]=\"demandes\"
  [rowKey]=\"rowKey\"
  [pageSize]=\"10\"
  [rowActions]=\"rowActions\"
  (rowAction)=\"handle($event)\"
></ori-data-table>
\`\`\`

Côté Angular, la cellule actions utilise un \`cellTemplate\` via \`ViewChild\` + \`TemplateRef\` pour rendre le DropdownMenu dans la dernière colonne (différence d'implémentation avec React qui utilise \`render\` direct, mais API publique identique).

## Tests

- 13 tests Vitest React (rendu, filtre, tri toggle, pagination, actions de ligne) — 196/196 verts au total
- 5 stories par framework avec exemples PF (47 demandes administratives, statuts, services, dates)
- Build React + Angular OK

## Roadmap

Item passé à \"In progress\" sur le board #3 → \"Done\" au merge. **Sixième et dernière Composition. La roadmap Primitives + Compositions est désormais complète : 5/5 + 6/6.**