### PR TITLE
docs(discoverability): expose llms.txt + page outillage automatisé (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ complète des composants disponibles et leurs API.
 - **Décisions de design** et **stratégie d'ouverture** : pages MDX dans `packages/docs/`
 - **Roadmap publique** : <https://github.com/orgs/govpf/projects/3> (Backlog, Up next, In progress, Done ; filtres par catégorie, effort, source)
 
+### Endpoints machine-readable
+
+Pour explorer Ori programmatiquement (agents IA, scripts d'audit, outils de scraping) sans exécuter le JavaScript du Storybook :
+
+| URL                                               | Format   | Contenu                                                                |
+| ------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| <https://ori.gov.pf/llms.txt>                     | Markdown | Résumé du DS, packages, composants, conventions (format [llmstxt.org]) |
+| <https://ori.gov.pf/storybook/react/index.json>   | JSON     | Index complet des stories React (id, title, importPath, tags, type)    |
+| <https://ori.gov.pf/storybook/angular/index.json> | JSON     | Idem Angular                                                           |
+
+Pour récupérer une story spécifique en HTML rendu : `https://ori.gov.pf/storybook/react/iframe.html?id={story-id}` (le rendu reste piloté par le JS du Storybook, mais sans la chrome de la SPA).
+
+[llmstxt.org]: https://llmstxt.org
+
 ## Démarrer
 
 ### Prérequis

--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -1,0 +1,90 @@
+# Ori - Design system de l'administration de la Polynésie française
+
+> Ori est le design system mutualisé des 54 services administratifs de la Polynésie française. Multi-framework (React, Angular, CSS pur), bâti sur une source unique de design tokens W3C DTCG. Conçu pour produire des applications web officielles accessibles RGAA AA, sans favoriser un service en particulier.
+
+Positionnement :
+
+- **Service public** : généricité institutionnelle, identité visuelle Polynésie française et non d'un service spécifique
+- **RGAA AA baseline obligatoire** : 406 stories Storybook validées WCAG 2.0 AA en CI à chaque PR (axe-core, 0 violation)
+- **Natif d'abord** : éléments HTML natifs privilégiés systématiquement (`<select>`, `<input type="date">`, etc.) pour garantir l'a11y sans audit à recommencer
+- **Bundle minimal** : adapté aux connexions limitées des archipels éloignés
+- **Multi-framework** : même apparence visuelle garantie sur React, Angular, HTML pur depuis une source unique de tokens
+
+Versionning : pré-1.0 (cf. [décision C.5](https://ori.gov.pf/storybook/react/?path=/docs/d%C3%A9cisions-d%C3%A9cisions-%C3%A0-prendre--docs)). Patch = backwards-compatible. Minor = breaking changes autorisés. Major (1.0) sortira après stabilisation.
+
+## Packages npm
+
+Tous publiés sous le scope `@govpf/`.
+
+- [@govpf/ori-react](https://www.npmjs.com/package/@govpf/ori-react) : composants React / Next.js
+- [@govpf/ori-angular](https://www.npmjs.com/package/@govpf/ori-angular) : composants Angular standalone (≥ 20)
+- [@govpf/ori-tailwind-preset](https://www.npmjs.com/package/@govpf/ori-tailwind-preset) : preset Tailwind + classes sémantiques `.ori-*`
+- [@govpf/ori-css](https://www.npmjs.com/package/@govpf/ori-css) : bundle CSS drop-in (intégrations GLPI, emails)
+- [@govpf/ori-tokens](https://www.npmjs.com/package/@govpf/ori-tokens) : design tokens W3C DTCG (CSS variables, JS, SCSS)
+
+## Endpoints machine-readable
+
+Pour explorer le design system programmatiquement sans exécuter le JavaScript du Storybook :
+
+- [https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json) : index complet des stories React (format Storybook v5, ~100 ko, JSON). Contient pour chaque story : `id`, `title`, `name`, `importPath`, `tags`, `type`.
+- [https://ori.gov.pf/storybook/angular/index.json](https://ori.gov.pf/storybook/angular/index.json) : équivalent Angular.
+- [https://github.com/govpf/ori](https://github.com/govpf/ori) : code source (sources React/Angular dans `packages/`, MDX docs dans `packages/docs/src/`)
+- [Roadmap publique](https://github.com/orgs/govpf/projects/3) : board GitHub Projects (Backlog, Up next, In progress, Done)
+
+Pour récupérer le contenu d'une story spécifique (HTML rendu) : `https://ori.gov.pf/storybook/react/iframe.html?id={story-id}` ou la fiche docs `https://ori.gov.pf/storybook/react/?path=/docs/{story-id}`.
+
+## Composants livrés
+
+Inventaire au [{{date}}](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux), classés en 3 niveaux (cf. décision B.0).
+
+### Primitives (≈ 35)
+
+Briques atomiques, API agnostique du domaine, présentes dans tous les DS de référence.
+
+Inputs : Button, Input, Textarea, Select, Combobox, MultiSelect, Checkbox, Radio, Switch, DatePicker
+Feedback : Dialog, AlertDialog, Tooltip, Toast, Notification, Alert, Spinner, Progress, Skeleton
+Navigation : DropdownMenu, Tabs, Accordion, Breadcrumb, Pagination, Steps, Link
+Data : Table, Tag, Avatar, Highlight, Statistic, Timeline, LanguageSwitcher, Logo
+
+### Compositions (≈ 11)
+
+Assemblages de primitives, paramétrables mais génériques.
+
+- AppShell : layout d'app avec header sticky, sidebar drawer responsive, skip link
+- LoginLayout : page d'authentification générique
+- Form / FormSection / FormField / FormActions : formulaire standardisé
+- Wizard : workflow multi-étapes
+- DataTable : Table + Pagination + filtre + actions de ligne
+- EmptyState : bloc d'absence de données
+- Header, Footer, MainNavigation, SideMenu, FileUpload, FileCard
+
+### Templates (3)
+
+Orientés cas d'usage administratif spécifique.
+
+- ErrorPage : page d'erreur 404 / 500 avec brand PF
+- LegalLayout : pages légales (mentions, accessibilité, RGPD, plan du site)
+- AuthButton : bouton fournisseur d'identité (Rumia usagers, GOV Connect agents)
+
+## Décisions transverses
+
+Documentées en MDX dans le repo, source de vérité publique :
+
+- [packages/docs/src/Decisions-A-Prendre.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx) : décisions architecturales tranchées
+- [packages/docs/src/Validation-Accessibilite.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Accessibilite.mdx) : méthode et couverture a11y
+
+## Conventions
+
+- **Tokens DTCG** : pas d'accès direct à un primitif (`color.primary.500`), toujours un alias sémantique (`color.brand.primary`). Permet bascule de palette ou thème sombre sans toucher au code.
+- **Classes sémantiques** : composants stylés via `.ori-btn`, `.ori-card`… définies dans le plugin Tailwind. Les classes consomment des CSS variables → bascule de thème dynamique sans recompilation.
+- **Pas d'utilitaires Tailwind inline dans le DS** : le DS expose des classes nommées. Les utilitaires Tailwind restent disponibles pour la mise en page côté apps consommatrices.
+- **React** : composants standards avec `forwardRef`, `clsx` pour les classes.
+- **Angular** : composants `standalone`, `ChangeDetectionStrategy.OnPush`, `ViewEncapsulation.None`.
+
+## Thème sombre
+
+Toggle via `data-theme="dark"` (ou classe `.dark-theme`) sur `<html>`. Pas de recompilation, juste un attribut. Fonctionne identiquement React, Angular et CSS pur.
+
+## Licence
+
+[MIT](https://github.com/govpf/ori/blob/main/LICENSE) — Copyright © 2026 Gouvernement de la Polynésie française.

--- a/apps/ori-site/src/components/Sidebar.astro
+++ b/apps/ori-site/src/components/Sidebar.astro
@@ -118,6 +118,7 @@ const sections: NavSection[] = [
       { label: 'Contribuer', slug: 'contribuer', href: `${base}ressources/contribuer/` },
       { label: 'Code de conduite', slug: 'code-de-conduite', href: `${base}ressources/code-de-conduite/` },
       { label: 'Sécurité', slug: 'securite', href: `${base}ressources/securite/` },
+      { label: 'Outillage automatisé', slug: 'outillage', href: `${base}ressources/outillage/` },
     ],
   },
 ];

--- a/apps/ori-site/src/pages/ressources/outillage.mdx
+++ b/apps/ori-site/src/pages/ressources/outillage.mdx
@@ -1,0 +1,86 @@
+---
+layout: ../../layouts/DocLayout.astro
+title: "Outillage automatisé"
+current: "outillage"
+headerCurrent: "ressources"
+---
+
+# Outillage automatisé
+
+Ori expose plusieurs endpoints conçus pour les agents IA, scripts d'audit
+et outils de scraping qui veulent inspecter le design system sans exécuter
+le JavaScript du Storybook.
+
+## Résumé pour agents IA — `llms.txt`
+
+[https://ori.gov.pf/llms.txt](https://ori.gov.pf/llms.txt) — Markdown
+court suivant la convention [llmstxt.org](https://llmstxt.org). Décrit
+le positionnement d'Ori, liste les packages npm, les principaux
+composants par niveau (Primitive / Composition / Template) et pointe
+vers les autres endpoints utiles.
+
+C'est le point d'entrée recommandé pour un agent qui découvre Ori : un
+seul fichier, lisible en quelques secondes, suffisant pour orienter la
+suite de l'exploration.
+
+## Index Storybook — `index.json`
+
+Storybook 8+ génère automatiquement un index machine-readable de toutes
+les stories à la racine de chaque build statique :
+
+- React : [https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json)
+- Angular : [https://ori.gov.pf/storybook/angular/index.json](https://ori.gov.pf/storybook/angular/index.json)
+
+Format JSON, ~100 ko. Pour chaque story :
+
+```json
+{
+  "id": "composants-inputs-button--default",
+  "title": "Composants/Inputs/Button",
+  "name": "Default",
+  "importPath": "../../packages/react/src/components/Button/Button.stories.tsx",
+  "tags": ["dev", "test", "autodocs"],
+  "type": "story"
+}
+```
+
+L'`importPath` permet de retrouver le fichier source dans le repo
+GitHub. Les `tags` distinguent stories interactives (`type: "story"`)
+et fiches de documentation MDX (`type: "docs"`).
+
+## Récupérer une story spécifique
+
+Une fois un `id` repéré dans `index.json`, deux options :
+
+- **Iframe Storybook** : `https://ori.gov.pf/storybook/react/iframe.html?id={story-id}`
+  rend la story isolée (sans la chrome de la SPA). Le rendu reste piloté
+  par le JS du Storybook, donc l'inspection HTML brute ne fonctionne pas
+  sans un browser headless.
+- **Source dans le repo GitHub** : suivre `importPath` vers
+  `https://github.com/govpf/ori/blob/main/{importPath}`.
+  C'est l'approche recommandée pour analyser le code d'un composant
+  sans dépendre du runtime.
+
+## Source de vérité dans le repo
+
+Pour les agents qui veulent aller plus loin que l'index :
+
+| Chemin                                                                                                  | Contenu                                                                |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [`packages/docs/src/Decisions-A-Prendre.mdx`](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx) | Décisions architecturales tranchées (avec leur statut et conclusion)   |
+| [`packages/docs/src/Validation-Accessibilite.mdx`](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Accessibilite.mdx) | Méthode et couverture a11y (axe-core, WCAG 2.0 AA)                     |
+| [`packages/tokens/src/`](https://github.com/govpf/ori/tree/main/packages/tokens/src)                    | Design tokens W3C DTCG (sources `core.json` et `semantic.json`)        |
+| [`packages/tailwind-preset/src/plugin-components.js`](https://github.com/govpf/ori/blob/main/packages/tailwind-preset/src/plugin-components.js) | Définition de toutes les classes sémantiques `.ori-*`                  |
+
+## Roadmap publique
+
+[https://github.com/orgs/govpf/projects/3](https://github.com/orgs/govpf/projects/3) —
+Board GitHub Projects avec colonnes Backlog / Up next / In progress /
+Done. Filtres par catégorie (Composant, Pattern, A11y, DX, Doc,
+Écosystème, Gouvernance, Sécu), niveau (Primitive, Composition,
+Template), source (Feedback externe, Roadmap interne, Bug remonté,
+Décision tranchée) et size (XS, S, M, L, XL).
+
+L'API GraphQL GitHub Projects permet d'interroger ce board en lecture
+sans authentification interactive (utiliser un PAT avec scope
+`read:project`).


### PR DESCRIPTION
Closes #63.

## Contexte

Un reviewer (probablement un agent IA) a remonté que l'\`index.json\` de Storybook lui était \"inaccessible\". **Diagnostic : faux sur le fond** — Storybook 8+ génère bien un index.json à la racine du build statique, et il est exposé en prod :

\`\`\`bash
curl -sI https://ori.gov.pf/storybook/react/index.json
# HTTP/1.1 200 OK
# Content-Type: application/json
\`\`\`

Mais l'endpoint n'était **pas documenté**, ce qui force les agents IA à deviner les URLs. Cette PR ferme le sujet.

## Livrables

### 1. \`apps/ori-site/public/llms.txt\`

Servi à la racine [https://ori.gov.pf/llms.txt](https://ori.gov.pf/llms.txt). Format [llmstxt.org](https://llmstxt.org), convention récente adoptée par Vercel, Anthropic, Stripe, Cloudflare. C'est le point d'entrée recommandé pour un agent qui découvre Ori : un seul fichier markdown qui résume le positionnement, liste les packages npm, les composants par niveau (Primitive / Composition / Template), et pointe vers les autres endpoints utiles.

### 2. \`apps/ori-site/src/pages/ressources/outillage.mdx\`

Page documentaire \"Outillage automatisé\" sous **Ressources**, listée dans la sidebar. Détaille les endpoints machine-readable (llms.txt, index.json React et Angular, source repo GitHub, roadmap GraphQL).

### 3. README.md

Tableau \"Endpoints machine-readable\" en tête de la section Documentation listant llms.txt, index.json React et Angular avec leurs formats et contenus.

## Vérification

- \`pnpm --filter @govpf/ori-site build\` : OK, 27 pages générées dont \`/ressources/outillage/\` et \`llms.txt\` copié dans \`dist/\`
- Après merge + deploy : \`curl -sI https://ori.gov.pf/llms.txt\` doit répondre 200

## Hors scope

- Sitemap.xml : moins prioritaire pour un site doc, à ouvrir comme item séparé si besoin SEO
- Server-side rendering complet du Storybook : trop lourd, on garde la SPA + iframe.html pour le rendu individuel