### PR TITLE
feat(demo-portail): utiliser SearchBar, PhoneInput, RichRadio, DownloadButton

### DIFF
--- a/apps/demo-portail/src/pages/Aide.tsx
+++ b/apps/demo-portail/src/pages/Aide.tsx
@@ -9,6 +9,7 @@ import {
   DialogContent,
   Highlight,
   Input,
+  SearchBar,
   Select,
   Tabs,
   Tag,
@@ -16,7 +17,7 @@ import {
   Tooltip,
   useToast,
 } from '@govpf/ori-react';
-import { BookOpen, Clock, Eye, HelpCircle, MessageCircle, Plus, Search, User } from 'lucide-react';
+import { BookOpen, Clock, Eye, HelpCircle, MessageCircle, Plus, User } from 'lucide-react';
 import {
   articlesAide,
   tickets as ticketsInitiaux,
@@ -167,25 +168,12 @@ export function AidePage({ onNavigate }: AidePageProps) {
             </p>
             <div className="help-hero__search">
               <div className="help-hero__search-input">
-                <Search
-                  size={18}
-                  aria-hidden="true"
-                  style={{
-                    position: 'absolute',
-                    left: '0.875rem',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    color: 'var(--color-text-muted)',
-                    pointerEvents: 'none',
-                  }}
-                />
-                <Input
-                  size="lg"
+                <SearchBar
+                  label="Rechercher dans l'aide"
                   placeholder="Mot-clé, numéro de ticket ou question…"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  style={{ paddingLeft: '2.5rem' }}
-                  aria-label="Rechercher dans l'aide"
+                  buttonLabel="Rechercher"
                 />
               </div>
               <Button variant="primary" size="lg" onClick={() => setCreateOpen(true)}>

--- a/apps/demo-portail/src/pages/Annuaire.tsx
+++ b/apps/demo-portail/src/pages/Annuaire.tsx
@@ -5,13 +5,13 @@ import {
   Card,
   CardBody,
   Highlight,
-  Input,
   Pagination,
+  SearchBar,
   Select,
   Tag,
   useToast,
 } from '@govpf/ori-react';
-import { Building2, Clock, ExternalLink, Mail, MapPin, Phone, Search } from 'lucide-react';
+import { Building2, Clock, ExternalLink, Mail, MapPin, Phone } from 'lucide-react';
 import {
   servicesAdministratifs,
   SERVICE_SECTEUR_LABEL,
@@ -85,28 +85,15 @@ export function AnnuairePage({ onNavigate }: AnnuairePageProps) {
         <CardBody>
           <div className="annuaire-search__row">
             <div className="annuaire-search__input">
-              <Search
-                size={18}
-                aria-hidden="true"
-                style={{
-                  position: 'absolute',
-                  left: '0.875rem',
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  color: 'var(--color-text-muted)',
-                  pointerEvents: 'none',
-                }}
-              />
-              <Input
-                size="lg"
+              <SearchBar
+                label="Rechercher dans l'annuaire"
                 placeholder="Rechercher un service, une adresse, un secteur…"
                 value={search}
                 onChange={(e) => {
                   setSearch(e.target.value);
                   setPage(1);
                 }}
-                style={{ paddingLeft: '2.5rem' }}
-                aria-label="Rechercher dans l'annuaire"
+                buttonLabel="Rechercher"
               />
             </div>
             <Select

--- a/apps/demo-portail/src/pages/CatalogueDemarches.tsx
+++ b/apps/demo-portail/src/pages/CatalogueDemarches.tsx
@@ -5,7 +5,7 @@ import {
   Card,
   CardBody,
   Highlight,
-  Input,
+  SearchBar,
   Tabs,
   Tag,
   Tooltip,
@@ -90,25 +90,12 @@ export function CatalogueDemarchesPage({ onNavigate }: CatalogueDemarchesPagePro
       <Card variant="flat" className="catalogue-search">
         <CardBody>
           <div className="catalogue-search__input">
-            <Search
-              size={18}
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                left: '0.875rem',
-                top: '50%',
-                transform: 'translateY(-50%)',
-                color: 'var(--color-text-muted)',
-                pointerEvents: 'none',
-              }}
-            />
-            <Input
-              size="lg"
+            <SearchBar
+              label="Rechercher dans le catalogue"
               placeholder="Rechercher une démarche (licence, attestation, aide…)"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              style={{ paddingLeft: '2.5rem' }}
-              aria-label="Rechercher dans le catalogue"
+              buttonLabel="Rechercher"
             />
           </div>
         </CardBody>

--- a/apps/demo-portail/src/pages/Dashboard.tsx
+++ b/apps/demo-portail/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   Input,
   Highlight,
+  DownloadButton,
   type TableSort,
 } from '@govpf/ori-react';
 import { FileText, Image as ImageIcon, FileType, Plus } from 'lucide-react';
@@ -210,9 +211,9 @@ export function DashboardPage({ onNavigate }: DashboardPageProps) {
                 </div>
               </CardBody>
               <CardFooter>
-                <Button variant="ghost" size="sm">
+                <DownloadButton href="#" fileType={doc.type.toUpperCase()} fileSize={doc.taille}>
                   Télécharger
-                </Button>
+                </DownloadButton>
                 <Button variant="ghost" size="sm">
                   Voir
                 </Button>

--- a/apps/demo-portail/src/pages/DemandeDetail.tsx
+++ b/apps/demo-portail/src/pages/DemandeDetail.tsx
@@ -10,8 +10,9 @@ import {
   DatePicker,
   Textarea,
   Checkbox,
-  RadioGroup,
-  Radio,
+  PhoneInput,
+  RichRadio,
+  RichRadioGroup,
   FileUpload,
   Button,
   Alert,
@@ -21,7 +22,7 @@ import {
   Timeline,
   useToast,
 } from '@govpf/ori-react';
-import { FileText } from 'lucide-react';
+import { FileText, Mail, MessageSquare, Send } from 'lucide-react';
 import { demandes, documents, historique, STATUT_LABEL, STATUT_VARIANT } from '../data/mock.js';
 import type { Route } from '../App.js';
 
@@ -151,25 +152,34 @@ export function DemandeDetailPage({ demandeId, onNavigate }: DemandeDetailPagePr
                   required
                   defaultValue="heitiare.tuheiava@gmail.com"
                 />
-                <Input
+                <PhoneInput
                   label="Téléphone"
-                  type="tel"
-                  defaultValue="+689 87 12 34 56"
+                  defaultValue="87 12 34 56"
                   hint="Numéro mobile de préférence"
                 />
               </div>
 
               <div className="form-stack" style={{ marginTop: '1rem' }}>
-                <RadioGroup
-                  label="Moyen de contact préféré"
-                  value={moyen}
-                  onChange={setMoyen}
-                  orientation="inline"
-                >
-                  <Radio value="email" label="Email" />
-                  <Radio value="sms" label="SMS" />
-                  <Radio value="courrier" label="Courrier postal" />
-                </RadioGroup>
+                <RichRadioGroup label="Moyen de contact préféré" value={moyen} onChange={setMoyen}>
+                  <RichRadio
+                    value="email"
+                    label="Email"
+                    description="Réponse sous 24 h ouvrées sur l'adresse renseignée plus haut."
+                    trailing={<Mail size={28} aria-hidden="true" />}
+                  />
+                  <RichRadio
+                    value="sms"
+                    label="SMS"
+                    description="Notification immédiate sur le numéro renseigné plus haut."
+                    trailing={<MessageSquare size={28} aria-hidden="true" />}
+                  />
+                  <RichRadio
+                    value="courrier"
+                    label="Courrier postal"
+                    description="Envoi sous 5 à 7 jours ouvrés à l'adresse de domiciliation."
+                    trailing={<Send size={28} aria-hidden="true" />}
+                  />
+                </RichRadioGroup>
 
                 <Textarea
                   label="Notes complémentaires"

--- a/apps/demo-portail/src/pages/Documents.tsx
+++ b/apps/demo-portail/src/pages/Documents.tsx
@@ -8,13 +8,13 @@ import {
   DialogContent,
   FileCard,
   FileUpload,
-  Input,
   Pagination,
+  SearchBar,
   Select,
   Tabs,
   useToast,
 } from '@govpf/ori-react';
-import { Download, Eye, FileText, Search, Trash2, Upload } from 'lucide-react';
+import { Download, Eye, FileText, Trash2, Upload } from 'lucide-react';
 import { documents as documentsInitiaux, type Document } from '../data/mock.js';
 import type { Route } from '../App.js';
 
@@ -152,27 +152,16 @@ export function DocumentsPage({ onNavigate }: DocumentsPageProps) {
       </Tabs>
 
       <div className="filters-row">
-        <div className="filters-row__field" style={{ flex: '1 1 280px', position: 'relative' }}>
-          <Search
-            size={16}
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              left: '0.625rem',
-              top: '50%',
-              transform: 'translateY(-50%)',
-              color: 'var(--color-text-muted)',
-              pointerEvents: 'none',
-            }}
-          />
-          <Input
+        <div className="filters-row__field" style={{ flex: '1 1 280px' }}>
+          <SearchBar
             placeholder="Rechercher un document…"
             value={search}
             onChange={(e) => {
               setSearch(e.target.value);
               setPage(1);
             }}
-            style={{ paddingLeft: '2rem' }}
+            iconOnlyButton
+            buttonAriaLabel="Lancer la recherche"
           />
         </div>
         <div className="filters-row__field" style={{ flex: '0 1 220px' }}>

--- a/apps/demo-portail/src/pages/Profil.tsx
+++ b/apps/demo-portail/src/pages/Profil.tsx
@@ -7,6 +7,7 @@ import {
   CardBody,
   CardHeader,
   Input,
+  PhoneInput,
   Radio,
   RadioGroup,
   Select,
@@ -117,12 +118,11 @@ export function ProfilPage({ onNavigate }: ProfilPageProps) {
               hint="Vous recevrez les notifications sur cette adresse."
               required
             />
-            <Input
+            <PhoneInput
               label="Téléphone"
-              type="tel"
               value={telephone}
-              onChange={(e) => setTelephone(e.target.value)}
-              hint="Format international, ex : +689 87 12 34 56"
+              onChange={(v) => setTelephone(v)}
+              hint="Indicatif Polynésie française fourni par défaut."
             />
           </div>
         </CardBody>

--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -5,7 +5,7 @@
 Positionnement :
 
 - **Service public** : généricité institutionnelle, identité visuelle Polynésie française et non d'un service spécifique
-- **RGAA AA baseline obligatoire** : 406 stories Storybook validées WCAG 2.0 AA en CI à chaque PR (axe-core, 0 violation)
+- **RGAA AA baseline obligatoire** : ensemble des stories Storybook validées WCAG 2.0 AA en CI à chaque PR (axe-core, 0 violation - le compte exact vit dans `index.json`)
 - **Natif d'abord** : éléments HTML natifs privilégiés systématiquement (`<select>`, `<input type="date">`, etc.) pour garantir l'a11y sans audit à recommencer
 - **Bundle minimal** : adapté aux connexions limitées des archipels éloignés
 - **Multi-framework** : même apparence visuelle garantie sur React, Angular, HTML pur depuis une source unique de tokens
@@ -39,13 +39,14 @@ Pour récupérer le contenu d'une story spécifique (HTML rendu) : `https://ori.
 
 Inventaire snapshot avril 2026, classés en 3 niveaux (cf. [décision B.0](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux)). L'inventaire à jour vit dans le repo et l'index Storybook ([https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json)).
 
-### Primitives (≈ 35)
+### Primitives (≈ 39)
 
 Briques atomiques, API agnostique du domaine, présentes dans tous les DS de référence.
 
-Inputs : Button, Input, Textarea, Select, Combobox, MultiSelect, Checkbox, Radio, Switch, DatePicker
+Inputs : Button, Input, Textarea, Select, Combobox, MultiSelect, Checkbox, Radio, RichRadio, Switch, DatePicker, PhoneInput, SearchBar
 Feedback : Dialog, AlertDialog, Tooltip, Toast, Notification, Alert, Spinner, Progress, Skeleton
 Navigation : DropdownMenu, Tabs, Accordion, Breadcrumb, Pagination, Steps, Link
+Actions : DownloadButton
 Data : Table, Tag, Avatar, Highlight, Statistic, Timeline, LanguageSwitcher, Logo
 
 ### Compositions (≈ 11)

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -3846,12 +3846,10 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       pointerEvents: 'none',
       // Couleur explicite plutôt qu'héritée : axe-core analyse les
       // contrastes au niveau du span de texte. On verrouille la couleur
-      // en brand-on-primary (mode pill) et on l'override pour le mode
-      // `--static` (lecture seule, fond transparent) ci-dessous.
+      // en brand-on-primary (le pill garde son fond brand-primary aussi
+      // bien en mode normal qu'en mode `--static` mono-pays). Le mode
+      // `--readonly` retire le fond et bascule la couleur ci-dessous.
       color: v('brand-on-primary'),
-    },
-    '.ori-phone-input__country--static .ori-phone-input__dial-code': {
-      color: v('text-primary'),
     },
     '.ori-phone-input__chevron': {
       flex: '0 0 auto',
@@ -3921,6 +3919,12 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       // contraste WCAG AA correct sur fond surface-base.
       color: v('text-primary'),
       paddingInline: '0',
+    },
+    '.ori-phone-input--readonly .ori-phone-input__dial-code': {
+      // Override de la règle générale `.ori-phone-input__dial-code` qui
+      // verrouille la couleur en brand-on-primary pour le pill bleu.
+      // En readonly, le pill disparaît, on s'aligne sur le texte courant.
+      color: v('text-primary'),
     },
     '.ori-phone-input--readonly .ori-phone-input__number': {
       borderColor: 'transparent',


### PR DESCRIPTION
## Contexte

Vague 1 (#74) a livré 4 nouveaux composants. Cette PR les fait vivre dans `demo-portail` partout où un pattern custom existait, et nettoie les bouts de HTML+CSS qui ré-implémentaient la même chose à la main.

## Migrations effectuées

| Page | Avant | Après |
|---|---|---|
| `Documents.tsx` | `<Search>` icône absolute + `<Input>` custom | `<SearchBar iconOnlyButton>` |
| `Annuaire.tsx` | Même pattern, taille `lg` | `<SearchBar>` avec libellé |
| `CatalogueDemarches.tsx` | Même pattern | `<SearchBar>` |
| `Aide.tsx` | Même pattern dans le hero | `<SearchBar>` |
| `Profil.tsx` | `<Input type=\"tel\" hint=\"Format intl...\">` | `<PhoneInput>` (PF +689 par défaut) |
| `DemandeDetail.tsx` | `<Input type=\"tel\">` + `<RadioGroup>` simple | `<PhoneInput>` + `<RichRadioGroup>` avec descriptions et icônes Lucide trailing (Mail / MessageSquare / Send) |
| `Dashboard.tsx` | `<Button variant=\"ghost\">Télécharger</Button>` | `<DownloadButton>` avec `fileType` + `fileSize` (FileCard intacte par contre - ses actions internes restent en boutons icônes) |

## Choix d'arbitrage

- Les éléments **propres à la démo** (`.demo-banner`, FAB du `ChatBot`, fiches `.service-card`) restent en HTML+CSS custom : pas d'équivalent DS, et ce sont des assets de POC qui n'ont pas vocation à entrer dans le DS générique.
- `FileCard` dans `Documents.tsx` n'est **pas** transformée en `DownloadButton` : `FileCard` a déjà sa propre API d'actions (icônes + `onClick`) plus adaptée à un layout liste.
- `Dashboard.tsx` mélange désormais `<DownloadButton>` (lien stylé underline) et `<Button variant=\"ghost\">Voir</Button>` (action plein) dans le même `CardFooter` : c'est intentionnel - le téléchargement est sémantiquement un *lien* (déclenche un téléchargement HTTP), pas une action ; le bouton \"Voir\" reste une action de navigation.
- Le `<RichRadioGroup>` du `DemandeDetail` apporte vraiment quelque chose ici : les délais et modes diffèrent significativement entre email / SMS / courrier, donc les descriptions inline aident le choix.

## CSS retiré indirectement

Aucun fichier CSS modifié. Les styles inline `style={{ position: 'absolute', left: '0.875rem', ... }}` qui posaient l'icône Search sur l'`<Input>` sont supprimés (4 occurrences) - le `SearchBar` les fournit en interne.

## Test plan

- [ ] CI verte (build, tests, a11y, format)
- [ ] Naviguer sur la démo dev une fois déployée :
  - [ ] Documents : taper dans la barre, vérifier que les filtres réagissent
  - [ ] Annuaire / Catalogue / Aide : idem, layout cohérent
  - [ ] Profil : ouvrir le sélecteur d'indicatif (devrait rester en lecture seule, +689 figé)
  - [ ] Demande > onglet Informations : voir les 3 RichRadio avec leurs icônes et descriptions
  - [ ] Dashboard : cliquer sur \"Télécharger\" d'un document récent, vérifier le rendu lien + meta `PDF - 2.55 MB`
- [ ] Tester au clavier (Tab, Entrée) sur les SearchBar (Entrée doit déclencher la recherche)