### PR TITLE
feat(app-shell): sidebarOpen pilote la sidebar sur tous les viewports

### DIFF
--- a/.changeset/app-shell-toggleable-sidebar.md
+++ b/.changeset/app-shell-toggleable-sidebar.md
@@ -1,0 +1,20 @@
+---
+'@govpf/ori-react': minor
+'@govpf/ori-angular': minor
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+AppShell : la prop `sidebarOpen` pilote désormais l'affichage de la sidebar **sur tous les viewports**, pas uniquement le drawer mobile.
+
+- Desktop ≥ 768px : `sidebarOpen=true` (défaut) la sidebar reste visible in-flow ; `sidebarOpen=false` la masque et le main reprend toute la largeur.
+- Mobile < 768px : comportement inchangé, la même prop ouvre / ferme le drawer.
+
+Permet aux apps de greffer un bouton de toggle « ☰ » dans le header projeté pour cacher la navigation latérale et gagner de la place sur grand écran. La démo portail le démontre : bouton hamburger à gauche du logo qui pilote `sidebarOpen` en `useState`.
+
+**Breaking pré-1.0 (minor)** : le défaut de `sidebarOpen` passe de `false` à `true`. Impact :
+
+- Desktop : aucun changement, la sidebar était déjà toujours visible.
+- Mobile : les apps qui ne pilotaient pas `sidebarOpen` voyaient le drawer fermé au load (la classe `--sidebar-open` n'était jamais appliquée). Avec le nouveau défaut, le drawer s'ouvre au load. Pour conserver l'ancien comportement, passer explicitement `sidebarOpen={false}` au mount, idéalement en récupérant la valeur depuis un `useState`.
+
+Aucun changement d'API : props existantes inchangées, ajout uniquement d'une règle CSS desktop conditionnée par la classe `.ori-app-shell--sidebar-open` déjà présente.

--- a/apps/demo-portail/src/layout/AppShell.tsx
+++ b/apps/demo-portail/src/layout/AppShell.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@govpf/ori-react';
-import { Moon, Sun, User, Settings, Shield, LogOut } from 'lucide-react';
+import { Moon, Sun, User, Settings, Shield, LogOut, Menu } from 'lucide-react';
 import type { Route } from '../App.js';
 
 // Route interne mappée sur le href des items de nav. Permet d'intercepter
@@ -60,7 +60,10 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
   const [lang, setLang] = useState('fr');
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [showBanner, setShowBanner] = useState(true);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  // Sidebar visible par défaut sur desktop. La même prop pilote aussi le
+  // drawer en mobile : passer `false` la cache sur desktop / ferme le drawer
+  // sur mobile.
+  const [sidebarOpen, setSidebarOpen] = useState(true);
 
   const toggleTheme = () => {
     const next = theme === 'light' ? 'dark' : 'light';
@@ -113,6 +116,17 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
       </div>
       <Header>
         <Header.Brand>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setSidebarOpen((v) => !v)}
+            aria-label={
+              sidebarOpen ? 'Masquer la navigation latérale' : 'Afficher la navigation latérale'
+            }
+            aria-expanded={sidebarOpen}
+          >
+            <Menu size={18} aria-hidden="true" />
+          </Button>
           <Logo href="#" title="Polynésie française" subtitle="Mon espace usager" />
         </Header.Brand>
         <Header.Nav>

--- a/packages/angular/src/components/app-shell/app-shell.component.ts
+++ b/packages/angular/src/components/app-shell/app-shell.component.ts
@@ -83,7 +83,14 @@ const MAIN_ID = 'ori-app-shell-main';
 export class OriAppShellComponent {
   @Input() skipLinkLabel: string = 'Aller au contenu principal';
   @Input() closeSidebarLabel: string = 'Fermer le menu';
-  @Input() sidebarOpen: boolean = false;
+  /**
+   * État de la sidebar. Pilote l'affichage sur tous les viewports :
+   * - desktop ≥ 768px : `true` = visible in-flow, `false` = masquée
+   * - mobile < 768px : `true` = drawer ouvert, `false` = drawer fermé
+   *
+   * Default : `true` (sidebar visible par défaut sur desktop).
+   */
+  @Input() sidebarOpen: boolean = true;
 
   @Output() sidebarOpenChange = new EventEmitter<boolean>();
 

--- a/packages/react/src/components/AppShell/AppShell.test.tsx
+++ b/packages/react/src/components/AppShell/AppShell.test.tsx
@@ -56,6 +56,20 @@ describe('AppShell', () => {
     expect(container.firstChild).toHaveClass('ori-app-shell--sidebar-open');
   });
 
+  it('applique sidebar-open par défaut (sidebar visible sans pilotage)', () => {
+    const { container } = render(<AppShell sidebar={<nav>x</nav>}>x</AppShell>);
+    expect(container.firstChild).toHaveClass('ori-app-shell--sidebar-open');
+  });
+
+  it('retire la classe sidebar-open quand sidebarOpen={false}', () => {
+    const { container } = render(
+      <AppShell sidebar={<nav>x</nav>} sidebarOpen={false}>
+        x
+      </AppShell>,
+    );
+    expect(container.firstChild).not.toHaveClass('ori-app-shell--sidebar-open');
+  });
+
   it('appelle onSidebarOpenChange(false) au clic sur le scrim', async () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -84,7 +98,7 @@ describe('AppShell', () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     render(
-      <AppShell sidebar={<nav>x</nav>} onSidebarOpenChange={onOpenChange}>
+      <AppShell sidebar={<nav>x</nav>} sidebarOpen={false} onSidebarOpenChange={onOpenChange}>
         x
       </AppShell>,
     );

--- a/packages/react/src/components/AppShell/AppShell.tsx
+++ b/packages/react/src/components/AppShell/AppShell.tsx
@@ -14,11 +14,18 @@ import { clsx } from 'clsx';
  * tout faits, l'app projette ce qu'elle veut. Pour l'usage standard, brancher
  * les composants Ori `<Header>`, `<SideMenu>` et `<Footer>`.
  *
- * Sidebar drawer mobile : à viewport < 768px (override possible côté CSS),
- * la sidebar est cachée et accessible via un toggle (le bouton hamburger
- * vit dans le header projeté ; l'app contrôle l'ouverture via
- * `sidebarOpen` + `onSidebarOpenChange`). Le drawer ferme sur ESC et au
- * clic sur le scrim.
+ * Sidebar pilotable sur tous les viewports via `sidebarOpen` /
+ * `onSidebarOpenChange` :
+ *
+ * - Desktop ≥ 768px : `sidebarOpen=true` (défaut) la sidebar est visible
+ *   in-flow à gauche. `sidebarOpen=false` la sidebar est masquée et le main
+ *   prend toute la largeur.
+ * - Mobile < 768px : la sidebar est en drawer hors-flux. `sidebarOpen=true`
+ *   l'ouvre par-dessus le scrim, `sidebarOpen=false` la ferme.
+ *
+ * Le bouton de toggle (hamburger) vit dans le header projeté ; l'app décide
+ * où le placer et quand l'afficher. Le drawer mobile ferme aussi sur ESC
+ * et au clic sur le scrim.
  *
  * a11y :
  * - skip link en première position, visible au focus uniquement
@@ -37,7 +44,13 @@ export interface AppShellProps {
   children?: ReactNode;
   /** Texte du skip link. */
   skipLinkLabel?: string;
-  /** État du drawer sidebar en responsive (mode mobile). */
+  /**
+   * État de la sidebar. Pilote l'affichage sur tous les viewports :
+   * - desktop ≥ 768px : `true` = visible in-flow, `false` = masquée
+   * - mobile < 768px : `true` = drawer ouvert (sur scrim), `false` = drawer fermé
+   *
+   * Default : `true` (sidebar visible par défaut sur desktop).
+   */
   sidebarOpen?: boolean;
   onSidebarOpenChange?: (open: boolean) => void;
   /** Label accessible du scrim (lecteur d'écran). */
@@ -54,7 +67,7 @@ export const AppShell = forwardRef<HTMLDivElement, AppShellProps>(function AppSh
     footer,
     children,
     skipLinkLabel = 'Aller au contenu principal',
-    sidebarOpen = false,
+    sidebarOpen = true,
     onSidebarOpenChange,
     closeSidebarLabel = 'Fermer le menu',
     className,

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1667,6 +1667,15 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
         minHeight: '0',
       },
     },
+    // Desktop ≥ 768px : si `sidebarOpen=false` (classe `--sidebar-open`
+    // absente), la sidebar disparaît du flow et le main reprend toute la
+    // largeur. Sur mobile, la même prop pilote l'ouverture du drawer (cf.
+    // règles @media (max-width: 767px) plus bas).
+    '.ori-app-shell--with-sidebar:not(.ori-app-shell--sidebar-open) .ori-app-shell__sidebar': {
+      '@media (min-width: 768px)': {
+        display: 'none',
+      },
+    },
     '.ori-app-shell__main': {
       flex: '1 1 auto',
       minWidth: '0',


### PR DESCRIPTION
## Demande

Avoir un toggle pour cacher la sidebar sur grand écran et gagner de la place.

## Implémentation

Avant, \`sidebarOpen\` contrôlait uniquement le drawer mobile. Maintenant la même prop agit sur tous les viewports :

| Viewport | \`sidebarOpen=true\` | \`sidebarOpen=false\` |
| - | - | - |
| Desktop ≥ 768px | Sidebar visible in-flow (état actuel) | Sidebar masquée, main pleine largeur |
| Mobile < 768px | Drawer ouvert sur scrim (inchangé) | Drawer fermé (inchangé) |

## API

Aucune nouvelle prop. La sémantique de \`sidebarOpen\` est étendue. Le bouton de toggle reste à la charge de l'app : la démo portail ajoute un bouton hamburger ghost à gauche du logo, piloté par \`useState\`.

## Breaking pré-1.0 (minor)

Le défaut de \`sidebarOpen\` passe de \`false\` à \`true\`.

- **Desktop** : aucun changement, la sidebar était déjà toujours visible.
- **Mobile** : les apps qui ne pilotaient pas \`sidebarOpen\` voyaient le drawer fermé au load (la classe \`--sidebar-open\` n'était jamais appliquée). Avec le nouveau défaut, **le drawer s'ouvre au load mobile**. Pour conserver l'ancien comportement, passer \`sidebarOpen={false}\` au mount, idéalement via un \`useState\` piloté.

## Tests

- [x] \`pnpm --filter @govpf/ori-react test\` : 198/198 verts (2 nouveaux tests : default + sidebarOpen=false)
- [x] \`pnpm --filter @govpf/ori-angular build\` : OK
- [x] \`pnpm --filter @govpf/ori-demo-portail build\` : OK
- [x] CSS \`@media (min-width: 768px)\` correctement préservé dans le bundle prod (vérifié par grep, cf. correctif PR #61 sur le piège PostCSS)

## Versionning (changeset embarqué)

- \`@govpf/ori-react\` : minor (default sidebarOpen change)
- \`@govpf/ori-angular\` : minor (idem)
- \`@govpf/ori-tailwind-preset\` : patch (nouvelle règle CSS)
- \`@govpf/ori-css\` : patch (bundle régénéré)