### PR TITLE
fix(demo-portail): conserver la sidebar ouverte lors d'une navigation desktop

### DIFF
--- a/apps/demo-portail/src/layout/AppShell.tsx
+++ b/apps/demo-portail/src/layout/AppShell.tsx
@@ -80,8 +80,11 @@ export function AppShell({ route, onNavigate, children }: AppShellProps) {
     if (target) {
       e.preventDefault();
       onNavigate(target);
-      // En mobile, fermer le drawer après navigation pour laisser voir le contenu cible.
-      setSidebarOpen(false);
+      // Mobile uniquement : fermer le drawer après navigation pour laisser voir le contenu cible.
+      // Sur desktop, on conserve le choix explicite de l'usager (sidebar ouverte ou masquée).
+      if (typeof window !== 'undefined' && window.matchMedia('(max-width: 767px)').matches) {
+        setSidebarOpen(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Symptôme

Sur la démo, la sidebar se referme à chaque navigation interne (clic sur un item de `SideMenu` ou `MainNavigation`), même quand l'usager l'avait laissée ouverte sur desktop.

## Cause

Dans `apps/demo-portail/src/layout/AppShell.tsx`, le handler `handleNavClick` faisait un `setSidebarOpen(false)` inconditionnel après chaque navigation. Le commentaire associé mentionnait pourtant « en mobile, fermer le drawer après navigation » : la garde de viewport manquait.

## Fix

On gate la fermeture par `window.matchMedia('(max-width: 767px)')`, qui correspond au breakpoint du composant `AppShell` du DS. Sur desktop, l'état de la sidebar reflète un choix explicite de l'usager (via le toggle chevron intégré au DS depuis #72) et doit être conservé d'une page à l'autre.

## Test plan

- [ ] Desktop : ouvrir la démo, naviguer entre Tableau de bord / Mes démarches / Profil — la sidebar reste ouverte.
- [ ] Desktop : masquer la sidebar via le chevron, naviguer — la sidebar reste masquée.
- [ ] Mobile (< 768px) : ouvrir le drawer, cliquer sur un item — le drawer se ferme automatiquement (comportement inchangé).