### PR TITLE
fix(stories): noms FR sur les exports camelCase français cités explicitement

### DIFF
--- a/packages/angular/src/components/statistic/statistic.stories.ts
+++ b/packages/angular/src/components/statistic/statistic.stories.ts
@@ -52,6 +52,7 @@ type Story = StoryObj<OriStatisticComponent>;
 export const Default: Story = { name: 'Par défaut' };
 
 export const AvecTendance: Story = {
+  name: 'Avec tendance',
   args: {
     label: 'Démarches en cours',
     value: 24,
@@ -60,6 +61,7 @@ export const AvecTendance: Story = {
 };
 
 export const TendanceNegative: Story = {
+  name: 'Tendance négative',
   args: {
     label: 'Délai moyen de traitement',
     value: 8,
@@ -69,6 +71,7 @@ export const TendanceNegative: Story = {
 };
 
 export const AvecSuffixe: Story = {
+  name: 'Avec suffixe',
   args: {
     label: 'Taux de complétude',
     value: 87,
@@ -78,6 +81,7 @@ export const AvecSuffixe: Story = {
 };
 
 export const VariantLarge: Story = {
+  name: 'Variante large',
   args: {
     label: 'Démarches en cours',
     value: 24,
@@ -87,6 +91,7 @@ export const VariantLarge: Story = {
 };
 
 export const VariantInline: Story = {
+  name: 'Variante en ligne',
   args: {
     label: 'Total des demandes',
     value: 154,
@@ -94,9 +99,10 @@ export const VariantInline: Story = {
   },
 };
 
-export const Loading: Story = { args: { loading: true } };
+export const Loading: Story = { name: 'Chargement', args: { loading: true } };
 
 export const DansUneCard: Story = {
+  name: 'Dans une carte',
   render: () => ({
     template: `
       <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; max-width: 720px;">

--- a/packages/react/src/components/FileCard/FileCard.stories.tsx
+++ b/packages/react/src/components/FileCard/FileCard.stories.tsx
@@ -41,6 +41,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = { name: 'Par défaut' };
 
 export const AvecActions: Story = {
+  name: 'Avec actions',
   args: {
     actions: [
       { label: 'Aperçu', icon: <Eye size={16} aria-hidden="true" /> },
@@ -51,6 +52,7 @@ export const AvecActions: Story = {
 };
 
 export const AvecLien: Story = {
+  name: 'Avec lien',
   args: {
     link: { label: 'Lié à 2026-0042', href: '#42' },
     actions: [
@@ -61,6 +63,7 @@ export const AvecLien: Story = {
 };
 
 export const TousLesTypes: Story = {
+  name: 'Tous les types',
   render: () => (
     <div
       style={{
@@ -80,6 +83,7 @@ export const TousLesTypes: Story = {
 };
 
 export const NomLong: Story = {
+  name: 'Nom long',
   args: {
     name: 'Justificatif de domicile - Avenue Pouvanaa a Oopa - Avril 2026.pdf',
     actions: [
@@ -90,6 +94,7 @@ export const NomLong: Story = {
 };
 
 export const SansActions: Story = {
+  name: 'Sans actions',
   args: {
     name: 'Attestation employeur.pdf',
     type: 'pdf',
@@ -99,6 +104,7 @@ export const SansActions: Story = {
 };
 
 export const CollectionLiéeÀUneDemarche: Story = {
+  name: 'Collection liée à une démarche',
   render: () => (
     <div
       style={{

--- a/packages/react/src/components/Statistic/Statistic.stories.tsx
+++ b/packages/react/src/components/Statistic/Statistic.stories.tsx
@@ -32,6 +32,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = { name: 'Par défaut' };
 
 export const AvecTendance: Story = {
+  name: 'Avec tendance',
   args: {
     label: 'Démarches en cours',
     value: 24,
@@ -40,6 +41,7 @@ export const AvecTendance: Story = {
 };
 
 export const TendanceNegative: Story = {
+  name: 'Tendance négative',
   args: {
     label: 'Délai moyen de traitement',
     value: 8,
@@ -49,6 +51,7 @@ export const TendanceNegative: Story = {
 };
 
 export const TendancePlate: Story = {
+  name: 'Tendance plate',
   args: {
     label: 'Documents archivés',
     value: 47,
@@ -57,6 +60,7 @@ export const TendancePlate: Story = {
 };
 
 export const AvecPrefixSuffix: Story = {
+  name: 'Avec préfixe et suffixe',
   args: {
     label: 'Montant des aides versées',
     value: 1240000,
@@ -65,6 +69,7 @@ export const AvecPrefixSuffix: Story = {
 };
 
 export const Pourcentage: Story = {
+  name: 'Pourcentage',
   args: {
     label: 'Taux de complétude',
     value: 87,
@@ -74,6 +79,7 @@ export const Pourcentage: Story = {
 };
 
 export const VariantLarge: Story = {
+  name: 'Variante large',
   args: {
     label: 'Démarches en cours',
     value: 24,
@@ -83,6 +89,7 @@ export const VariantLarge: Story = {
 };
 
 export const VariantInline: Story = {
+  name: 'Variante en ligne',
   args: {
     label: 'Total des demandes',
     value: 154,
@@ -100,6 +107,7 @@ export const Loading: Story = {
 };
 
 export const ChargementProgressif: Story = {
+  name: 'Chargement progressif',
   render: () => {
     const [v, setV] = useState<number | null>(null);
     useEffect(() => {
@@ -118,6 +126,7 @@ export const ChargementProgressif: Story = {
 };
 
 export const DansUneCard: Story = {
+  name: 'Dans une carte',
   render: () => (
     <div
       style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '1rem', maxWidth: 720 }}
@@ -158,6 +167,7 @@ export const Inline: Story = {
 };
 
 export const FormatageNombre: Story = {
+  name: 'Formatage du nombre',
   render: () => (
     <div
       style={{


### PR DESCRIPTION
## Bug

Le reviewer a remonté :

> \`Collection LiéeÀ Une Demarche\` a un \`À\` accolé qui sent le bug d'auto-formatage Storybook depuis le nom de l'export.

Diagnostic : Storybook splite les noms d'exports camelCase à chaque transition lower → upper, mais ne reconnaît **pas** les majuscules accentuées (À, É, È…) comme separator. D'où le \`LiéeÀUne\` qui restait collé. Les autres exports camelCase français fonctionnent visuellement (\"Avec Actions\", \"Tous Les Types\") mais perdent les accents minuscules au split (\"Tendance Negative\" au lieu de \"Tendance négative\").

## Fix

Ajout d'une prop \`name: 'FR'\` sur les exports les plus visibles cités explicitement :

- **FileCard React** : AvecActions, AvecLien, TousLesTypes, NomLong, SansActions, CollectionLiéeÀUneDemarche
- **Statistic React + Angular** : AvecTendance, TendanceNegative (\"Tendance négative\"), TendancePlate, AvecPrefixSuffix (\"Avec préfixe et suffixe\"), AvecSuffixe, Pourcentage, VariantLarge (\"Variante large\"), VariantInline, ChargementProgressif, DansUneCard (\"Dans une carte\"), FormatageNombre (\"Formatage du nombre\"), Loading

## Test plan

- [x] \`pnpm --filter @govpf/ori-react test\` : 196/196 verts
- [x] \`pnpm --filter @govpf/ori-storybook-react build\` : OK (18 s)

## Hors scope

Les autres exports camelCase français (~60 occurrences) restent sur le split par défaut Storybook puisqu'ils sont intelligibles tels quels. À traiter au cas par cas si une régression visuelle est remontée.