### PR TITLE
chore(stories): ajoute name FR sur les exports de stories anglais standards

### DIFF
--- a/packages/angular/src/components/accordion/accordion.stories.ts
+++ b/packages/angular/src/components/accordion/accordion.stories.ts
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<OriAccordionComponent>;
 
 export const Multiple: Story = {
+  name: 'Multiple',
   render: () => ({
     template: `
       <ori-accordion type="multiple">

--- a/packages/angular/src/components/alert-dialog/alert-dialog.stories.ts
+++ b/packages/angular/src/components/alert-dialog/alert-dialog.stories.ts
@@ -27,6 +27,7 @@ type Story = StoryObj<OriAlertDialogComponent>;
  * sur "Annuler" pour éviter qu'un Entrée accidentel ne déclenche l'action.
  */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       isOpen: false,
@@ -62,6 +63,7 @@ export const Default: Story = {
  * variant standard plutôt que danger.
  */
 export const Logout: Story = {
+  name: 'Déconnexion',
   render: () => ({
     props: {
       isOpen: false,

--- a/packages/angular/src/components/alert/alert.stories.ts
+++ b/packages/angular/src/components/alert/alert.stories.ts
@@ -41,17 +41,20 @@ const meta: Meta<OriAlertComponent> = {
 export default meta;
 type Story = StoryObj<OriAlertComponent>;
 
-export const Info: Story = {};
+export const Info: Story = { name: 'Variante information' };
 
 export const Success: Story = {
+  name: 'Variante succès',
   args: { severity: 'success', title: 'Action réalisée' },
 };
 
 export const Warning: Story = {
+  name: 'Variante avertissement',
   args: { severity: 'warning', title: 'Attention' },
 };
 
 export const Danger: Story = {
+  name: 'Variante danger',
   args: { severity: 'danger', title: 'Erreur' },
 };
 
@@ -60,6 +63,7 @@ export const Dismissible: Story = {
 };
 
 export const NoTitle: Story = {
+  name: 'Sans titre',
   args: { title: '' },
 };
 

--- a/packages/angular/src/components/app-shell/app-shell.stories.ts
+++ b/packages/angular/src/components/app-shell/app-shell.stories.ts
@@ -23,6 +23,7 @@ export default meta;
 type Story = StoryObj<OriAppShellComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     template: `
       <div style="height: 600px; border: 1px dashed #d4d4d8;">
@@ -66,6 +67,7 @@ export const Default: Story = {
 };
 
 export const NoSidebar: Story = {
+  name: 'Sans sidebar',
   render: () => ({
     template: `
       <div style="height: 600px; border: 1px dashed #d4d4d8;">
@@ -92,6 +94,7 @@ export const NoSidebar: Story = {
 };
 
 export const SidebarDrawer: Story = {
+  name: 'Sidebar en drawer',
   render: () => ({
     props: {
       open: false,

--- a/packages/angular/src/components/avatar/avatar.stories.ts
+++ b/packages/angular/src/components/avatar/avatar.stories.ts
@@ -39,6 +39,7 @@ export const WithImage: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => ({
     template: `
       <div style="display: flex; gap: 12px; align-items: center;">

--- a/packages/angular/src/components/breadcrumb/breadcrumb.stories.ts
+++ b/packages/angular/src/components/breadcrumb/breadcrumb.stories.ts
@@ -25,6 +25,7 @@ export default meta;
 type Story = StoryObj<OriBreadcrumbComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     items: [
       { label: 'Accueil', href: '/' },

--- a/packages/angular/src/components/button/button.stories.ts
+++ b/packages/angular/src/components/button/button.stories.ts
@@ -59,13 +59,14 @@ const meta: Meta<ButtonStoryArgs> = {
 export default meta;
 type Story = StoryObj<ButtonStoryArgs>;
 
-export const Primary: Story = {};
+export const Primary: Story = { name: 'Variante primaire' };
 export const Secondary: Story = { args: { variant: 'secondary' } };
 export const Ghost: Story = { args: { variant: 'ghost' } };
 export const Danger: Story = { args: { variant: 'danger', label: 'Supprimer' } };
 export const Disabled: Story = { args: { disabled: true, label: 'Désactivé' } };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: (args: Args) => ({
     props: args,
     template: `
@@ -79,6 +80,7 @@ export const Sizes: Story = {
 };
 
 export const AllVariants: Story = {
+  name: 'Toutes les variantes',
   render: () => ({
     template: `
       <div style="display: flex; gap: 1rem; flex-wrap: wrap;">

--- a/packages/angular/src/components/card/card.stories.ts
+++ b/packages/angular/src/components/card/card.stories.ts
@@ -62,7 +62,7 @@ const meta: Meta<OriCardComponent> = {
 export default meta;
 type Story = StoryObj<OriCardComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 export const Elevated: Story = { args: { variant: 'elevated' } };
 export const Flat: Story = { args: { variant: 'flat' } };
 

--- a/packages/angular/src/components/checkbox/checkbox.stories.ts
+++ b/packages/angular/src/components/checkbox/checkbox.stories.ts
@@ -42,29 +42,34 @@ const meta: Meta<OriCheckboxComponent> = {
 export default meta;
 type Story = StoryObj<OriCheckboxComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Checked: Story = { args: { checked: true } };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: 'Vous pouvez retirer votre consentement à tout moment depuis vos préférences.',
   },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: { error: 'Vous devez accepter les conditions pour continuer.' },
 };
 
 export const Indeterminate: Story = {
+  name: 'Indéterminé',
   args: { indeterminate: true, label: 'Sélectionner toutes les lignes' },
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, checked: true, label: 'Option verrouillée' },
 };
 
 export const Group: Story = {
+  name: 'Groupe',
   render: () => ({
     template: `
       <fieldset class="ori-choice-group" style="border: 0; padding: 0; margin: 0;">

--- a/packages/angular/src/components/combobox/combobox.stories.ts
+++ b/packages/angular/src/components/combobox/combobox.stories.ts
@@ -40,6 +40,7 @@ export default meta;
 type Story = StoryObj<OriComboboxComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       options: services,
@@ -63,6 +64,7 @@ export const Default: Story = {
 };
 
 export const WithDescription: Story = {
+  name: 'Avec description',
   render: () => ({
     props: {
       options: archipels,
@@ -86,6 +88,7 @@ export const WithDescription: Story = {
 };
 
 export const WithDisabledOption: Story = {
+  name: 'Avec option désactivée',
   render: () => ({
     props: {
       options: [
@@ -113,6 +116,7 @@ export const WithDisabledOption: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   render: () => ({
     props: { options: services },
     template: `

--- a/packages/angular/src/components/data-table/data-table.stories.ts
+++ b/packages/angular/src/components/data-table/data-table.stories.ts
@@ -83,6 +83,7 @@ export default meta;
 type Story = StoryObj<OriDataTableComponent<Demande>>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       columns,
@@ -109,6 +110,7 @@ export const Default: Story = {
 };
 
 export const ReadOnly: Story = {
+  name: 'Consultation seule',
   render: () => ({
     props: {
       columns,
@@ -128,6 +130,7 @@ export const ReadOnly: Story = {
 };
 
 export const NoPagination: Story = {
+  name: 'Sans pagination',
   render: () => ({
     props: {
       columns,
@@ -148,6 +151,7 @@ export const NoPagination: Story = {
 };
 
 export const Loading: Story = {
+  name: 'Chargement',
   render: () => ({
     props: {
       columns,

--- a/packages/angular/src/components/date-picker/date-picker.stories.ts
+++ b/packages/angular/src/components/date-picker/date-picker.stories.ts
@@ -50,9 +50,10 @@ const meta: Meta<OriDatePickerComponent> = {
 export default meta;
 type Story = StoryObj<OriDatePickerComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: "Telle qu'elle figure sur votre pièce d'identité." },
 };
 
@@ -72,6 +73,7 @@ export const WithBounds: Story = {
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: "Cette date doit être antérieure à aujourd'hui.",
     value: '2030-01-01',
@@ -79,5 +81,6 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: '2026-04-25' },
 };

--- a/packages/angular/src/components/dialog/dialog.stories.ts
+++ b/packages/angular/src/components/dialog/dialog.stories.ts
@@ -31,6 +31,7 @@ type Story = StoryObj<OriDialogComponent>;
  * page docs casse la navigation (focus piégé, body non scrollable).
  */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       isOpen: false,
@@ -65,6 +66,7 @@ export const Default: Story = {
  * le footer restent fixes, seul le body scrolle). Parité avec la story React.
  */
 export const LongContent: Story = {
+  name: 'Contenu long',
   render: () => ({
     props: {
       isOpen: false,
@@ -101,6 +103,7 @@ export const LongContent: Story = {
  * Sans footer : le dialog n'affiche que header + body. Parité avec la story React.
  */
 export const NoFooter: Story = {
+  name: 'Sans pied',
   render: () => ({
     props: {
       isOpen: false,

--- a/packages/angular/src/components/dropdown-menu/dropdown-menu.stories.ts
+++ b/packages/angular/src/components/dropdown-menu/dropdown-menu.stories.ts
@@ -53,6 +53,7 @@ const moreActions: OriDropdownMenuItem[] = [
 ];
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       items: actions,
@@ -70,6 +71,7 @@ export const Default: Story = {
 };
 
 export const UserMenu: Story = {
+  name: 'Menu utilisateur',
   render: () => ({
     props: {
       items: userActions,
@@ -87,6 +89,7 @@ export const UserMenu: Story = {
 };
 
 export const WithShortcuts: Story = {
+  name: 'Avec raccourcis',
   render: () => ({
     props: {
       items: editActions,
@@ -100,6 +103,7 @@ export const WithShortcuts: Story = {
 };
 
 export const WithDisabledItem: Story = {
+  name: 'Avec élément désactivé',
   render: () => ({
     props: {
       items: moreActions,

--- a/packages/angular/src/components/empty-state/empty-state.stories.ts
+++ b/packages/angular/src/components/empty-state/empty-state.stories.ts
@@ -28,6 +28,7 @@ export default meta;
 type Story = StoryObj<OriEmptyStateComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: { Inbox },
     template: `
@@ -43,6 +44,7 @@ export const Default: Story = {
 };
 
 export const SearchNoResults: Story = {
+  name: 'Recherche sans résultat',
   render: () => ({
     props: { Search },
     template: `
@@ -59,6 +61,7 @@ export const SearchNoResults: Story = {
 };
 
 export const OnboardingLarge: Story = {
+  name: 'Onboarding grande taille',
   render: () => ({
     props: { Users },
     template: `
@@ -78,6 +81,7 @@ export const OnboardingLarge: Story = {
 };
 
 export const Minimal: Story = {
+  name: 'Minimal',
   render: () => ({
     props: { FilePlus },
     template: `
@@ -90,6 +94,7 @@ export const Minimal: Story = {
 };
 
 export const TextOnly: Story = {
+  name: 'Texte seul',
   render: () => ({
     template: `
       <ori-empty-state

--- a/packages/angular/src/components/file-card/file-card.stories.ts
+++ b/packages/angular/src/components/file-card/file-card.stories.ts
@@ -46,7 +46,7 @@ const meta: Meta<OriFileCardComponent> = {
 export default meta;
 type Story = StoryObj<OriFileCardComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const AvecActions: Story = {
   args: {

--- a/packages/angular/src/components/file-upload/file-upload.stories.ts
+++ b/packages/angular/src/components/file-upload/file-upload.stories.ts
@@ -49,9 +49,10 @@ const meta: Meta<OriFileUploadComponent> = {
 export default meta;
 type Story = StoryObj<OriFileUploadComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: 'Formats acceptés : PDF, JPG, PNG. Taille maximale : 5 Mo.',
     accept: '.pdf,image/jpeg,image/png',
@@ -61,6 +62,7 @@ export const WithHint: Story = {
 };
 
 export const Multiple: Story = {
+  name: 'Multiple',
   args: {
     label: 'Pièces justificatives',
     hint: 'Vous pouvez ajouter plusieurs fichiers.',
@@ -71,10 +73,12 @@ export const Multiple: Story = {
 };
 
 export const Required: Story = {
+  name: 'Requis',
   args: { required: true },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: 'Au moins un fichier est obligatoire.',
     required: true,
@@ -82,5 +86,6 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true },
 };

--- a/packages/angular/src/components/footer/footer.stories.ts
+++ b/packages/angular/src/components/footer/footer.stories.ts
@@ -32,6 +32,7 @@ export default meta;
 type Story = StoryObj<OriFooterComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     brand: 'Polynésie française',
     description: 'Service en ligne officiel',
@@ -83,5 +84,6 @@ export const WithColumns: Story = {
 };
 
 export const Minimal: Story = {
+  name: 'Minimal',
   args: { brand: 'Polynésie française', legal: '© 2026' },
 };

--- a/packages/angular/src/components/form/form.stories.ts
+++ b/packages/angular/src/components/form/form.stories.ts
@@ -42,6 +42,7 @@ export default meta;
 type Story = StoryObj<OriFormComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     template: `
       <ori-form style="max-width: 480px;">
@@ -71,6 +72,7 @@ export const Default: Story = {
 };
 
 export const MultipleSections: Story = {
+  name: 'Plusieurs sections',
   render: () => ({
     template: `
       <ori-form style="max-width: 560px;">
@@ -127,6 +129,7 @@ export const MultipleSections: Story = {
 };
 
 export const WithErrors: Story = {
+  name: 'Avec erreurs',
   render: () => ({
     template: `
       <ori-form style="max-width: 480px;">

--- a/packages/angular/src/components/header/header.stories.ts
+++ b/packages/angular/src/components/header/header.stories.ts
@@ -35,6 +35,7 @@ export default meta;
 type Story = StoryObj<OriHeaderComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     template: `
       <ori-header>
@@ -45,6 +46,7 @@ export const Default: Story = {
 };
 
 export const WithSubtitle: Story = {
+  name: 'Avec sous-titre',
   render: () => ({
     template: `
       <ori-header>
@@ -55,6 +57,7 @@ export const WithSubtitle: Story = {
 };
 
 export const WithActions: Story = {
+  name: 'Avec actions',
   render: () => ({
     template: `
       <ori-header>

--- a/packages/angular/src/components/input/input.stories.ts
+++ b/packages/angular/src/components/input/input.stories.ts
@@ -52,23 +52,27 @@ const meta: Meta<OriInputComponent> = {
 export default meta;
 type Story = StoryObj<OriInputComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: "Tel qu'il apparaît sur votre pièce d'identité." },
 };
 
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: { value: '', error: 'Ce champ est obligatoire.', required: true },
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: 'Valeur verrouillée' },
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => ({
     template: `
       <div style="display: flex; flex-direction: column; gap: 12px;">

--- a/packages/angular/src/components/language-switcher/language-switcher.stories.ts
+++ b/packages/angular/src/components/language-switcher/language-switcher.stories.ts
@@ -48,6 +48,7 @@ export const FrEn: Story = {
 };
 
 export const WithTahitian: Story = {
+  name: 'Avec Reo Tahiti',
   args: {
     value: 'fr',
     languages: [

--- a/packages/angular/src/components/link/link.stories.ts
+++ b/packages/angular/src/components/link/link.stories.ts
@@ -27,7 +27,7 @@ const meta: Meta<OriLinkComponent> = {
 export default meta;
 type Story = StoryObj<OriLinkComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Quiet: Story = {
   args: { variant: 'quiet' },
@@ -46,6 +46,7 @@ export const External: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   render: () => ({
     template: `
       <p style="max-width: 480px;">

--- a/packages/angular/src/components/login-layout/login-layout.stories.ts
+++ b/packages/angular/src/components/login-layout/login-layout.stories.ts
@@ -46,6 +46,7 @@ export default meta;
 type Story = StoryObj<OriLoginLayoutComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     template: `
       <ori-login-layout
@@ -85,6 +86,7 @@ export const Default: Story = {
 };
 
 export const WithAuthProvider: Story = {
+  name: 'Avec fournisseur d’identité',
   render: () => ({
     template: `
       <ori-login-layout
@@ -107,6 +109,7 @@ export const WithAuthProvider: Story = {
 };
 
 export const Minimal: Story = {
+  name: 'Minimal',
   render: () => ({
     template: `
       <ori-login-layout title="Se connecter">

--- a/packages/angular/src/components/logo/logo.stories.ts
+++ b/packages/angular/src/components/logo/logo.stories.ts
@@ -29,9 +29,10 @@ const meta: Meta<OriLogoComponent> = {
 export default meta;
 type Story = StoryObj<OriLogoComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithSubtitle: Story = {
+  name: 'Avec sous-titre',
   args: { subtitle: 'Direction des affaires maritimes' },
 };
 
@@ -40,5 +41,6 @@ export const AsLink: Story = {
 };
 
 export const TitleOnly: Story = {
+  name: 'Titre seul',
   args: { hideCrest: true, subtitle: 'Service en ligne' },
 };

--- a/packages/angular/src/components/main-navigation/main-navigation.stories.ts
+++ b/packages/angular/src/components/main-navigation/main-navigation.stories.ts
@@ -36,6 +36,7 @@ export default meta;
 type Story = StoryObj<OriMainNavigationComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     items: [
       { label: 'Accueil', href: '/' },

--- a/packages/angular/src/components/multi-select/multi-select.stories.ts
+++ b/packages/angular/src/components/multi-select/multi-select.stories.ts
@@ -32,6 +32,7 @@ export default meta;
 type Story = StoryObj<OriMultiSelectComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       options: services,
@@ -55,6 +56,7 @@ export const Default: Story = {
 };
 
 export const Virtualized5000: Story = {
+  name: '5000 options virtualisées',
   render: () => ({
     props: {
       options: Array.from({ length: 5000 }, (_, i) => ({
@@ -85,6 +87,7 @@ export const Virtualized5000: Story = {
 };
 
 export const WithMaxLimit: Story = {
+  name: 'Avec limite',
   render: () => ({
     props: {
       options: services,
@@ -113,6 +116,7 @@ export const WithMaxLimit: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   render: () => ({
     props: { options: services },
     template: `

--- a/packages/angular/src/components/notification/notification.stories.ts
+++ b/packages/angular/src/components/notification/notification.stories.ts
@@ -37,7 +37,7 @@ const meta: Meta<OriNotificationComponent> = {
 export default meta;
 type Story = StoryObj<OriNotificationComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithAction: Story = {
   args: {
@@ -60,6 +60,7 @@ export const WithAction: Story = {
 };
 
 export const Variants: Story = {
+  name: 'Variantes',
   render: () => ({
     template: `
       <div style="display: flex; flex-direction: column; gap: 8px;">

--- a/packages/angular/src/components/pagination/pagination.stories.ts
+++ b/packages/angular/src/components/pagination/pagination.stories.ts
@@ -30,6 +30,7 @@ export default meta;
 type Story = StoryObj<OriPaginationComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { page: 1, totalPages: 10 },
 };
 

--- a/packages/angular/src/components/progress/progress.stories.ts
+++ b/packages/angular/src/components/progress/progress.stories.ts
@@ -30,12 +30,13 @@ const meta: Meta<OriProgressComponent> = {
 export default meta;
 type Story = StoryObj<OriProgressComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithLabel: Story = {
   args: { value: 35, label: 'Téléversement en cours' },
 };
 
 export const Indeterminate: Story = {
+  name: 'Indéterminé',
   args: { value: null, label: 'Traitement en cours' },
 };

--- a/packages/angular/src/components/radio/radio.stories.ts
+++ b/packages/angular/src/components/radio/radio.stories.ts
@@ -22,6 +22,7 @@ export default meta;
 type Story = StoryObj<OriRadioGroupComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { label: 'Canal de notification préféré', value: 'email' },
   render: (args: Args) => ({
     props: args,
@@ -54,6 +55,7 @@ export const WithHints: Story = {
 };
 
 export const Required: Story = {
+  name: 'Requis',
   args: { label: 'Civilité', required: true },
   render: (args: Args) => ({
     props: args,
@@ -68,6 +70,7 @@ export const Required: Story = {
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     label: 'Civilité',
     required: true,
@@ -86,6 +89,7 @@ export const WithError: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   args: { label: 'Êtes-vous résident polynésien ?', orientation: 'inline', value: 'oui' },
   render: (args: Args) => ({
     props: args,
@@ -104,6 +108,7 @@ export const Inline: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { label: 'Mode de livraison', disabled: true, value: 'standard' },
   render: (args: Args) => ({
     props: args,

--- a/packages/angular/src/components/select/select.stories.ts
+++ b/packages/angular/src/components/select/select.stories.ts
@@ -56,23 +56,27 @@ const meta: Meta<OriSelectComponent> = {
 export default meta;
 type Story = StoryObj<OriSelectComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: "Telle que figurant sur votre pièce d'identité." },
 };
 
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: { error: 'Ce champ est obligatoire.', required: true },
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: 'mme' },
 };
 
 export const WithDisabledOption: Story = {
+  name: 'Avec option désactivée',
   args: {
     label: 'Mode de livraison',
     placeholder: 'Choisir un mode',
@@ -85,6 +89,7 @@ export const WithDisabledOption: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => ({
     template: `
       <div style="display: flex; flex-direction: column; gap: 12px;">

--- a/packages/angular/src/components/spinner/spinner.stories.ts
+++ b/packages/angular/src/components/spinner/spinner.stories.ts
@@ -23,10 +23,12 @@ export default meta;
 type Story = StoryObj<OriSpinnerComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { size: 'md', label: 'Chargement…' },
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => ({
     template: `
       <div style="display: flex; align-items: center; gap: 16px;">
@@ -39,6 +41,7 @@ export const Sizes: Story = {
 };
 
 export const InsideButton: Story = {
+  name: 'Dans un bouton',
   render: () => ({
     template: `
       <div style="display: flex; gap: 12px;">
@@ -55,6 +58,7 @@ export const InsideButton: Story = {
 };
 
 export const InlineInText: Story = {
+  name: 'En ligne dans un texte',
   render: () => ({
     template: `
       <p style="display: flex; align-items: center; gap: 8px; margin: 0;">
@@ -66,6 +70,7 @@ export const InlineInText: Story = {
 };
 
 export const CustomColor: Story = {
+  name: 'Couleur personnalisée',
   render: () => ({
     template: `
       <div style="display: flex; align-items: center; gap: 16px; color: #dc2626;">

--- a/packages/angular/src/components/statistic/statistic.stories.ts
+++ b/packages/angular/src/components/statistic/statistic.stories.ts
@@ -49,7 +49,7 @@ const meta: Meta<OriStatisticComponent> = {
 export default meta;
 type Story = StoryObj<OriStatisticComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const AvecTendance: Story = {
   args: {
@@ -125,6 +125,7 @@ export const DansUneCard: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   render: () => ({
     template: `
       <div style="display: flex; flex-direction: column; gap: 8px; max-width: 320px;">

--- a/packages/angular/src/components/switch/switch.stories.ts
+++ b/packages/angular/src/components/switch/switch.stories.ts
@@ -39,11 +39,12 @@ const meta: Meta<OriSwitchComponent> = {
 export default meta;
 type Story = StoryObj<OriSwitchComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const On: Story = { args: { checked: true } };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: "L'envoi est immédiat dès activation.",
     checked: true,
@@ -51,10 +52,12 @@ export const WithHint: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, checked: true, label: 'Réglage verrouillé' },
 };
 
 export const Group: Story = {
+  name: 'Groupe',
   render: () => ({
     template: `
       <fieldset class="ori-choice-group" style="border: 0; padding: 0; margin: 0;">

--- a/packages/angular/src/components/tabs/tabs.stories.ts
+++ b/packages/angular/src/components/tabs/tabs.stories.ts
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<OriTabsComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: { active: 'profile' },
     template: `

--- a/packages/angular/src/components/tag/tag.stories.ts
+++ b/packages/angular/src/components/tag/tag.stories.ts
@@ -29,9 +29,10 @@ const meta: Meta<OriTagComponent> = {
 export default meta;
 type Story = StoryObj<OriTagComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Variants: Story = {
+  name: 'Variantes',
   render: () => ({
     template: `
       <div style="display: flex; gap: 8px; flex-wrap: wrap;">

--- a/packages/angular/src/components/textarea/textarea.stories.ts
+++ b/packages/angular/src/components/textarea/textarea.stories.ts
@@ -50,18 +50,21 @@ const meta: Meta<OriTextareaComponent> = {
 export default meta;
 type Story = StoryObj<OriTextareaComponent>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: 'Maximum 500 caractères.' },
 };
 
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: { value: '', error: 'La description est obligatoire.', required: true },
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: 'Texte verrouillé qui ne peut pas être modifié.' },
 };

--- a/packages/angular/src/components/timeline/timeline.stories.ts
+++ b/packages/angular/src/components/timeline/timeline.stories.ts
@@ -62,6 +62,7 @@ const defaultItems: OriTimelineItem[] = [
 ];
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { items: defaultItems },
 };
 

--- a/packages/angular/src/components/toast/toast.stories.ts
+++ b/packages/angular/src/components/toast/toast.stories.ts
@@ -80,6 +80,7 @@ export default meta;
 type Story = StoryObj<ToastDemo>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { position: 'top-right' },
 };
 

--- a/packages/angular/src/components/tooltip/tooltip.stories.ts
+++ b/packages/angular/src/components/tooltip/tooltip.stories.ts
@@ -30,6 +30,7 @@ export default meta;
 type Story = StoryObj;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     template: `<ori-button variant="danger" pfTooltip="Action de suppression définitive">Supprimer</ori-button>`,
   }),

--- a/packages/angular/src/components/wizard/wizard.stories.ts
+++ b/packages/angular/src/components/wizard/wizard.stories.ts
@@ -41,6 +41,7 @@ export default meta;
 type Story = StoryObj<OriWizardComponent>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => ({
     props: {
       step: 0,
@@ -124,6 +125,7 @@ export const Default: Story = {
 };
 
 export const FiveSteps: Story = {
+  name: 'Cinq étapes',
   render: () => ({
     props: {
       step: 0,
@@ -150,6 +152,7 @@ export const FiveSteps: Story = {
 };
 
 export const NoGoBack: Story = {
+  name: 'Retour arrière désactivé',
   render: () => ({
     props: {
       step: 0,

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -26,6 +26,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Multiple: Story = {
+  name: 'Multiple',
   render: () => (
     <Accordion type="multiple">
       <Accordion.Item title="Quelles sont les pièces à fournir ?">

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -34,9 +34,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Info: Story = {};
+export const Info: Story = { name: 'Variante information' };
 
 export const Success: Story = {
+  name: 'Variante succès',
   args: {
     severity: 'success',
     title: 'Action réalisée',
@@ -45,6 +46,7 @@ export const Success: Story = {
 };
 
 export const Warning: Story = {
+  name: 'Variante avertissement',
   args: {
     severity: 'warning',
     title: 'Attention',
@@ -53,6 +55,7 @@ export const Warning: Story = {
 };
 
 export const Danger: Story = {
+  name: 'Variante danger',
   args: {
     severity: 'danger',
     title: 'Erreur',
@@ -68,6 +71,7 @@ export const Dismissible: Story = {
 };
 
 export const NoTitle: Story = {
+  name: 'Sans titre',
   args: {
     title: undefined,
     children: 'Un message simple, sans titre.',

--- a/packages/react/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -25,6 +25,7 @@ type Story = StoryObj<typeof meta>;
  * destructive.
  */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <AlertDialog>
       <AlertDialogTrigger asChild>
@@ -53,6 +54,7 @@ export const Default: Story = {
  * n'est pas en variant="danger".
  */
 export const Logout: Story = {
+  name: 'Déconnexion',
   render: () => (
     <AlertDialog>
       <AlertDialogTrigger asChild>

--- a/packages/react/src/components/AppShell/AppShell.stories.tsx
+++ b/packages/react/src/components/AppShell/AppShell.stories.tsx
@@ -100,6 +100,7 @@ const mockMain = (
 
 /** Layout complet : header + sidebar + main + footer. */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <div style={{ height: 600, border: '1px dashed #d4d4d8' }}>
       <AppShell header={mockHeader} sidebar={mockSidebar} footer={mockFooter}>
@@ -111,6 +112,7 @@ export const Default: Story = {
 
 /** Sans sidebar : layout simple (header + main + footer). */
 export const NoSidebar: Story = {
+  name: 'Sans sidebar',
   render: () => (
     <div style={{ height: 600, border: '1px dashed #d4d4d8' }}>
       <AppShell header={mockHeader} footer={mockFooter}>
@@ -122,6 +124,7 @@ export const NoSidebar: Story = {
 
 /** Drawer mobile : démontre le toggle de la sidebar piloté par l'app. */
 export const SidebarDrawer: Story = {
+  name: 'Sidebar en drawer',
   render: () => {
     const [open, setOpen] = useState(false);
     return (

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -34,6 +34,7 @@ export const WithImage: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => (
     <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
       <Avatar alt="Marie Dupont" size="sm" />

--- a/packages/react/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -19,6 +19,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     items: [
       { label: 'Accueil', href: '/' },

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -36,21 +36,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {};
+export const Primary: Story = { name: 'Variante primaire' };
 
 export const Secondary: Story = {
+  name: 'Variante secondaire',
   args: { variant: 'secondary' },
 };
 
 export const Ghost: Story = {
+  name: 'Variante fantôme',
   args: { variant: 'ghost' },
 };
 
 export const Danger: Story = {
+  name: 'Variante danger',
   args: { variant: 'danger', children: 'Supprimer' },
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: (args) => (
     <div style={{ display: 'flex', gap: '1rem', alignItems: 'center' }}>
       <Button {...args} size="sm">
@@ -67,6 +71,7 @@ export const Sizes: Story = {
 };
 
 export const AllVariants: Story = {
+  name: 'Toutes les variantes',
   render: () => (
     <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
       <Button variant="primary">Primary</Button>

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -31,6 +31,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: (args) => (
     <Card {...args}>
       <CardHeader title="Titre de la card" subtitle="Un sous-titre descriptif" />

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -26,33 +26,38 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Checked: Story = {
   args: { defaultChecked: true },
 };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: 'Vous pouvez retirer votre consentement à tout moment depuis vos préférences.',
   },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: 'Vous devez accepter les conditions pour continuer.',
   },
 };
 
 export const Indeterminate: Story = {
+  name: 'Indéterminé',
   args: { indeterminate: true, label: 'Sélectionner toutes les lignes' },
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, defaultChecked: true, label: 'Option verrouillée' },
 };
 
 export const Group: Story = {
+  name: 'Groupe',
   render: () => (
     <fieldset className="ori-choice-group" style={{ border: 0, padding: 0, margin: 0 }}>
       <legend className="ori-field__label">Notifications par email</legend>

--- a/packages/react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/Combobox/Combobox.stories.tsx
@@ -31,6 +31,7 @@ const archipels: ComboboxOption[] = [
 ];
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => {
     const [value, setValue] = useState<string | undefined>(undefined);
     return (
@@ -48,6 +49,7 @@ export const Default: Story = {
 };
 
 export const WithDescription: Story = {
+  name: 'Avec description',
   render: () => {
     const [value, setValue] = useState<string | undefined>('soc');
     return (
@@ -65,6 +67,7 @@ export const WithDescription: Story = {
 };
 
 export const WithDisabledOption: Story = {
+  name: 'Avec option désactivée',
   render: () => {
     const [value, setValue] = useState<string | undefined>(undefined);
     const opts: ComboboxOption[] = [
@@ -87,6 +90,7 @@ export const WithDisabledOption: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   render: () => (
     <div style={{ width: 360 }}>
       <Combobox options={services} value="dgi" label="Service administratif" disabled />
@@ -95,6 +99,7 @@ export const Disabled: Story = {
 };
 
 export const NoResults: Story = {
+  name: 'Aucun résultat',
   render: () => {
     const [value, setValue] = useState<string | undefined>(undefined);
     return (

--- a/packages/react/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/react/src/components/DataTable/DataTable.stories.tsx
@@ -89,6 +89,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Cas standard : 47 demandes, filtre + tri + actions + pagination 10 par page. */
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     columns,
     data: demandes,
@@ -104,6 +105,7 @@ export const Default: Story = {
 
 /** Sans actions de ligne : table consultative. */
 export const ReadOnly: Story = {
+  name: 'Consultation seule',
   args: {
     columns,
     data: demandes.slice(0, 15),
@@ -114,6 +116,7 @@ export const ReadOnly: Story = {
 
 /** Sans pagination : affichage compact pour listes courtes (≤ 20 lignes typiquement). */
 export const NoPagination: Story = {
+  name: 'Sans pagination',
   args: {
     columns,
     data: demandes.slice(0, 8),
@@ -125,6 +128,7 @@ export const NoPagination: Story = {
 
 /** État de chargement. */
 export const Loading: Story = {
+  name: 'Chargement',
   args: {
     columns,
     data: [],
@@ -135,6 +139,7 @@ export const Loading: Story = {
 
 /** Aucune donnée correspondante. */
 export const EmptyAfterFilter: Story = {
+  name: 'Vide après filtrage',
   args: {
     columns,
     data: demandes.slice(0, 5),

--- a/packages/react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.tsx
@@ -35,9 +35,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: "Telle qu'elle figure sur votre pièce d'identité.",
   },
@@ -59,6 +60,7 @@ export const WithBounds: Story = {
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: "Cette date doit être antérieure à aujourd'hui.",
     defaultValue: '2030-01-01',
@@ -66,10 +68,12 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, defaultValue: '2026-04-25' },
 };
 
 export const Controlled: Story = {
+  name: 'Contrôlé',
   render: (args) => {
     const [value, setValue] = useState('');
     return (

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -15,6 +15,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <Dialog>
       <DialogTrigger asChild>
@@ -43,6 +44,7 @@ export const Default: Story = {
 };
 
 export const LongContent: Story = {
+  name: 'Contenu long',
   render: () => (
     <Dialog>
       <DialogTrigger asChild>
@@ -68,6 +70,7 @@ export const LongContent: Story = {
 };
 
 export const NoFooter: Story = {
+  name: 'Sans pied',
   render: () => (
     <Dialog>
       <DialogTrigger asChild>

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -33,6 +33,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -54,6 +55,7 @@ export const Default: Story = {
 };
 
 export const UserMenu: Story = {
+  name: 'Menu utilisateur',
   render: () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -78,6 +80,7 @@ export const UserMenu: Story = {
 };
 
 export const WithShortcuts: Story = {
+  name: 'Avec raccourcis',
   render: () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -100,6 +103,7 @@ export const WithShortcuts: Story = {
 };
 
 export const WithDisabledItem: Story = {
+  name: 'Avec élément désactivé',
   render: () => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -117,6 +121,7 @@ export const WithDisabledItem: Story = {
 };
 
 export const ControlledOpen: Story = {
+  name: 'Contrôlé (ouvert)',
   render: () => {
     const [open, setOpen] = useState(false);
     return (

--- a/packages/react/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/react/src/components/EmptyState/EmptyState.stories.tsx
@@ -15,6 +15,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Cas standard : taille md, une action principale. */
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     icon: <Inbox size={48} />,
     title: 'Aucune demande en cours',
@@ -26,6 +27,7 @@ export const Default: Story = {
 
 /** Filtre vide : taille sm, ton plus discret. */
 export const SearchNoResults: Story = {
+  name: 'Recherche sans résultat',
   args: {
     icon: <Search size={32} />,
     title: 'Aucun résultat',
@@ -38,6 +40,7 @@ export const SearchNoResults: Story = {
 
 /** Onboarding : taille lg pour une page entière, deux actions. */
 export const OnboardingLarge: Story = {
+  name: 'Onboarding grande taille',
   args: {
     icon: <Users size={64} />,
     title: 'Bienvenue dans votre espace',
@@ -55,6 +58,7 @@ export const OnboardingLarge: Story = {
 
 /** Sans description : titre seul + action. */
 export const Minimal: Story = {
+  name: 'Minimal',
   args: {
     icon: <FilePlus size={48} />,
     title: 'Aucun document',
@@ -64,6 +68,7 @@ export const Minimal: Story = {
 
 /** Sans icône ni action : juste le texte d'absence. */
 export const TextOnly: Story = {
+  name: 'Texte seul',
   args: {
     title: 'Aucune notification',
     description: 'Vous serez prévenu ici de toute nouvelle activité concernant vos dossiers.',

--- a/packages/react/src/components/FileCard/FileCard.stories.tsx
+++ b/packages/react/src/components/FileCard/FileCard.stories.tsx
@@ -38,7 +38,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const AvecActions: Story = {
   args: {

--- a/packages/react/src/components/FileUpload/FileUpload.stories.tsx
+++ b/packages/react/src/components/FileUpload/FileUpload.stories.tsx
@@ -34,9 +34,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: 'Formats acceptés : PDF, JPG, PNG. Taille maximale : 5 Mo.',
     accept: '.pdf,image/jpeg,image/png',
@@ -46,6 +47,7 @@ export const WithHint: Story = {
 };
 
 export const Multiple: Story = {
+  name: 'Multiple',
   args: {
     label: 'Pièces justificatives',
     hint: 'Vous pouvez ajouter plusieurs fichiers.',
@@ -56,10 +58,12 @@ export const Multiple: Story = {
 };
 
 export const Required: Story = {
+  name: 'Requis',
   args: { required: true },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: 'Au moins un fichier est obligatoire.',
     required: true,
@@ -67,10 +71,12 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true },
 };
 
 export const Controlled: Story = {
+  name: 'Contrôlé',
   render: (args) => {
     const [files, setFiles] = useState<File[]>([]);
     const [rejected, setRejected] = useState<string | null>(null);

--- a/packages/react/src/components/Footer/Footer.stories.tsx
+++ b/packages/react/src/components/Footer/Footer.stories.tsx
@@ -20,6 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     brand: 'Polynésie française',
     description: 'Service en ligne officiel',
@@ -71,6 +72,7 @@ export const WithColumns: Story = {
 };
 
 export const Minimal: Story = {
+  name: 'Minimal',
   args: {
     brand: 'Polynésie française',
     legal: '© 2026',

--- a/packages/react/src/components/Form/Form.stories.tsx
+++ b/packages/react/src/components/Form/Form.stories.tsx
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Formulaire simple : une section, deux champs, deux actions. */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <Form
       onSubmit={(e) => {
@@ -45,6 +46,7 @@ export const Default: Story = {
 
 /** Plusieurs sections : démontre la séparation visuelle entre groupes de champs. */
 export const MultipleSections: Story = {
+  name: 'Plusieurs sections',
   render: () => (
     <Form style={{ maxWidth: 560 }}>
       <FormSection title="Identité" description="Informations administratives.">
@@ -87,6 +89,7 @@ export const MultipleSections: Story = {
 
 /** Validation : démontre l'affichage d'erreur en rouge sous le champ. */
 export const WithErrors: Story = {
+  name: 'Avec erreurs',
   render: () => {
     const [submitted, setSubmitted] = useState(false);
     return (
@@ -120,6 +123,7 @@ export const WithErrors: Story = {
 
 /** Aligned start : actions à gauche au lieu de droite. */
 export const ActionsAlignedStart: Story = {
+  name: 'Actions alignées à gauche',
   render: () => (
     <Form style={{ maxWidth: 480 }}>
       <FormSection>

--- a/packages/react/src/components/Header/Header.stories.tsx
+++ b/packages/react/src/components/Header/Header.stories.tsx
@@ -23,14 +23,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { title: 'Polynésie française' },
 };
 
 export const WithSubtitle: Story = {
+  name: 'Avec sous-titre',
   args: { title: 'Polynésie française', subtitle: 'Service en ligne' },
 };
 
 export const WithActions: Story = {
+  name: 'Avec actions',
   render: () => (
     <Header>
       <Header.Brand>

--- a/packages/react/src/components/Input/Input.stories.tsx
+++ b/packages/react/src/components/Input/Input.stories.tsx
@@ -35,17 +35,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: "Tel qu'il apparaît sur votre pièce d'identité." },
 };
 
 export const Required: Story = {
+  name: 'Requis',
   args: { required: true },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     value: '',
     error: 'Ce champ est obligatoire.',
@@ -54,10 +57,12 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: 'Valeur verrouillée' },
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <Input {...args} size="sm" label="Petit" />

--- a/packages/react/src/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
+++ b/packages/react/src/components/LanguageSwitcher/LanguageSwitcher.stories.tsx
@@ -43,6 +43,7 @@ export const FrEn: Story = {
 };
 
 export const WithTahitian: Story = {
+  name: 'Avec Reo Tahiti',
   render: () => {
     const [lang, setLang] = useState('fr');
     return (

--- a/packages/react/src/components/Link/Link.stories.tsx
+++ b/packages/react/src/components/Link/Link.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Quiet: Story = {
   args: { variant: 'quiet', children: 'Modifier mon adresse' },
@@ -40,6 +40,7 @@ export const External: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   render: () => (
     <p style={{ maxWidth: 480 }}>
       Vous pouvez consulter <Link href="/cgu">les conditions générales</Link>, ou en savoir plus sur

--- a/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
@@ -33,6 +33,7 @@ const sharedFooter = (
 
 /** Cas standard : login email + mot de passe + lien d'aide. */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <LoginLayout
       logo={<Logo />}
@@ -67,6 +68,7 @@ export const Default: Story = {
 
 /** Avec AuthButton (GOV Connect / Rumia / Microsoft) : pas de formulaire local. */
 export const WithAuthProvider: Story = {
+  name: 'Avec fournisseur d’identité',
   render: () => (
     <LoginLayout
       logo={<Logo />}
@@ -84,6 +86,7 @@ export const WithAuthProvider: Story = {
 
 /** Sans cardFooter ni footer : login minimal. */
 export const Minimal: Story = {
+  name: 'Minimal',
   render: () => (
     <LoginLayout title="Se connecter">
       <Form>

--- a/packages/react/src/components/Logo/Logo.stories.tsx
+++ b/packages/react/src/components/Logo/Logo.stories.tsx
@@ -18,9 +18,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithSubtitle: Story = {
+  name: 'Avec sous-titre',
   args: {
     title: 'Polynésie française',
     subtitle: 'Direction des affaires maritimes',
@@ -36,5 +37,6 @@ export const AsLink: Story = {
 };
 
 export const TitleOnly: Story = {
+  name: 'Titre seul',
   args: { hideCrest: true, title: 'Polynésie française', subtitle: 'Service en ligne' },
 };

--- a/packages/react/src/components/MainNavigation/MainNavigation.stories.tsx
+++ b/packages/react/src/components/MainNavigation/MainNavigation.stories.tsx
@@ -21,6 +21,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     items: [
       { label: 'Accueil', href: '/' },

--- a/packages/react/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/packages/react/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -26,6 +26,7 @@ const services: MultiSelectOption[] = [
 
 /** Cas standard : peu d'options, sans virtualisation perçue. */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => {
     const [values, setValues] = useState<string[]>([]);
     return (
@@ -44,6 +45,7 @@ export const Default: Story = {
 
 /** Cas large : 5 000 options générées, démontre la virtualisation. */
 export const Virtualized5000: Story = {
+  name: '5000 options virtualisées',
   render: () => {
     const opts: MultiSelectOption[] = Array.from({ length: 5000 }, (_, i) => ({
       id: `opt-${i}`,
@@ -70,6 +72,7 @@ export const Virtualized5000: Story = {
 
 /** Limite à 3 sélections : les autres options se grisent quand la limite est atteinte. */
 export const WithMaxLimit: Story = {
+  name: 'Avec limite',
   render: () => {
     const [values, setValues] = useState<string[]>([]);
     return (
@@ -92,6 +95,7 @@ export const WithMaxLimit: Story = {
 };
 
 export const WithDisabledOption: Story = {
+  name: 'Avec option désactivée',
   render: () => {
     const opts: MultiSelectOption[] = [
       { id: 'a', label: 'Option A' },
@@ -114,6 +118,7 @@ export const WithDisabledOption: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   render: () => (
     <div style={{ width: 360 }}>
       <MultiSelect options={services} values={['dgi', 'dge']} label="Services concernés" disabled />

--- a/packages/react/src/components/Notification/Notification.stories.tsx
+++ b/packages/react/src/components/Notification/Notification.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithAction: Story = {
   args: {
@@ -40,6 +40,7 @@ export const WithAction: Story = {
 };
 
 export const Variants: Story = {
+  name: 'Variantes',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <Notification variant="info">

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -20,6 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => {
     const [page, setPage] = useState(1);
     return <Pagination page={page} totalPages={10} onPageChange={setPage} />;

--- a/packages/react/src/components/Progress/Progress.stories.tsx
+++ b/packages/react/src/components/Progress/Progress.stories.tsx
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { value: 60, max: 100 },
 };
 
@@ -35,6 +36,7 @@ export const WithLabel: Story = {
 };
 
 export const Indeterminate: Story = {
+  name: 'Indéterminé',
   args: { label: 'Traitement en cours' },
 };
 

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -20,6 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => {
     const [value, setValue] = useState('email');
     return (
@@ -51,6 +52,7 @@ export const WithHints: Story = {
 };
 
 export const Required: Story = {
+  name: 'Requis',
   render: () => {
     const [value, setValue] = useState<string | undefined>(undefined);
     return (
@@ -64,6 +66,7 @@ export const Required: Story = {
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   render: () => (
     <RadioGroup label="Civilité" required error="Vous devez sélectionner une option.">
       <Radio value="mme" label="Madame" />
@@ -74,6 +77,7 @@ export const WithError: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   render: () => {
     const [value, setValue] = useState('oui');
     return (
@@ -91,6 +95,7 @@ export const Inline: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   render: () => (
     <RadioGroup label="Mode de livraison" disabled value="standard">
       <Radio value="standard" label="Standard" />

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -41,9 +41,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: "Telle que figurant sur votre pièce d'identité.",
   },
@@ -52,6 +53,7 @@ export const WithHint: Story = {
 export const Required: Story = { args: { required: true } };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     error: 'Ce champ est obligatoire.',
     required: true,
@@ -59,10 +61,12 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, defaultValue: 'mme' },
 };
 
 export const WithDisabledOption: Story = {
+  name: 'Avec option désactivée',
   args: {
     label: 'Mode de livraison',
     placeholder: 'Choisir un mode',
@@ -75,6 +79,7 @@ export const WithDisabledOption: Story = {
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       <Select {...args} size="sm" label="Petit" />
@@ -85,6 +90,7 @@ export const Sizes: Story = {
 };
 
 export const Controlled: Story = {
+  name: 'Contrôlé',
   render: (args) => {
     const [value, setValue] = useState('');
     return (

--- a/packages/react/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/Spinner/Spinner.stories.tsx
@@ -13,10 +13,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { size: 'md', label: 'Chargement…' },
 };
 
 export const Sizes: Story = {
+  name: 'Tailles',
   render: () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
       <Spinner size="sm" />
@@ -31,6 +33,7 @@ export const Sizes: Story = {
  * pendant une action asynchrone (envoi de formulaire, validation).
  */
 export const InsideButton: Story = {
+  name: 'Dans un bouton',
   render: () => (
     <div style={{ display: 'flex', gap: 12 }}>
       <Button disabled>
@@ -47,6 +50,7 @@ export const InsideButton: Story = {
  * Inline dans un texte : indique un chargement local sans bloquer l'écran.
  */
 export const InlineInText: Story = {
+  name: 'En ligne dans un texte',
   render: () => (
     <p style={{ display: 'flex', alignItems: 'center', gap: 8, margin: 0 }}>
       <Spinner size="sm" label="Vérification du numéro fiscal" />
@@ -60,6 +64,7 @@ export const InlineInText: Story = {
  * `currentColor`. Ici, un parent en rouge.
  */
 export const CustomColor: Story = {
+  name: 'Couleur personnalisée',
   render: () => (
     <div style={{ display: 'flex', alignItems: 'center', gap: 16, color: '#dc2626' }}>
       <Spinner size="lg" />

--- a/packages/react/src/components/Statistic/Statistic.stories.tsx
+++ b/packages/react/src/components/Statistic/Statistic.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const AvecTendance: Story = {
   args: {
@@ -91,6 +91,7 @@ export const VariantInline: Story = {
 };
 
 export const Loading: Story = {
+  name: 'Chargement',
   args: {
     label: 'Calcul en cours…',
     value: 0,
@@ -145,6 +146,7 @@ export const DansUneCard: Story = {
 };
 
 export const Inline: Story = {
+  name: 'En ligne',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: 320 }}>
       <Statistic variant="inline" label="Démarches en cours" value={2} />

--- a/packages/react/src/components/Steps/Steps.stories.tsx
+++ b/packages/react/src/components/Steps/Steps.stories.tsx
@@ -34,6 +34,7 @@ const steps = [
 ];
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: { steps, current: 1 },
 };
 

--- a/packages/react/src/components/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/Switch/Switch.stories.tsx
@@ -25,13 +25,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const On: Story = {
   args: { defaultChecked: true },
 };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: {
     hint: "L'envoi est immédiat dès activation.",
     defaultChecked: true,
@@ -39,10 +40,12 @@ export const WithHint: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, defaultChecked: true, label: 'Réglage verrouillé' },
 };
 
 export const Controlled: Story = {
+  name: 'Contrôlé',
   render: () => {
     const [enabled, setEnabled] = useState(false);
     return (
@@ -62,6 +65,7 @@ export const Controlled: Story = {
 };
 
 export const Group: Story = {
+  name: 'Groupe',
   render: () => (
     <fieldset className="ori-choice-group" style={{ border: 0, padding: 0, margin: 0 }}>
       <legend className="ori-field__label">Préférences de confidentialité</legend>

--- a/packages/react/src/components/Table/Table.stories.tsx
+++ b/packages/react/src/components/Table/Table.stories.tsx
@@ -95,6 +95,7 @@ const STATUT_LABEL = {
 } as const;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <Table<Demande>
       caption="Liste des demandes"
@@ -282,6 +283,7 @@ export const Empty: Story = {
 };
 
 export const Loading: Story = {
+  name: 'Chargement',
   render: () => (
     <Table
       columns={[

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <Tabs defaultValue="profile">
       <Tabs.List aria-label="Réglages utilisateur">
@@ -68,6 +69,7 @@ export const WithDisabled: Story = {
 };
 
 export const Controlled: Story = {
+  name: 'Contrôlé',
   render: () => {
     const [value, setValue] = useState('a');
     return (

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -26,9 +26,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const Variants: Story = {
+  name: 'Variantes',
   render: () => (
     <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
       <Tag variant="neutral">Brouillon</Tag>

--- a/packages/react/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/Textarea/Textarea.stories.tsx
@@ -36,17 +36,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithHint: Story = {
+  name: 'Avec indication',
   args: { hint: 'Maximum 500 caractères.' },
 };
 
 export const Required: Story = {
+  name: 'Requis',
   args: { required: true },
 };
 
 export const WithError: Story = {
+  name: 'Avec erreur',
   args: {
     value: '',
     error: 'La description est obligatoire.',
@@ -55,6 +58,7 @@ export const WithError: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: { disabled: true, value: 'Texte verrouillé qui ne peut pas être modifié.' },
 };
 

--- a/packages/react/src/components/Timeline/Timeline.stories.tsx
+++ b/packages/react/src/components/Timeline/Timeline.stories.tsx
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     items: [
       {

--- a/packages/react/src/components/Toast/Toast.stories.tsx
+++ b/packages/react/src/components/Toast/Toast.stories.tsx
@@ -64,6 +64,7 @@ function Trigger({ position }: { position?: ToastViewportPosition }) {
 }
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <ToastProvider>
       <Trigger />

--- a/packages/react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.tsx
@@ -27,6 +27,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   args: {
     content: 'Action de suppression définitive',
     children: <Button variant="danger">Supprimer</Button>,
@@ -61,6 +62,7 @@ export const FastDelay: Story = {
 };
 
 export const Disabled: Story = {
+  name: 'Désactivé',
   args: {
     content: "Ce tooltip ne s'affichera pas",
     disabled: true,

--- a/packages/react/src/components/Wizard/Wizard.stories.tsx
+++ b/packages/react/src/components/Wizard/Wizard.stories.tsx
@@ -18,6 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Démarche en 3 étapes avec validation simple par étape. */
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => {
     const [step, setStep] = useState(0);
     const [nom, setNom] = useState('');
@@ -86,6 +87,7 @@ export const Default: Story = {
 
 /** Wizard avec 5 étapes : démontre le rendu de Steps avec plus de marches. */
 export const FiveSteps: Story = {
+  name: 'Cinq étapes',
   render: () => {
     const [step, setStep] = useState(0);
     return (
@@ -107,6 +109,7 @@ export const FiveSteps: Story = {
 
 /** allowGoBack=false : retour aux étapes précédentes désactivé via Steps. */
 export const NoGoBack: Story = {
+  name: 'Retour arrière désactivé',
   render: () => {
     const [step, setStep] = useState(0);
     return (

--- a/packages/react/src/docs/Callout/Callout.stories.tsx
+++ b/packages/react/src/docs/Callout/Callout.stories.tsx
@@ -43,6 +43,7 @@ export const Tip: Story = {
 };
 
 export const Warning: Story = {
+  name: 'Variante avertissement',
   args: {
     variant: 'warning',
     title: 'Attention',
@@ -51,6 +52,7 @@ export const Warning: Story = {
 };
 
 export const Danger: Story = {
+  name: 'Variante danger',
   args: {
     variant: 'danger',
     title: 'À ne pas faire',
@@ -59,10 +61,12 @@ export const Danger: Story = {
 };
 
 export const NoTitle: Story = {
+  name: 'Sans titre',
   args: { title: undefined },
 };
 
 export const AllVariants: Story = {
+  name: 'Toutes les variantes',
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
       <Callout variant="note" title="Note">

--- a/packages/react/src/docs/CodeBlock/CodeBlock.stories.tsx
+++ b/packages/react/src/docs/CodeBlock/CodeBlock.stories.tsx
@@ -32,7 +32,7 @@ export function App() {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithFilename: Story = {
   args: { filename: 'src/App.tsx' },

--- a/packages/react/src/docs/Toc/Toc.stories.tsx
+++ b/packages/react/src/docs/Toc/Toc.stories.tsx
@@ -31,6 +31,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   decorators: [
     (Story) => (
       <div style={{ width: '14rem' }}>

--- a/packages/react/src/marketing/FeatureGrid/FeatureGrid.stories.tsx
+++ b/packages/react/src/marketing/FeatureGrid/FeatureGrid.stories.tsx
@@ -22,6 +22,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  name: 'Par défaut',
   render: () => (
     <FeatureGrid>
       <FeatureCard

--- a/packages/react/src/marketing/Hero/Hero.stories.tsx
+++ b/packages/react/src/marketing/Hero/Hero.stories.tsx
@@ -30,9 +30,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = { name: 'Par défaut' };
 
 export const WithActions: Story = {
+  name: 'Avec actions',
   args: {
     actions: (
       <>
@@ -48,5 +49,6 @@ export const Muted: Story = {
 };
 
 export const TitleOnly: Story = {
+  name: 'Titre seul',
   args: { eyebrow: undefined, subtitle: undefined },
 };


### PR DESCRIPTION
## Contexte

Feedback du reviewer après l'exposition d'\`index.json\` :

> Mélange FR/EN dans les noms de stories. Statistic a 'Avec Tendance', 'Tendance Negative', 'Pourcentage' en français à côté de 'Loading', 'Default', 'Inline' en anglais. Décide une fois pour toutes : soit tout en français, soit tout en anglais. **L'inconsistance actuelle est ce qu'il y a de pire.**

Choix retenu : **tout en français** (cohérent avec un DS de service public PF).

## Approche

- **Pas de renommage des exports** (\`export const Default: Story = ...\`) : on garde les noms anglais standards comme convention de code, plus copiable depuis StackBlitz et autres exemples Storybook.
- **Ajout de la prop \`name: 'FR'\`** sur chaque story portant un nom anglais standard. Storybook 8+ utilise cette prop pour l'affichage en priorité, et fallback sur le nom de l'export sinon.

## Stats

- **272 ajouts dans 91 fichiers** stories (.tsx React + .ts Angular)
- Mapping de ~60 noms anglais courants → FR :
  - \`Default\` → Par défaut (80 occurrences)
  - \`Disabled\` → Désactivé (21x)
  - \`WithHint\` → Avec indication (14x)
  - \`WithError\` → Avec erreur (14x)
  - \`Required\` → Requis (12x)
  - \`Sizes\` → Tailles (10x)
  - \`Loading\` → Chargement
  - \`Inline\` → En ligne
  - \`Multiple\` → Multiple
  - \`Indeterminate\` → Indéterminé
  - \`Group\` → Groupe
  - \`Controlled\` → Contrôlé
  - \`Minimal\` → Minimal
  - ... etc

Mapping complet généré par \`scripts/add-french-story-names.pl\` (script perl avec \`use utf8\` pour préserver les accents).

## Test plan

- [x] \`pnpm --filter @govpf/ori-react test\` : 196/196 verts
- [x] \`pnpm --filter @govpf/ori-storybook-react build\` : OK (15 s)
- [x] \`pnpm --filter @govpf/ori-storybook-angular build\` : OK
- [x] Aucun import externe des stories vérifié par grep (donc renommage exports aurait été safe aussi, mais l'approche \`name:\` reste plus standard)

## Hors scope

Quelques exports déjà en français camelCase perdent leurs accents au split Storybook (\`TendanceNegative\` → \"Tendance Negative\" sans accent sur le é). Cas chirurgicaux à traiter au besoin dans une PR ultérieure après évaluation visuelle.