### PR TITLE
fix(app-shell): préserve l'@media du drawer mobile

### DIFF
--- a/.changeset/fix-app-shell-mobile-media.md
+++ b/.changeset/fix-app-shell-mobile-media.md
@@ -1,0 +1,10 @@
+---
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+Fix AppShell : la sidebar reste correctement dans le flow (côte à côte avec le main) sur desktop.
+
+Avant ce fix, la règle media `(max-width: 767px)` du plugin était définie au niveau racine d'`addComponents` et contenait des sélecteurs composés (`.ori-app-shell--with-sidebar .ori-app-shell__sidebar`). PostCSS/Tailwind aplatissait ces sélecteurs en perdant à la fois le wrapping `@media` et le parent composé, transformant la règle « drawer mobile fixed » en règle desktop. Résultat visible : sur la démo, la sidebar était `position: fixed` sur tous les viewports, ce qui la sortait du flow et faisait remonter le main sous le header.
+
+Refactor : chaque sélecteur garde sa forme `.parent .child` et porte son propre `@media (max-width: 767px)` imbriqué. La sortie CSS conserve désormais correctement les media queries.

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1692,8 +1692,14 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       cursor: 'pointer',
     },
     // Mode mobile : sidebar devient un drawer hors flux.
-    '@media (max-width: 767px)': {
-      '.ori-app-shell--with-sidebar .ori-app-shell__sidebar': {
+    // NB : on imbrique l'@media DANS chaque sélecteur (et non l'inverse) car
+    // PostCSS / Tailwind aplatit les @media de niveau racine d'addComponents
+    // en perdant les sélecteurs parents composés (`.parent .child`), ce qui
+    // appliquait la règle "drawer fixed" sur tous les viewports. Avec cette
+    // forme, chaque sélecteur garde son `parent .child` et l'@media est
+    // correctement préservée dans la sortie CSS.
+    '.ori-app-shell--with-sidebar .ori-app-shell__sidebar': {
+      '@media (max-width: 767px)': {
         position: 'fixed',
         top: '0',
         bottom: '0',
@@ -1705,10 +1711,14 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
         transitionTimingFunction: theme('transitionTimingFunction.standard'),
         boxShadow: theme('boxShadow.xl'),
       },
-      '.ori-app-shell--sidebar-open .ori-app-shell__sidebar': {
+    },
+    '.ori-app-shell--sidebar-open .ori-app-shell__sidebar': {
+      '@media (max-width: 767px)': {
         transform: 'translateX(0)',
       },
-      '.ori-app-shell--sidebar-open .ori-app-shell__scrim': {
+    },
+    '.ori-app-shell--sidebar-open .ori-app-shell__scrim': {
+      '@media (max-width: 767px)': {
         display: 'block',
       },
     },


### PR DESCRIPTION
## Bug

Visible sur la démo : sur desktop (≥ 768px), la sidebar passait sous le header au lieu d'être côte à côte avec le main.

## Cause

La règle \`@media (max-width: 767px)\` du plugin était définie au niveau racine d'\`addComponents\` et contenait des sélecteurs composés :

\`\`\`js
'@media (max-width: 767px)': {
  '.ori-app-shell--with-sidebar .ori-app-shell__sidebar': { position: 'fixed', ... },
  '.ori-app-shell--sidebar-open .ori-app-shell__sidebar': { transform: '...' },
}
\`\`\`

PostCSS / Tailwind aplatissait ces sélecteurs en perdant **à la fois** le wrapping \`@media\` **et** le parent composé. La sortie réelle dans le CSS final était :

\`\`\`css
.ori-app-shell__sidebar { position: fixed; ... }   /* sans @media ! */
.ori-app-shell__sidebar { transform: translate(0) }
\`\`\`

→ La sidebar était \`position: fixed\` sur tous les viewports, ce qui la sortait du flow et faisait remonter le main sous le header.

## Fix

Chaque sélecteur garde sa forme \`.parent .child\` au top-level d'\`addComponents\` et porte son propre \`@media (max-width: 767px)\` imbriqué :

\`\`\`js
'.ori-app-shell--with-sidebar .ori-app-shell__sidebar': {
  '@media (max-width: 767px)': { position: 'fixed', ... },
},
'.ori-app-shell--sidebar-open .ori-app-shell__sidebar': {
  '@media (max-width: 767px)': { transform: 'translateX(0)' },
},
\`\`\`

Vérifié sur le bundle prod compilé de la démo : la sortie CSS contient bien désormais \`@media(max-width:767px){.ori-app-shell--with-sidebar .ori-app-shell__sidebar{position:fixed;...}...}\`.

## Versionning

Patch sur \`@govpf/ori-tailwind-preset\` et \`@govpf/ori-css\`. Aucun changement d'API.