### PR TITLE
fix(docs): remplace les em-dash par des tirets simples dans la doc PR #64

### DIFF
--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -87,4 +87,4 @@ Toggle via `data-theme="dark"` (ou classe `.dark-theme`) sur `<html>`. Pas de re
 
 ## Licence
 
-[MIT](https://github.com/govpf/ori/blob/main/LICENSE) — Copyright © 2026 Gouvernement de la Polynésie française.
+[MIT](https://github.com/govpf/ori/blob/main/LICENSE) - Copyright © 2026 Gouvernement de la Polynésie française.

--- a/apps/ori-site/src/pages/ressources/outillage.mdx
+++ b/apps/ori-site/src/pages/ressources/outillage.mdx
@@ -11,9 +11,9 @@ Ori expose plusieurs endpoints conçus pour les agents IA, scripts d'audit
 et outils de scraping qui veulent inspecter le design system sans exécuter
 le JavaScript du Storybook.
 
-## Résumé pour agents IA — `llms.txt`
+## Résumé pour agents IA - `llms.txt`
 
-[https://ori.gov.pf/llms.txt](https://ori.gov.pf/llms.txt) — Markdown
+[https://ori.gov.pf/llms.txt](https://ori.gov.pf/llms.txt) - Markdown
 court suivant la convention [llmstxt.org](https://llmstxt.org). Décrit
 le positionnement d'Ori, liste les packages npm, les principaux
 composants par niveau (Primitive / Composition / Template) et pointe
@@ -23,7 +23,7 @@ C'est le point d'entrée recommandé pour un agent qui découvre Ori : un
 seul fichier, lisible en quelques secondes, suffisant pour orienter la
 suite de l'exploration.
 
-## Index Storybook — `index.json`
+## Index Storybook - `index.json`
 
 Storybook 8+ génère automatiquement un index machine-readable de toutes
 les stories à la racine de chaque build statique :
@@ -74,7 +74,7 @@ Pour les agents qui veulent aller plus loin que l'index :
 
 ## Roadmap publique
 
-[https://github.com/orgs/govpf/projects/3](https://github.com/orgs/govpf/projects/3) —
+[https://github.com/orgs/govpf/projects/3](https://github.com/orgs/govpf/projects/3) -
 Board GitHub Projects avec colonnes Backlog / Up next / In progress /
 Done. Filtres par catégorie (Composant, Pattern, A11y, DX, Doc,
 Écosystème, Gouvernance, Sécu), niveau (Primitive, Composition,


### PR DESCRIPTION
J'ai laissé passer 5 em-dash (\`—\`) dans les fichiers de la PR #64 :

- \`apps/ori-site/public/llms.txt\` : 1 occurrence (footer Licence)
- \`apps/ori-site/src/pages/ressources/outillage.mdx\` : 4 occurrences (titres + corps)

La règle de fond du repo (et préférence de l'utilisateur) interdit em-dash et en-dash dans tout contenu textuel : uniquement le tiret simple \`-\` est autorisé. Cette PR corrige les 5 occurrences.

Vérifié par \`grep -nE "—|–"\` sur les fichiers concernés : 0 occurrence restante.