### PR TITLE
fix(vague-1): bugs CSS visuels SearchBar et PhoneInput

### DIFF
--- a/.changeset/phone-input-collapsed.md
+++ b/.changeset/phone-input-collapsed.md
@@ -1,0 +1,10 @@
+---
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+PhoneInput : coller le pill indicatif et l'input numéro en un seul combo visuel.
+
+Avant, un `gap: spacing.2` séparait le pill `+689` de l'input du numéro - ils ressemblaient à deux contrôles distincts plutôt qu'à un champ unifié.
+
+Désormais le `gap` passe à `0` et les rayons sont asymétriques : le pill garde son rayon à gauche, l'input son rayon à droite. Visuellement les deux moitiés forment un seul rectangle scindé, ce qui rend mieux l'idée que la valeur saisie est composée des deux parties (`dialCode + value`).

--- a/.changeset/search-bar-button-pico.md
+++ b/.changeset/search-bar-button-pico.md
@@ -1,0 +1,10 @@
+---
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+SearchBar : corriger le « pico » disgracieux sous le coin bas-droit du bouton.
+
+La `border-bottom` de l'underline était posée sur le wrapper `__field` qui englobe input + bouton. Comme le bouton a un `border-radius`, son coin bas-droit ne touchait pas la ligne et laissait apparaître un petit triangle disgracieux au point où la ligne quittait le radius du bouton.
+
+On migre la `border-bottom` sur l'input lui-même : elle s'arrête net au bord droit de l'input et le bouton vit librement à côté avec son radius. Comportement de focus inchangé : le `:focus-visible` de l'input bascule la couleur sur `border-focus`.

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -3717,14 +3717,6 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       alignItems: 'stretch',
       gap: theme('spacing.2'),
       width: '100%',
-      borderBottomWidth: '2px',
-      borderBottomStyle: 'solid',
-      borderBottomColor: v('brand-primary'),
-      transitionProperty: 'border-color',
-      transitionDuration: theme('transitionDuration.fast'),
-      '&:focus-within': {
-        borderBottomColor: v('border-focus'),
-      },
     },
     '.ori-search-bar__input': {
       flex: '1 1 auto',
@@ -3736,10 +3728,22 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       lineHeight: theme('lineHeight.normal'),
       color: v('text-primary'),
       backgroundColor: 'transparent',
-      borderWidth: '0',
+      // L'underline vit sur l'input lui-même : ça évite le « pico » qu'on
+      // voyait dans le coin bas-droit du bouton quand la border était sur
+      // le wrapper et passait sous le radius du bouton.
+      borderTopWidth: '0',
+      borderInlineWidth: '0',
+      borderBottomWidth: '2px',
+      borderBottomStyle: 'solid',
+      borderBottomColor: v('brand-primary'),
       outline: 'none',
+      transitionProperty: 'border-color',
+      transitionDuration: theme('transitionDuration.fast'),
       '&::placeholder': { color: v('text-muted') },
       '&::-webkit-search-cancel-button': { cursor: 'pointer' },
+      '&:focus-visible, &:focus': {
+        borderBottomColor: v('border-focus'),
+      },
       '&:disabled': {
         cursor: 'not-allowed',
         color: v('text-disabled'),

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -3799,7 +3799,11 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
     '.ori-phone-input': {
       display: 'flex',
       alignItems: 'stretch',
-      gap: theme('spacing.2'),
+      // Pas de gap : pill country + input number sont collés et forment
+      // un combo visuel unifié. Les radii asymétriques (left-only sur le
+      // country, right-only sur l'input) donnent l'impression d'un seul
+      // rectangle scindé en deux moitiés.
+      gap: '0',
       width: '100%',
     },
     '.ori-phone-input__country': {
@@ -3814,7 +3818,8 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       fontWeight: theme('fontWeight.medium'),
       color: v('brand-on-primary'),
       backgroundColor: v('brand-primary'),
-      borderRadius: theme('borderRadius.md'),
+      borderTopLeftRadius: theme('borderRadius.md'),
+      borderBottomLeftRadius: theme('borderRadius.md'),
       cursor: 'pointer',
       transitionProperty: 'background-color',
       transitionDuration: theme('transitionDuration.fast'),
@@ -3884,7 +3889,12 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       lineHeight: theme('lineHeight.normal'),
       color: v('text-primary'),
       backgroundColor: v('surface-base'),
-      borderRadius: theme('borderRadius.md'),
+      // Radii asymétriques : seul le bord droit est arrondi pour coller
+      // au pill country à gauche.
+      borderTopLeftRadius: '0',
+      borderBottomLeftRadius: '0',
+      borderTopRightRadius: theme('borderRadius.md'),
+      borderBottomRightRadius: theme('borderRadius.md'),
       borderWidth: '1px',
       borderStyle: 'solid',
       borderColor: v('border-default'),


### PR DESCRIPTION
## Bugs visuels remontés à la review

Deux retouches CSS sur les composants de la vague 1.

### 1. SearchBar : pico disgracieux sous le coin du bouton

Le coin bas-droit du bouton « Rechercher » laissait apparaître un petit triangle visible au point où le radius du bouton quittait la ligne d'underline.

**Cause** : la `border-bottom: 2px brand-primary` était posée sur le wrapper `.ori-search-bar__field` qui englobe input + bouton. Le bouton a un `border-radius: md`, donc son coin bas-droit ne suivait pas la ligne droite et laissait un pico.

**Fix** : la border-bottom déménage sur `.ori-search-bar__input` directement. Elle s'arrête net au bord droit de l'input et le bouton vit librement à côté avec son radius. Le focus visuel reste géré (`:focus-visible` / `:focus` de l'input bascule la couleur sur `border-focus`).

### 2. PhoneInput : pill indicatif et input numéro collés

Avant, un `gap: spacing.2` séparait le pill `+689` de l'input du numéro - ils ressemblaient à deux contrôles distincts plutôt qu'à un champ unifié.

**Fix** : `gap: 0` + rayons asymétriques. Le pill garde son rayon à gauche, l'input son rayon à droite. Visuellement les deux moitiés forment un seul rectangle scindé, ce qui rend mieux l'idée que la valeur saisie est composée des deux parties (`dialCode + value`).

## Test plan

- [ ] CI verte
- [ ] Storybook React déployé :
  - [ ] `Primitives/Saisie/SearchBar/Par défaut` - plus de pico sous le bouton.
  - [ ] `Primitives/Saisie/PhoneInput/Par défaut` + `Plusieurs indicatifs` - pill et input collés.
- [ ] Démo : pages Documents / Annuaire / Catalogue / Aide - plus de pico sur les SearchBar.
- [ ] Démo : page Profil + Demande de détail - pill PhoneInput collé à l'input.

## Changeset

`patch` sur `@govpf/ori-tailwind-preset` et `@govpf/ori-css`. Aucune surface API touchée.