### PR TITLE
fix(login-layout): aligner sur le pattern AuthLogin Keycloak

### DIFF
--- a/.changeset/login-layout-align-on-authlogin.md
+++ b/.changeset/login-layout-align-on-authlogin.md
@@ -1,0 +1,20 @@
+---
+'@govpf/ori-react': minor
+'@govpf/ori-angular': minor
+'@govpf/ori-tailwind-preset': minor
+'@govpf/ori-css': minor
+---
+
+LoginLayout : aligner le pattern visuel sur la mire Keycloak `AuthLogin.mdx`.
+
+Cohérence d'expérience entre la mire SSO Keycloak (HTML+CSS pur, hors composant DS, cf. décision K.1) et les pages de connexion d'apps internes (composant LoginLayout) : les deux écrans affichent désormais le même pattern.
+
+Changements visuels :
+
+- Le `logo` est rendu **dans** la carte (en haut, centré), plus au-dessus.
+- Le titre et la description sont **centrés**.
+- Le `cardFooter` n'a plus de séparateur `border-top` : c'est juste un paragraphe centré dans le bas de la carte (l'espacement vient du `gap` du parent).
+
+Aucun changement d'API : les props `logo`, `title`, `description`, `children`, `cardFooter`, `footer` sont inchangées. Les apps qui passaient déjà ces slots verront leur layout se réorganiser visuellement, sans casser le code.
+
+**Breaking pré-1.0 (minor)** : les apps qui dépendaient de la position du logo hors carte verront un nouveau rendu. Pour conserver l'ancien layout, il faut désormais wrapper le logo en dehors de `<LoginLayout>` (mais ce pattern n'était plus aligné sur la spec Keycloak, donc à éviter).

--- a/apps/demo-portail/src/pages/Connexion.tsx
+++ b/apps/demo-portail/src/pages/Connexion.tsx
@@ -1,4 +1,4 @@
-import { AuthButton, Button, LoginLayout } from '@govpf/ori-react';
+import { AuthButton, Button, LoginLayout, Logo } from '@govpf/ori-react';
 import type { Route } from '../App.js';
 
 interface Props {
@@ -12,29 +12,16 @@ interface Props {
  * réservées aux espaces agent.
  *
  * Page rendue plein écran sans AppShell, comme une vraie mire pré-auth.
- * Utilise <LoginLayout> du DS pour la structure.
+ * Utilise <LoginLayout> du DS pour la structure (logo dans la carte +
+ * titre centré, aligné sur AuthLogin Keycloak).
  */
 export function ConnexionPage({ onNavigate }: Props) {
   return (
     <LoginLayout
-      logo={
-        <div className="connexion-page__logo-block">
-          <img
-            src="/assets/logo-pf.svg"
-            alt=""
-            className="connexion-page__logo"
-            aria-hidden="true"
-          />
-          <div>
-            <strong className="connexion-page__brand">Polynésie française</strong>
-            <p className="connexion-page__tagline">Démarches en ligne</p>
-          </div>
-        </div>
-      }
-      title="Se connecter"
-      description="Accédez à votre espace personnel pour suivre vos démarches, consulter vos documents et recevoir vos notifications."
+      logo={<Logo subtitle="Démarches en ligne" />}
+      title="Connexion"
       cardFooter={
-        <p className="connexion-page__help">
+        <p>
           Pas encore de compte Rumia ?{' '}
           <a href="https://rumia.gov.pf" target="_blank" rel="noreferrer">
             Créer un compte

--- a/packages/angular/src/components/login-layout/login-layout.component.ts
+++ b/packages/angular/src/components/login-layout/login-layout.component.ts
@@ -3,18 +3,19 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 /**
  * Login layout générique.
  *
- * Page d'authentification : logo + carte centrée contenant titre /
- * description / contenu (formulaire, AuthButton, etc.) + footer optionnel.
+ * Page d'authentification : carte centrée contenant logo + titre +
+ * contenu (formulaire, AuthButton, etc.) + cardFooter optionnel.
+ * Footer hors carte (mentions légales) optionnel.
  *
- * Volontairement agnostique : le DS pose le layout, l'app projette son
- * contenu d'authentification (formulaire de mot de passe, bouton fournisseur
- * d'identité, sélecteur d'IdP). Pour brancher GOV Connect, glisser un
- * `<ori-auth-button>` dans le slot principal.
+ * Pattern visuel aligné sur la mire Keycloak `AuthLogin.mdx` (décision
+ * K.1) : logo et titre vivent dans la carte pour offrir une expérience
+ * d'authentification cohérente entre la mire SSO et les pages de
+ * connexion d'apps internes.
  *
  * Slots :
- * - `slot="logo"` : logo au-dessus de la carte
- * - `slot="cardFooter"` : pied de carte (mot de passe oublié, créer un compte)
- * - `slot="footer"` : pied de page (mentions légales, copyright)
+ * - `slot="logo"` : logo en haut de la carte (centré)
+ * - `slot="cardFooter"` : pied de carte (créer un compte)
+ * - `slot="footer"` : pied de page sous la carte (mentions légales, copyright)
  * - projection par défaut : contenu principal de la carte (formulaire, boutons)
  */
 @Component({
@@ -25,12 +26,12 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
   template: `
     <div class="ori-login-layout">
       <div class="ori-login-layout__inner">
-        @if (hasLogo) {
-          <div class="ori-login-layout__logo">
-            <ng-content select="[slot=logo]"></ng-content>
-          </div>
-        }
         <div class="ori-login-layout__card">
+          @if (hasLogo) {
+            <div class="ori-login-layout__logo">
+              <ng-content select="[slot=logo]"></ng-content>
+            </div>
+          }
           <header class="ori-login-layout__header">
             <h1 class="ori-login-layout__title">{{ title }}</h1>
             @if (description) {

--- a/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
@@ -31,35 +31,44 @@ const sharedFooter = (
   </>
 );
 
-/** Cas standard : login email + mot de passe + lien d'aide. */
+/**
+ * Cas standard : login identifiant + mot de passe + lien d'aide.
+ *
+ * Aligné sur la mire Keycloak `AuthLogin` : logo dans la carte, titre
+ * centré, bouton de soumission en pleine largeur, lien « mot de passe
+ * oublié ? » sous le champ password.
+ */
 export const Default: Story = {
   name: 'Par défaut',
   render: () => (
     <LoginLayout
-      logo={<Logo />}
-      title="Se connecter"
-      description="Accédez à votre espace personnel."
+      logo={<Logo subtitle="Démarches en ligne" />}
+      title="Connexion"
       cardFooter={
-        <>
-          <Link href="#">Mot de passe oublié ?</Link>
-          <span>
-            Pas encore de compte ? <Link href="#">Créer un compte</Link>
-          </span>
-        </>
+        <span>
+          Pas encore de compte ? <Link href="#">Créer un compte</Link>
+        </span>
       }
       footer={sharedFooter}
     >
       <Form>
         <FormSection>
-          <FormField label="Adresse électronique" required>
-            {(p) => <Input {...p} type="email" placeholder="exemple@administration.gov.pf" />}
+          <FormField label="Identifiant" required>
+            {(p) => <Input {...p} type="text" autoComplete="username" />}
           </FormField>
           <FormField label="Mot de passe" required>
-            {(p) => <Input {...p} type="password" />}
+            {(p) => <Input {...p} type="password" autoComplete="current-password" />}
           </FormField>
         </FormSection>
-        <FormActions align="end">
-          <Button type="submit">Se connecter</Button>
+        <div style={{ marginTop: '-0.25rem', textAlign: 'right' }}>
+          <Link href="#" variant="quiet">
+            Mot de passe oublié ?
+          </Link>
+        </div>
+        <FormActions>
+          <Button type="submit" block>
+            Se connecter
+          </Button>
         </FormActions>
       </Form>
     </LoginLayout>
@@ -71,14 +80,16 @@ export const WithAuthProvider: Story = {
   name: 'Avec fournisseur d’identité',
   render: () => (
     <LoginLayout
-      logo={<Logo />}
+      logo={<Logo subtitle="Démarches en ligne" />}
       title="Connexion administration"
       description="Cette application est réservée aux agents de la fonction publique. Authentifiez-vous via GOV Connect."
       footer={sharedFooter}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <Button>Se connecter avec GOV Connect</Button>
-        <Button variant="secondary">Connexion alternative (Microsoft)</Button>
+        <Button block>Se connecter avec GOV Connect</Button>
+        <Button variant="secondary" block>
+          Connexion alternative (Microsoft)
+        </Button>
       </div>
     </LoginLayout>
   ),
@@ -88,7 +99,7 @@ export const WithAuthProvider: Story = {
 export const Minimal: Story = {
   name: 'Minimal',
   render: () => (
-    <LoginLayout title="Se connecter">
+    <LoginLayout title="Connexion">
       <Form>
         <FormSection>
           <FormField label="Identifiant" required>
@@ -99,7 +110,9 @@ export const Minimal: Story = {
           </FormField>
         </FormSection>
         <FormActions>
-          <Button type="submit">Connexion</Button>
+          <Button type="submit" block>
+            Se connecter
+          </Button>
         </FormActions>
       </Form>
     </LoginLayout>

--- a/packages/react/src/components/LoginLayout/LoginLayout.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.tsx
@@ -5,9 +5,14 @@ import { clsx } from 'clsx';
 /**
  * Login layout générique.
  *
- * Page d'authentification : logo + carte centrée verticalement et
- * horizontalement contenant titre / description / contenu (formulaire,
- * AuthButton GOV Connect, etc.) + footer optionnel.
+ * Page d'authentification : carte centrée verticalement et horizontalement,
+ * contenant logo + titre + contenu (formulaire, AuthButton, etc.) +
+ * cardFooter optionnel. Footer hors carte (mentions légales) optionnel.
+ *
+ * Pattern visuel aligné sur la mire Keycloak `AuthLogin.mdx` (décision
+ * K.1) : logo et titre vivent dans la carte pour offrir une expérience
+ * d'authentification cohérente entre la mire SSO et les pages de
+ * connexion d'apps internes.
  *
  * Volontairement agnostique : le DS pose le layout, l'app projette son
  * contenu d'authentification (formulaire de mot de passe, bouton fournisseur
@@ -20,15 +25,15 @@ import { clsx } from 'clsx';
  */
 
 export interface LoginLayoutProps {
-  /** Logo affiché au-dessus de la carte (typiquement <Logo>). */
+  /** Logo affiché en haut de la carte, centré (typiquement <Logo>). */
   logo?: ReactNode;
-  /** Titre de la page (h1). */
+  /** Titre de la page (h1, centré). */
   title: ReactNode;
-  /** Description courte sous le titre. */
+  /** Description courte sous le titre (centrée). */
   description?: ReactNode;
   /** Contenu principal (formulaire, AuthButton, mix). */
   children?: ReactNode;
-  /** Pied de carte : liens secondaires (mot de passe oublié, créer un compte). */
+  /** Pied de carte : liens secondaires (créer un compte). */
   cardFooter?: ReactNode;
   /** Pied de page sous la carte : mentions légales, copyright. */
   footer?: ReactNode;
@@ -42,8 +47,8 @@ export const LoginLayout = forwardRef<HTMLDivElement, LoginLayoutProps>(function
   return (
     <div ref={ref} className={clsx('ori-login-layout', className)}>
       <div className="ori-login-layout__inner">
-        {logo && <div className="ori-login-layout__logo">{logo}</div>}
         <div className="ori-login-layout__card">
+          {logo && <div className="ori-login-layout__logo">{logo}</div>}
           <header className="ori-login-layout__header">
             <h1 className="ori-login-layout__title">{title}</h1>
             {description && <p className="ori-login-layout__description">{description}</p>}

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -1853,8 +1853,9 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
 
     // ─── LoginLayout ────────────────────────────────────────────────────────
     // Page d'authentification : centrage vertical/horizontal d'une carte
-    // contenant le titre + contenu + footer optionnel. Le logo et le footer
-    // de page restent en dehors de la carte.
+    // qui héberge logo + titre + contenu + footer optionnel. Aligné sur
+    // la mire Keycloak (cf. AuthLogin.mdx) pour offrir une expérience de
+    // connexion cohérente entre la mire SSO et les pages d'apps internes.
     '.ori-login-layout': {
       minHeight: '100vh',
       display: 'flex',
@@ -1869,7 +1870,7 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       maxWidth: '28rem',
       display: 'flex',
       flexDirection: 'column',
-      gap: theme('spacing.6'),
+      gap: theme('spacing.4'),
       alignItems: 'center',
     },
     '.ori-login-layout__logo': {
@@ -1894,6 +1895,7 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       display: 'flex',
       flexDirection: 'column',
       gap: theme('spacing.1'),
+      textAlign: 'center',
     },
     '.ori-login-layout__title': {
       margin: '0',
@@ -1912,10 +1914,10 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       flexDirection: 'column',
     },
     '.ori-login-layout__card-footer': {
-      paddingTop: theme('spacing.4'),
-      borderTopWidth: '1px',
-      borderTopStyle: 'solid',
-      borderTopColor: v('border-subtle'),
+      // Plus de séparateur visuel : aligné avec AuthLogin où la ligne
+      // « Pas encore de compte ? » est juste un paragraphe centré dans
+      // le bas de la carte, sans border-top. L'espacement est géré par
+      // le `gap` du parent `.ori-login-layout__card`.
       display: 'flex',
       flexDirection: 'column',
       gap: theme('spacing.2'),


### PR DESCRIPTION
## Contexte

Remarqué visuellement : le composant `LoginLayout` (React/Angular) et la mire Keycloak `AuthLogin.mdx` (HTML+CSS pur, décision K.1) divergent alors qu'ils servent le même contexte (s'authentifier pour accéder à un service PF) et sont vus par les mêmes usagers.

| Aspect | Avant (LoginLayout) | Après (= AuthLogin) |
|---|---|---|
| Position du logo | Hors carte, au-dessus | Dans la carte, centré |
| Brand subtitle | Absent | « Démarches en ligne » sous « Polynésie française » |
| Titre | « Se connecter », à gauche | « Connexion », centré |
| `cardFooter` | Avec `border-top` (séparateur) | Sans séparateur, juste un paragraphe centré |

## Changements

- **`packages/react/src/components/LoginLayout/LoginLayout.tsx`** : déplace le rendu du `logo` à l'intérieur de `__card`, au-dessus de `__header`.
- **`packages/angular/src/components/login-layout/login-layout.component.ts`** : même chose côté template Angular.
- **`packages/tailwind-preset/src/plugin-components.js`** :
  - `__header` reçoit `text-align: center` (titre + description).
  - `__card-footer` perd son `border-top` et son `padding-top` (l'espacement vient du `gap` du parent).
  - Le `gap` de `__inner` passe de `spacing.6` à `spacing.4` (la carte gère elle-même son espace).
- **Stories `LoginLayout.stories.tsx`** : `Default` aligné sur AuthLogin (champs « Identifiant » + « Mot de passe », bouton submit `block`, lien « Mot de passe oublié ? » sous le password, `cardFooter` réduit à « Pas encore de compte ? »).
- **Démo `apps/demo-portail/src/pages/Connexion.tsx`** : remplace le bloc logo custom par `<Logo subtitle="Démarches en ligne" />` du DS, titre passe de « Se connecter » à « Connexion » pour matcher le terme Keycloak.

## Aucun changement d'API

Les props `logo`, `title`, `description`, `children`, `cardFooter`, `footer` du `LoginLayout` sont inchangées. C'est une refonte visuelle, pas API.

## Changeset

`minor` sur les 4 packages publishables (changement de pattern visuel par défaut, cf. décision C.5 sur le versionning pré-1.0).

## Test plan

- [ ] CI verte (build, tests, A11y, format)
- [ ] Storybook React déployé : ouvrir `Compositions/Layout/LoginLayout` et vérifier les 3 stories (Default, WithAuthProvider, Minimal) - le rendu doit ressembler à `Patterns/Fonctionnels/Keycloak/AuthLogin`.
- [ ] Démo : ouvrir la page de connexion (lien dans le menu utilisateur > déconnexion) - le logo doit être dans la carte, le titre « Connexion » centré.
- [ ] A11y : `<h1>` toujours présent (titre du layout), label/input toujours associés, `role="alert"` sur les erreurs (cf. AuthLogin.mdx variante erreur).