### PR TITLE
fix(llms-txt): retire placeholder {{date}} + précise format index.json

### DIFF
--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -26,8 +26,10 @@ Tous publiés sous le scope `@govpf/`.
 
 Pour explorer le design system programmatiquement sans exécuter le JavaScript du Storybook :
 
-- [https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json) : index complet des stories React (format Storybook v5, ~100 ko, JSON). Contient pour chaque story : `id`, `title`, `name`, `importPath`, `tags`, `type`.
+- [https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json) : index complet des entrées React (format Storybook v5, ~100 ko, JSON). Contient pour chaque entrée : `id`, `title`, `name`, `importPath`, `tags`, `type`.
 - [https://ori.gov.pf/storybook/angular/index.json](https://ori.gov.pf/storybook/angular/index.json) : équivalent Angular.
+
+L'index contient deux types d'entrées (champ `type`) à filtrer selon l'usage : `type === "story"` pour les stories interactives (~200 entrées), `type === "docs"` pour les fiches autodocs et MDX rattachés (~200 entrées). Pour explorer les composants disponibles, filtrer sur `type === "story"`. Pour lire la documentation rédigée, filtrer sur `type === "docs"`.
 - [https://github.com/govpf/ori](https://github.com/govpf/ori) : code source (sources React/Angular dans `packages/`, MDX docs dans `packages/docs/src/`)
 - [Roadmap publique](https://github.com/orgs/govpf/projects/3) : board GitHub Projects (Backlog, Up next, In progress, Done)
 
@@ -35,7 +37,7 @@ Pour récupérer le contenu d'une story spécifique (HTML rendu) : `https://ori.
 
 ## Composants livrés
 
-Inventaire au [{{date}}](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux), classés en 3 niveaux (cf. décision B.0).
+Inventaire snapshot avril 2026, classés en 3 niveaux (cf. [décision B.0](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux)). L'inventaire à jour vit dans le repo et l'index Storybook ([https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json)).
 
 ### Primitives (≈ 35)
 


### PR DESCRIPTION
## Bug 1 : placeholder non interpolé

Le bloc \"Composants livrés\" du llms.txt contenait \`[{{date}}]\` littéral, vestige d'un système de templating qui n'existe pas (le fichier est servi tel quel depuis \`public/\`, sans traitement Astro). Remplacé par \"snapshot avril 2026\" + pointeur vers index.json comme source de vérité à jour.

## Bug 2 : format index.json sous-documenté

Le bloc \"Endpoints machine-readable\" ne précisait pas que l'\`index.json\` mélange deux types d'entrées :

- \`type === \"story\"\` (~200 entrées) : stories interactives → utiliser pour découvrir les composants disponibles
- \`type === \"docs\"\` (~200 entrées) : fiches autodocs et MDX rattachés → utiliser pour lire la documentation rédigée

Note explicite ajoutée sur le filtrage selon l'usage. Sans ça, un agent qui découvre Ori comptait ~400 \"composants\" alors qu'il y en a ~200, le reste étant de la doc.

## Hors scope

La refacto taxonomique du Storybook (doublons FR/EN \"Saisie\" vs \"Inputs\", \"Mise en page\" vs \"Layout\", \"Données\" vs \"Data\", ErrorPage mal classé) est traitée dans une PR séparée vu son ampleur.