### PR TITLE
fix(stories,demo): alignement visuel post-merge vague 1

### DIFF
--- a/apps/demo-portail/src/pages/Aide.tsx
+++ b/apps/demo-portail/src/pages/Aide.tsx
@@ -176,8 +176,8 @@ export function AidePage({ onNavigate }: AidePageProps) {
                   buttonLabel="Rechercher"
                 />
               </div>
-              <Button variant="primary" size="lg" onClick={() => setCreateOpen(true)}>
-                <Plus size={18} aria-hidden="true" />
+              <Button variant="primary" onClick={() => setCreateOpen(true)}>
+                <Plus size={16} aria-hidden="true" />
                 Nouveau ticket
               </Button>
             </div>

--- a/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
+++ b/packages/react/src/components/LoginLayout/LoginLayout.stories.tsx
@@ -56,15 +56,15 @@ export const Default: Story = {
           <FormField label="Identifiant" required>
             {(p) => <Input {...p} type="text" autoComplete="username" />}
           </FormField>
-          <FormField label="Mot de passe" required>
-            {(p) => <Input {...p} type="password" autoComplete="current-password" />}
-          </FormField>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+            <FormField label="Mot de passe" required>
+              {(p) => <Input {...p} type="password" autoComplete="current-password" />}
+            </FormField>
+            <Link href="#" variant="quiet" style={{ alignSelf: 'flex-end', fontSize: '0.8125rem' }}>
+              Mot de passe oublié ?
+            </Link>
+          </div>
         </FormSection>
-        <div style={{ marginTop: '-0.25rem', textAlign: 'right' }}>
-          <Link href="#" variant="quiet">
-            Mot de passe oublié ?
-          </Link>
-        </div>
         <FormActions>
           <Button type="submit" block>
             Se connecter


### PR DESCRIPTION
## Bugs visuels remontés après contrôle visuel post-déploiement

### 1. LoginLayout story `Default` : lien « Mot de passe oublié ? » trop loin du champ

Le lien flottait avec un gros espace blanc au-dessus parce qu'il était posé en sibling du `<FormSection>` dans le `<Form>`, qui applique son `gap` par défaut entre tous les enfants.

**Fix** : on regroupe le `<FormField>` Mot de passe **et** le lien dans un wrapper `flex-direction: column` avec `gap: 0.25rem`, comme dans la spec `AuthLogin.mdx` (`pf-auth-password-block`). Le lien colle désormais au champ.

### 2. Aide.tsx hero : bouton « Nouveau ticket » mal aligné avec le SearchBar

Le bouton « + Nouveau ticket » à droite de la `<SearchBar>` était en `size="lg"` alors que le bouton interne de la SearchBar est en `md`. Hauteurs différentes, alignement cassé visuellement.

**Fix** : retrait du `size="lg"` (le bouton vient en `md` par défaut) et taille de l'icône `Plus` passe de 18 à 16 pour matcher le bouton du SearchBar.

## Test plan

- [ ] CI verte
- [ ] Storybook React déployé : `Compositions/Layout/LoginLayout/Par défaut` - le lien colle au champ password.
- [ ] Démo : page `Aide` - les deux boutons à droite (Rechercher + Nouveau ticket) sont alignés.

Pas de changeset : modifs dans la démo et dans une story uniquement, aucun package publishable touché.