### PR TITLE
chore(release): changeset rétroactif pour les 11 composants livrés

### DIFF
--- a/.changeset/primitives-compositions-batch.md
+++ b/.changeset/primitives-compositions-batch.md
@@ -1,0 +1,27 @@
+---
+'@govpf/ori-react': patch
+'@govpf/ori-angular': patch
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+Ajout de 11 composants (5 Primitives + 6 Compositions), tous backwards-compatible.
+
+**Primitives** :
+
+- `DropdownMenu` (PR #45) - menu déroulant accessible avec navigation clavier complète
+- `AlertDialog` (PR #46) - modale de confirmation critique (`role="alertdialog"`)
+- `Spinner` (PR #47) - indicateur de chargement compact, hérite de `currentColor`
+- `Combobox` (PR #48) - input texte + listbox filtrable (pattern WAI-ARIA combobox v1.2)
+- `MultiSelect` (PR #49) - multi-sélection virtualisée jusqu'à plusieurs milliers d'options
+
+**Compositions** :
+
+- `EmptyState` (PR #50) - bloc d'absence de données avec icône + titre + description + actions
+- `AppShell` (PR #51) - layout d'application avec skip link, sidebar drawer responsive
+- `Form` + `FormSection` + `FormField` + `FormActions` (PR #52) - layout de formulaire standardisé
+- `LoginLayout` (PR #53) - page d'authentification générique
+- `Wizard` + `WizardStep` (PR #54) - workflow multi-étapes avec validation pilotée par l'app
+- `DataTable` (PR #55) - Table + Pagination + filtre global + actions de ligne
+
+Toutes les classes CSS associées sont ajoutées au plugin Tailwind (et donc au bundle `ori.css`). Aucun composant ni classe existant n'est modifié.


### PR DESCRIPTION
## Contexte

Les 11 PRs Primitives + Compositions (#45 à #55) ont été mergées sans embarquer de changeset, donc Changesets n'a déclenché aucune release npm. Les versions publiées sont restées à \`0.1.0\`.

Cette PR ajoute un changeset rétroactif qui couvre l'ensemble des 11 livraisons et bumpe en **patch** (politique semver pré-1.0, cf. décision C.5 — tous les ajouts sont backwards-compatible).

## Packages concernés

| Package | Avant | Après merge de la PR Version Packages |
| - | - | - |
| \`@govpf/ori-react\` | 0.1.0 | 0.1.1 |
| \`@govpf/ori-angular\` | 0.1.0 | 0.1.1 |
| \`@govpf/ori-tailwind-preset\` | 0.1.2 | 0.1.3 |
| \`@govpf/ori-css\` | 0.1.1 | 0.1.2 |

\`@govpf/ori-tokens\` n'a pas été touché par les 11 PRs, donc pas de bump.

## Pipeline attendu

1. Merge de cette PR sur \`main\`
2. Le workflow \`release.yml\` détecte le changeset et ouvre la PR **« chore(release): version packages »**
3. Cette seconde PR consume le changeset, bumpe les \`package.json\` et met à jour les CHANGELOG
4. Merge de la PR Version Packages → publish automatique sur npm via OIDC

## Action de suivi (hors PR)

Pour les futures PRs, ajouter un changeset à chaque PR avec impact public. Un check CI \`changesets/changeset-bot\` sur les PRs serait utile pour rappeler la règle automatiquement.