### PR TITLE
fix(app-shell): la sidebar étire son contenu projeté sur toute la hauteur

### DIFF
--- a/.changeset/fix-app-shell-sidebar-stretch.md
+++ b/.changeset/fix-app-shell-sidebar-stretch.md
@@ -1,0 +1,10 @@
+---
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+Fix AppShell : la sidebar s'étire désormais correctement sur toute la hauteur du body de l'AppShell, et son contenu projeté (typiquement un `<nav>` portant une `border-right`) descend jusqu'au footer.
+
+Avant ce fix, le contenu projeté ne prenait que la hauteur de ses items, ce qui laissait un espace blanc en bas de la sidebar quand le contenu n'occupait pas toute la zone, et la bordure de séparation s'arrêtait au niveau du dernier item au lieu de descendre jusqu'au footer.
+
+La sidebar Ori (`.ori-app-shell__sidebar`) est désormais un container flex column qui force son enfant direct à `flex: 1 1 auto`. Aucun changement d'API : c'est uniquement un correctif CSS dans le plugin Tailwind partagé.

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1656,6 +1656,16 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       flexShrink: '0',
       overflowY: 'auto',
       backgroundColor: v('surface-base'),
+      // Container flex column pour que le contenu projeté (typiquement un
+      // <nav>) s'étire en hauteur sur toute la sidebar. Sans ça, une bordure
+      // ou un fond appliqué au contenu projeté s'arrête à la hauteur de ses
+      // items et laisse un espace blanc en bas avant le footer.
+      display: 'flex',
+      flexDirection: 'column',
+      '& > *': {
+        flex: '1 1 auto',
+        minHeight: '0',
+      },
     },
     '.ori-app-shell__main': {
       flex: '1 1 auto',


### PR DESCRIPTION
## Bug

Un utilisateur a remonté que le délimiteur (border-right) du \`<nav>\` projeté dans la sidebar de l'AppShell s'arrêtait au niveau du dernier item de navigation, laissant un espace blanc visible avant le footer.

## Cause

La sidebar Ori (\`.ori-app-shell__sidebar\`) était bien étirée à 100% de hauteur par le flex parent (body de l'AppShell), mais le contenu projeté **à l'intérieur** ne prenait que la hauteur de ses items. Tout style appliqué au contenu (background, border) ne descendait donc pas plus bas.

## Fix

Rendre la sidebar elle-même un container \`display: flex; flex-direction: column\` et forcer son enfant direct à \`flex: 1 1 auto\` + \`min-height: 0\`. Le \`<nav>\` projeté occupe désormais toute la hauteur de la sidebar et sa border descend jusqu'au footer.

\`\`\`css
.ori-app-shell__sidebar {
  /* ... */
  display: flex;
  flex-direction: column;
}
.ori-app-shell__sidebar > * {
  flex: 1 1 auto;
  min-height: 0;
}
\`\`\`

## Impact

Pure correction CSS. Aucun changement d'API. Les apps qui n'avaient pas le bug (parce qu'elles forçaient elles-mêmes \`height: 100%\` sur leur \`<nav>\`) ne changent rien. Les autres voient leur bordure / fond s'étendre correctement.

## Versionning

Patch sur \`@govpf/ori-tailwind-preset\` et \`@govpf/ori-css\` (le bundle est régénéré au build et inclut la mise à jour du plugin). Pas de bump pour \`ori-react\` ni \`ori-angular\` puisque le code TS/component reste identique.

Changeset embarqué directement cette fois (cf. session précédente).