### PR TITLE
feat(app-shell): bouton de toggle intégré sur le bord droit de la sidebar

### DIFF
--- a/.changeset/app-shell-integrated-toggle.md
+++ b/.changeset/app-shell-integrated-toggle.md
@@ -1,0 +1,21 @@
+---
+'@govpf/ori-react': patch
+'@govpf/ori-angular': patch
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+AppShell : bouton de toggle intégré sur le bord droit de la sidebar.
+
+Le composant rend désormais lui-même un bouton chevron sur la frontière sidebar/main, qui pilote `sidebarOpen` via `onSidebarOpenChange`. Plus besoin de greffer un bouton hamburger dans le header projeté.
+
+- Quand la sidebar est visible (`sidebarOpen=true`) : chevron vers la gauche, posé sur le bord droit de la sidebar
+- Quand elle est masquée (`sidebarOpen=false`) : chevron vers la droite, glissé au début du main
+- Caché sur mobile (le drawer ferme via le scrim cliquable et la touche Escape, comportement inchangé)
+
+Le bouton n'est rendu que si `onSidebarOpenChange` est fourni : sans callback, le toggle ne pourrait rien faire. Aucun changement breaking : les apps qui ne passent pas `onSidebarOpenChange` ne voient pas le bouton.
+
+Nouvelles props (toutes optionnelles) :
+
+- `collapseSidebarLabel?: string` (défaut : « Masquer la navigation latérale »)
+- `expandSidebarLabel?: string` (défaut : « Afficher la navigation latérale »)

--- a/apps/demo-portail/src/layout/AppShell.tsx
+++ b/apps/demo-portail/src/layout/AppShell.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@govpf/ori-react';
-import { Moon, Sun, User, Settings, Shield, LogOut, Menu } from 'lucide-react';
+import { Moon, Sun, User, Settings, Shield, LogOut } from 'lucide-react';
 import type { Route } from '../App.js';
 
 // Route interne mappée sur le href des items de nav. Permet d'intercepter
@@ -116,17 +116,6 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
       </div>
       <Header>
         <Header.Brand>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setSidebarOpen((v) => !v)}
-            aria-label={
-              sidebarOpen ? 'Masquer la navigation latérale' : 'Afficher la navigation latérale'
-            }
-            aria-expanded={sidebarOpen}
-          >
-            <Menu size={18} aria-hidden="true" />
-          </Button>
           <Logo href="#" title="Polynésie française" subtitle="Mon espace usager" />
         </Header.Brand>
         <Header.Nav>

--- a/packages/angular/src/components/app-shell/app-shell.component.ts
+++ b/packages/angular/src/components/app-shell/app-shell.component.ts
@@ -9,6 +9,9 @@ import {
   Output,
   ViewEncapsulation,
 } from '@angular/core';
+import { LucideAngularModule, ChevronLeft, ChevronRight } from 'lucide-angular';
+
+type LucideIconData = typeof ChevronLeft;
 
 const MAIN_ID = 'ori-app-shell-main';
 
@@ -40,6 +43,7 @@ const MAIN_ID = 'ori-app-shell-main';
 @Component({
   selector: 'ori-app-shell',
   standalone: true,
+  imports: [LucideAngularModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   template: `
@@ -59,6 +63,20 @@ const MAIN_ID = 'ori-app-shell-main';
           <aside class="ori-app-shell__sidebar" aria-label="Navigation latérale">
             <ng-content select="[slot=sidebar]"></ng-content>
           </aside>
+          <button
+            type="button"
+            class="ori-app-shell__sidebar-toggle"
+            [attr.aria-label]="sidebarOpen ? collapseSidebarLabel : expandSidebarLabel"
+            [attr.aria-expanded]="sidebarOpen"
+            [attr.aria-controls]="mainId"
+            (click)="toggleSidebar()"
+          >
+            <lucide-icon
+              [img]="sidebarOpen ? ChevronLeftIcon : ChevronRightIcon"
+              [size]="16"
+              aria-hidden="true"
+            ></lucide-icon>
+          </button>
           <div
             class="ori-app-shell__scrim"
             role="button"
@@ -76,13 +94,15 @@ const MAIN_ID = 'ori-app-shell-main';
       </div>
     </div>
   `,
-  // Trick : on duplique les ng-content avec sélecteurs pour pouvoir détecter
-  // si du contenu est projeté (via ContentChild + ElementRef sur les wraps).
-  // Plus propre que des @Input booleans dupliqués qui désynchroniseraient.
 })
 export class OriAppShellComponent {
   @Input() skipLinkLabel: string = 'Aller au contenu principal';
   @Input() closeSidebarLabel: string = 'Fermer le menu';
+  @Input() collapseSidebarLabel: string = 'Masquer la navigation latérale';
+  @Input() expandSidebarLabel: string = 'Afficher la navigation latérale';
+
+  protected readonly ChevronLeftIcon: LucideIconData = ChevronLeft;
+  protected readonly ChevronRightIcon: LucideIconData = ChevronRight;
   /**
    * État de la sidebar. Pilote l'affichage sur tous les viewports :
    * - desktop ≥ 768px : `true` = visible in-flow, `false` = masquée
@@ -118,6 +138,11 @@ export class OriAppShellComponent {
     if (!this.sidebarOpen) return;
     this.sidebarOpen = false;
     this.sidebarOpenChange.emit(false);
+  }
+
+  toggleSidebar(): void {
+    this.sidebarOpen = !this.sidebarOpen;
+    this.sidebarOpenChange.emit(this.sidebarOpen);
   }
 
   @HostListener('document:keydown.escape')

--- a/packages/react/src/components/AppShell/AppShell.tsx
+++ b/packages/react/src/components/AppShell/AppShell.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { clsx } from 'clsx';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 /**
  * AppShell : layout d'application.
@@ -23,9 +24,12 @@ import { clsx } from 'clsx';
  * - Mobile < 768px : la sidebar est en drawer hors-flux. `sidebarOpen=true`
  *   l'ouvre par-dessus le scrim, `sidebarOpen=false` la ferme.
  *
- * Le bouton de toggle (hamburger) vit dans le header projeté ; l'app décide
- * où le placer et quand l'afficher. Le drawer mobile ferme aussi sur ESC
- * et au clic sur le scrim.
+ * Sur desktop, le composant rend lui-même un bouton de toggle intégré
+ * (chevron) sur le bord droit de la sidebar quand elle est visible, qui
+ * glisse à gauche du main quand elle est masquée. Le bouton est rendu
+ * uniquement si `onSidebarOpenChange` est fourni (sans callback, le
+ * toggle ne servirait à rien). Sur mobile, le bouton est masqué : le
+ * drawer ferme via le scrim cliquable et la touche Escape.
  *
  * a11y :
  * - skip link en première position, visible au focus uniquement
@@ -55,6 +59,10 @@ export interface AppShellProps {
   onSidebarOpenChange?: (open: boolean) => void;
   /** Label accessible du scrim (lecteur d'écran). */
   closeSidebarLabel?: string;
+  /** Label accessible du bouton de toggle quand la sidebar est ouverte. */
+  collapseSidebarLabel?: string;
+  /** Label accessible du bouton de toggle quand la sidebar est fermée. */
+  expandSidebarLabel?: string;
   className?: string;
 }
 
@@ -70,6 +78,8 @@ export const AppShell = forwardRef<HTMLDivElement, AppShellProps>(function AppSh
     sidebarOpen = true,
     onSidebarOpenChange,
     closeSidebarLabel = 'Fermer le menu',
+    collapseSidebarLabel = 'Masquer la navigation latérale',
+    expandSidebarLabel = 'Afficher la navigation latérale',
     className,
   },
   ref,
@@ -108,6 +118,22 @@ export const AppShell = forwardRef<HTMLDivElement, AppShellProps>(function AppSh
             <aside className="ori-app-shell__sidebar" aria-label="Navigation latérale">
               {sidebar}
             </aside>
+            {onSidebarOpenChange && (
+              <button
+                type="button"
+                className="ori-app-shell__sidebar-toggle"
+                aria-label={sidebarOpen ? collapseSidebarLabel : expandSidebarLabel}
+                aria-expanded={sidebarOpen}
+                aria-controls={MAIN_ID}
+                onClick={() => onSidebarOpenChange(!sidebarOpen)}
+              >
+                {sidebarOpen ? (
+                  <ChevronLeft size={16} aria-hidden="true" />
+                ) : (
+                  <ChevronRight size={16} aria-hidden="true" />
+                )}
+              </button>
+            )}
             <div
               className="ori-app-shell__scrim"
               role="button"

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1676,6 +1676,47 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
         display: 'none',
       },
     },
+    // Bouton de toggle intégré : sur desktop, frère direct du sidebar et du
+    // main. Sa position dans le flow flex le colle naturellement entre les
+    // deux quand la sidebar est visible, et au début du body quand elle est
+    // masquée. Caché sur mobile (le drawer ferme via le scrim cliquable).
+    '.ori-app-shell__sidebar-toggle': {
+      alignSelf: 'flex-start',
+      flexShrink: '0',
+      marginTop: theme('spacing.4'),
+      width: '1.75rem',
+      height: '1.75rem',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '0',
+      backgroundColor: v('surface-base'),
+      border: `1px solid ${v('border-subtle')}`,
+      borderRadius: '9999px',
+      color: v('text-secondary'),
+      cursor: 'pointer',
+      boxShadow: theme('boxShadow.sm'),
+      transitionProperty: 'background-color, color, border-color, transform',
+      transitionDuration: theme('transitionDuration.fast'),
+      transitionTimingFunction: theme('transitionTimingFunction.standard'),
+      // Translate le bouton pour qu'il chevauche pile la frontière
+      // sidebar/main (effet "collé sur le bord droit de la sidebar"
+      // quand ouverte, "collé au bord gauche du main" quand fermée).
+      transform: 'translateX(-50%)',
+      zIndex: '5',
+      '&:hover': {
+        backgroundColor: v('surface-muted'),
+        color: v('text-primary'),
+        borderColor: v('border-default'),
+      },
+      '&:focus-visible': {
+        outline: `2px solid ${v('border-focus')}`,
+        outlineOffset: '2px',
+      },
+      '@media (max-width: 767px)': {
+        display: 'none',
+      },
+    },
     '.ori-app-shell__main': {
       flex: '1 1 auto',
       minWidth: '0',


### PR DESCRIPTION
## Demande utilisateur

> Pourquoi est-ce à gauche ? […] Pas de bouton dans le header, juste un toggle natif sur la sidebar elle-même (un chevron < collé sur le bord droit de la sidebar).

Pattern VSCode / Linear / Notion : le toggle est intégré au composant de layout, pas un bouton greffé dans le header par l'app.

## Implémentation

Le bouton est rendu par \`<AppShell>\` lui-même quand \`onSidebarOpenChange\` est fourni. Position dans le flow flex du \`__body\`, frère du sidebar et du main :

- **Sidebar visible** : chevron-left, posé sur le bord droit de la sidebar (translate -50%)
- **Sidebar masquée** : chevron-right, glissé au début du main
- **Mobile** : caché (le drawer ferme via scrim + Escape, comportement inchangé)

L'effet \"pastille collée sur la frontière\" vient d'un \`transform: translateX(-50%)\` qui chevauche pile la limite sidebar/main.

## Démo portail

Retrait du bouton hamburger précédemment ajouté dans \`Header.Brand\` (PR #70). Le toggle vit maintenant dans le composant DS — l'app n'a plus à le placer.

## API

Aucun breaking. Le bouton n'apparaît que si l'app passe \`onSidebarOpenChange\`. Nouvelles props optionnelles :

- \`collapseSidebarLabel?: string\` — défaut « Masquer la navigation latérale »
- \`expandSidebarLabel?: string\` — défaut « Afficher la navigation latérale »

## Tests

- [x] React tests : 198/198 verts
- [x] Builds packages, démo, Storybook : OK
- [ ] Vérification visuelle en prod après deploy

## Versionning

Patch sur les 4 packages publishables (changeset embarqué). Le bouton est additif — pas de changement de signature.