### PR TITLE
fix(search-bar): coller le trait au bouton et carrer son coin gauche

### DIFF
--- a/.changeset/search-bar-button-square-left.md
+++ b/.changeset/search-bar-button-square-left.md
@@ -1,0 +1,15 @@
+---
+'@govpf/ori-tailwind-preset': patch
+'@govpf/ori-css': patch
+---
+
+SearchBar : coller le trait à la base du bouton et carré le coin gauche du bouton.
+
+Le wrapper `__field` avait un `gap: spacing.2` qui laissait un espace entre l'input et le bouton. Du coup la border-bottom de l'input s'arrêtait avant le bouton, et le bouton avait son radius normal à gauche - on voyait un petit creux disgracieux à la jonction.
+
+Désormais :
+
+- `gap: 0` : input et bouton sont collés.
+- Le bouton perd son rayon à gauche (`border-top-left-radius` et `border-bottom-left-radius` à `0`), seul le côté droit reste arrondi.
+
+Visuellement, le trait sous l'input rejoint le bord gauche du bouton sans interruption, et la coupure verticale entre l'input et le bouton est nette.

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -3717,7 +3717,10 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
     '.ori-search-bar__field': {
       display: 'flex',
       alignItems: 'stretch',
-      gap: theme('spacing.2'),
+      // Pas de gap : l'input et le bouton sont collés. La border-bottom
+      // de l'input rejoint le bord gauche du bouton sans interruption,
+      // et le bouton perd son rayon à gauche pour matcher la coupure.
+      gap: '0',
       width: '100%',
     },
     '.ori-search-bar__input': {
@@ -3765,7 +3768,13 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       color: v('brand-on-primary'),
       backgroundColor: v('brand-primary'),
       borderWidth: '0',
-      borderRadius: theme('borderRadius.md'),
+      // Coin gauche carré pour s'aligner avec la coupure droite de
+      // l'input (pas de gap entre les deux). Seul le côté droit reste
+      // arrondi.
+      borderTopLeftRadius: '0',
+      borderBottomLeftRadius: '0',
+      borderTopRightRadius: theme('borderRadius.md'),
+      borderBottomRightRadius: theme('borderRadius.md'),
       cursor: 'pointer',
       transitionProperty: 'background-color, box-shadow',
       transitionDuration: theme('transitionDuration.fast'),


### PR DESCRIPTION
## Bug

Entre l'input de la SearchBar et son bouton « Rechercher », un petit espace laissait apparaître :
- une **interruption** du trait d'underline juste avant le bouton ;
- un **creux** visuel à cause du radius arrondi du coin gauche du bouton.

## Fix

- `gap: 0` sur `.ori-search-bar__field` : input et bouton sont désormais collés.
- Coin gauche du bouton **carré** (`border-top-left-radius` et `border-bottom-left-radius` à `0`). Seul le côté droit reste arrondi.

Visuellement le trait sous l'input rejoint sans interruption le bord gauche du bouton, et la coupure verticale entre les deux est nette.

## Test plan

- [ ] CI verte
- [ ] Storybook : `Primitives/Saisie/SearchBar/Par défaut` - trait collé au bouton, coin gauche du bouton bien carré.
- [ ] Démo : pages Documents / Annuaire / Catalogue / Aide - même rendu.

## Changeset

`patch` sur `@govpf/ori-tailwind-preset` et `@govpf/ori-css`.