### PR TITLE
feat(ci): visual parity React vs Angular (a la demande, non bloquant)

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -1,0 +1,114 @@
+name: Visual parity React ↔ Angular
+
+# Test de parité visuelle entre les Storybook React et Angular.
+# Pour chaque story qui existe dans les deux frameworks, screenshot
+# `#storybook-root` côté React et côté Angular, puis diff pixel-à-pixel.
+#
+# Phase actuelle : déclenchement à la demande uniquement (workflow_dispatch
+# ou label `visual-test` posé sur une PR). Pas bloquant pour le merge tant
+# que le check n'est pas ajouté à la branch protection.
+#
+# Pour passer en automatique : remplacer le bloc `if:` par un trigger
+# `pull_request` standard et ajouter `continue-on-error: true` au job
+# (cf. tools/visual-parity/README.md).
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+env:
+  NODE_VERSION: '24'
+  PNPM_VERSION: '10.29.3'
+
+jobs:
+  visual-parity:
+    name: Visual parity test
+    # Déclenchement explicite uniquement : bouton manuel OU label
+    # `visual-test` posé sur une PR. Pas de coût CI hors demande explicite.
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'visual-test'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages (deps des Storybooks)
+        run: pnpm -r --filter "./packages/*" build
+
+      - name: Build Storybook React
+        run: pnpm --filter @govpf/ori-storybook-react build
+
+      - name: Build Storybook Angular
+        run: pnpm --filter @govpf/ori-storybook-angular build
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @govpf/ori-tools-visual-parity exec playwright install --with-deps chromium
+
+      - name: Run visual parity test
+        run: |
+          npx http-server apps/storybook-react/storybook-static -p 6006 -s -c-1 &
+          REACT_PID=$!
+          npx http-server apps/storybook-angular/storybook-static -p 6008 -s -c-1 &
+          ANGULAR_PID=$!
+          npx wait-on tcp:6006 tcp:6008 --timeout 60000
+          set +e
+          node tools/visual-parity/compare.mjs
+          STATUS=$?
+          set -e
+          kill $REACT_PID $ANGULAR_PID 2>/dev/null || true
+          exit $STATUS
+        env:
+          REACT_URL: http://localhost:6006
+          ANGULAR_URL: http://localhost:6008
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-parity-report
+          path: tools/visual-parity/output/
+          retention-days: 14
+
+      - name: Comment on PR with summary
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'tools/visual-parity/output/results.json';
+            if (!fs.existsSync(path)) return;
+            const summary = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const failed = (summary.results || []).filter((r) => !r.passed && !r.error);
+            const errored = (summary.results || []).filter((r) => r.error);
+            const top = failed
+              .sort((a, b) => (b.ratio || 0) - (a.ratio || 0))
+              .slice(0, 10)
+              .map((r) => `- \`${r.title} / ${r.name}\` - ${(r.ratio * 100).toFixed(2)} %`)
+              .join('\n');
+            const body = [
+              `## Visual parity React ↔ Angular`,
+              ``,
+              `- ${summary.passed} en parité · ${summary.failed} divergences · ${summary.errored} erreurs`,
+              `- Stories uniquement React : ${summary.onlyReact} · uniquement Angular : ${summary.onlyAngular}`,
+              ``,
+              failed.length === 0
+                ? '> ✅ Aucune divergence détectée.'
+                : `> ❌ Top divergences :\n\n${top}\n\nRapport HTML complet : artifact \`visual-parity-report\`.`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,6 +247,42 @@ tests a11y axe-core (193 stories) et sur le fait que la logique est
 miroir de la version React (71 tests Vitest). À ré-évaluer à chaque
 release Angular ou Vitest majeure.
 
+#### Tests de parité visuelle React ↔ Angular (à la demande)
+
+Pour chaque story qui existe dans les deux Storybooks (clé `title +
+name`), un job CI dédié peut prendre une capture du `#storybook-root`
+côté React et côté Angular, puis comparer les deux pixel-à-pixel via
+`pixelmatch`. Si la divergence dépasse un seuil (1 % de pixels par
+défaut), le job remonte un fail avec un rapport HTML détaillé en
+artifact.
+
+**Phase actuelle** : test à la demande, **non bloquant** pour le merge.
+Trois manières de le déclencher :
+
+- Bouton **`Run workflow`** dans l'UI GitHub Actions, sur le workflow
+  _Visual parity React ↔ Angular_.
+- CLI : `gh workflow run visual-parity.yml --ref ma-branche`.
+- Poser le label **`visual-test`** sur une PR : déclenche le job
+  automatiquement.
+
+Le rapport HTML est uploadé en artifact (`visual-parity-report`,
+rétention 14 jours) et un commentaire récapitulatif est posté sur la PR
+avec le top 10 des divergences.
+
+Pour exclure une story du test (animation continue, données
+aléatoires…), ajouter le tag `skip-visual` dans son `meta.tags` :
+
+```ts
+const meta = {
+  title: 'Primitives/...',
+  component: ...,
+  tags: ['autodocs', 'skip-visual'],
+};
+```
+
+Documentation et configuration complète : [`tools/visual-parity/README.md`](./tools/visual-parity/README.md)
+et la fiche Storybook _Fondations / Validation parité visuelle_.
+
 ### 4. Conventions de commits
 
 Format **Conventional Commits** :

--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -6,6 +6,7 @@ Positionnement :
 
 - **Service public** : généricité institutionnelle, identité visuelle Polynésie française et non d'un service spécifique
 - **RGAA AA baseline obligatoire** : ensemble des stories Storybook validées WCAG 2.0 AA en CI à chaque PR (axe-core, 0 violation - le compte exact vit dans `index.json`)
+- **Parité visuelle React ↔ Angular** : test pixel-à-pixel disponible à la demande via le workflow `Visual parity React ↔ Angular` (label `visual-test` sur PR ou `gh workflow run`). Phase d'observation actuellement, non bloquant pour le merge.
 - **Natif d'abord** : éléments HTML natifs privilégiés systématiquement (`<select>`, `<input type="date">`, etc.) pour garantir l'a11y sans audit à recommencer
 - **Bundle minimal** : adapté aux connexions limitées des archipels éloignés
 - **Multi-framework** : même apparence visuelle garantie sur React, Angular, HTML pur depuis une source unique de tokens
@@ -75,6 +76,7 @@ Documentées en MDX dans le repo, source de vérité publique :
 
 - [packages/docs/src/Decisions-A-Prendre.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx) : décisions architecturales tranchées
 - [packages/docs/src/Validation-Accessibilite.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Accessibilite.mdx) : méthode et couverture a11y
+- [packages/docs/src/Validation-Parite-Visuelle.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Parite-Visuelle.mdx) : test de parité visuelle React ↔ Angular (à la demande, non bloquant en phase d'observation)
 
 ## Conventions
 

--- a/packages/docs/src/Validation-Parite-Visuelle.mdx
+++ b/packages/docs/src/Validation-Parite-Visuelle.mdx
@@ -1,0 +1,112 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Fondations/Validation parité visuelle" />
+
+# Validation parité visuelle React ↔ Angular
+
+Ori expose les mêmes composants côté React et Angular, animés par les mêmes tokens et les mêmes classes CSS `.ori-*`. La promesse implicite : ce qui rend chez l'un doit rendre **pixel-identiquement** chez l'autre. Cette page décrit comment cette promesse est vérifiée et les limites de la garantie automatisée.
+
+## Pourquoi un test dédié
+
+Les composants React et Angular consomment la même feuille de style à la racine, mais leur templating diffère : balisage HTML structuré différemment, gestion des slots, des classes dynamiques, des states. Sauf bug local, le rendu doit être identique.
+
+Avant ce test, la cohérence reposait uniquement sur la **discipline de revue manuelle** lors des PR. Cette discipline a montré ses limites : on a découvert plusieurs drifts (SearchBar, PhoneInput) au moment où les composants ont été utilisés en production, donc plusieurs jours après le merge.
+
+## Comment ça marche
+
+Pour chaque story qui existe dans les deux Storybooks (clé `title + name`), un test Playwright :
+
+1. Charge l'iframe Storybook React avec la story.
+2. Charge l'iframe Storybook Angular avec la même story.
+3. Capture le `#storybook-root` des deux côtés.
+4. Compare pixel-à-pixel via [`pixelmatch`](https://github.com/mapbox/pixelmatch).
+5. Marque la story `pass` si la divergence reste sous le seuil (1 % de pixels par défaut), `fail` sinon.
+
+Le test produit un rapport HTML lisible (`tools/visual-parity/output/report.html`) avec, par story, un triptyque **React | Angular | diff visuel** pour identifier la zone qui pose souci.
+
+## Statut courant - phase d'observation
+
+<div
+  style={{
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0.5rem',
+    padding: '0.5rem 0.75rem',
+    borderRadius: '0.375rem',
+    background: 'var(--color-feedback-info-bg)',
+    color: 'var(--color-feedback-info-strong)',
+    border: '1px solid var(--color-feedback-info)',
+    fontWeight: 600,
+  }}
+>
+  ⏳ Phase d'observation : test à la demande, non bloquant
+</div>
+
+Le job CI `Visual parity React ↔ Angular` est en place mais **ne tourne pas systématiquement** sur chaque PR. Il faut le déclencher explicitement de l'une des trois façons suivantes :
+
+- **Bouton manuel** dans l'UI GitHub Actions (`Run workflow` → choisir la branche).
+- **CLI** : `gh workflow run visual-parity.yml --ref ma-branche`.
+- **Label sur PR** : poser le label `visual-test` sur une pull request.
+
+Quand le job échoue, la PR n'est **pas bloquée** : le check apparaît en rouge mais ne fait pas partie des checks requis pour merger.
+
+## Roadmap
+
+La progression vers l'enforcement total se fait en trois phases :
+
+1. **Phase d'observation (actuelle)**  
+   Déclenchement à la demande. On accumule de la confiance sur l'outil, on calibre les thresholds, on identifie les stories instables (animations qui ne stabilisent pas, données aléatoires, etc.).
+
+2. **Phase de stabilisation**  
+   Le job tourne automatiquement sur chaque PR mais avec `continue-on-error: true`. Les divergences sont visibles sans bloquer le merge - feedback informatif pour l'équipe.
+
+3. **Phase de gating**  
+   Retrait de `continue-on-error`. Le check est ajouté à la branch protection. Toute divergence visuelle bloque le merge tant qu'elle n'est pas corrigée ou que le seuil n'est pas explicitement remonté.
+
+Chaque transition se fait en modifiant `.github/workflows/visual-parity.yml` et la branch protection côté GitHub Settings.
+
+## Configuration
+
+Le test est paramétrable par variables d'environnement :
+
+| Variable | Défaut | Effet |
+|---|---|---|
+| `THRESHOLD` | `0.01` | Tolérance globale (1 % de pixels divergents par story). |
+| `PIXEL_THRESHOLD` | `0.1` | Sensibilité de pixelmatch par pixel (`0` = strict, `1` = permissif). |
+| `VIEWPORT_WIDTH` / `VIEWPORT_HEIGHT` | `1280` / `800` | Taille du viewport pour la capture. |
+| `SETTLE_MS` | `500` | Attente après render avant la capture (laisse les animations se poser). |
+| `SKIP_TAGS` | `skip-visual,docs-only,test-only` | Tags Storybook exclus du test. |
+
+## Comment exclure une story
+
+Si une story ne peut pas être stabilisée (animation continue, données générées aléatoirement à chaque render, dépendance externe non maîtrisée), ajouter le tag `skip-visual` dans son `meta.tags` :
+
+```ts
+const meta = {
+  title: 'Primitives/...',
+  component: ...,
+  tags: ['autodocs', 'skip-visual'],
+};
+```
+
+À justifier par un commentaire au-dessus du `tags`.
+
+## Limites assumées
+
+- **Couverture limitée aux paires existantes**  
+  Les stories qui n'existent que d'un côté (par exemple un composant Angular pas encore livré côté React) ne sont pas testables. Le rapport les liste à part dans la section « Stories uniquement côté X ».
+
+- **Pas de couverture multi-viewport**  
+  Le test tourne sur un seul viewport (1280×800). Une régression spécifique mobile peut passer inaperçue. À ajouter dans une itération ultérieure si besoin.
+
+- **Pas de couverture multi-thème**  
+  Le test tourne en thème clair. Le thème sombre est validé par discipline de revue. À renforcer plus tard.
+
+- **Sensibilité au font rendering**  
+  Les fonts peuvent rendre légèrement différemment selon la machine. Le seuil de 1 % absorbe ces micro-différences mais peut masquer un vrai drift sur de petites zones. À ajuster selon les retours.
+
+## Références
+
+- Outil : [`tools/visual-parity/`](https://github.com/govpf/ori/tree/main/tools/visual-parity)
+- Workflow : [`.github/workflows/visual-parity.yml`](https://github.com/govpf/ori/blob/main/.github/workflows/visual-parity.yml)
+- Bibliothèques : [Playwright](https://playwright.dev/), [pixelmatch](https://github.com/mapbox/pixelmatch), [pngjs](https://github.com/lukeapage/pngjs)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,24 @@ importers:
         specifier: ^4.2.0
         version: 4.4.0(tslib@2.8.1)
 
+  tools/visual-parity:
+    dependencies:
+      http-server:
+        specifier: ^14.1.1
+        version: 14.1.1
+      pixelmatch:
+        specifier: ^7.1.0
+        version: 7.2.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
+      wait-on:
+        specifier: ^9.0.1
+        version: 9.0.5
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -7771,6 +7789,10 @@ packages:
     resolution: {integrity: sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==}
     engines: {node: '>=20.x'}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
@@ -7792,6 +7814,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -9334,6 +9360,11 @@ packages:
   wait-on@8.0.5:
     resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
     engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  wait-on@9.0.5:
+    resolution: {integrity: sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==}
+    engines: {node: '>=20.0.0'}
     hasBin: true
 
   wait-port@0.2.14:
@@ -18511,6 +18542,10 @@ snapshots:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   pkce-challenge@5.0.1: {}
 
   pkg-dir@4.2.0:
@@ -18528,6 +18563,8 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   polished@4.3.1:
     dependencies:
@@ -20266,6 +20303,16 @@ snapshots:
       - debug
 
   wait-on@8.0.5:
+    dependencies:
+      axios: 1.15.2
+      joi: 18.1.2
+      lodash: 4.18.1
+      minimist: 1.2.8
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - debug
+
+  wait-on@9.0.5:
     dependencies:
       axios: 1.15.2
       joi: 18.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/*"
   - "apps/*"
+  - "tools/*"
 
 # pnpm v10 attend `onlyBuiltDependencies` et `overrides` ici, pas dans
 # package.json (sinon : "field will not take effect").

--- a/tools/visual-parity/.gitignore
+++ b/tools/visual-parity/.gitignore
@@ -1,0 +1,2 @@
+output/
+node_modules/

--- a/tools/visual-parity/README.md
+++ b/tools/visual-parity/README.md
@@ -1,0 +1,84 @@
+# Visual parity React ↔ Angular
+
+Outil interne de test de parité visuelle entre les Storybook React et Angular d'Ori. Pour chaque story qui existe dans les deux frameworks (clé `title + name`), capture le `#storybook-root` côté React et côté Angular, puis compare pixel-à-pixel.
+
+## Pourquoi
+
+Les deux frameworks consomment les mêmes tokens et les mêmes classes CSS `.ori-*`. Sauf bug de templating, les rendus doivent être identiques. La discipline de revue ne suffit pas à attraper tous les drifts (cf. l'incident SearchBar/PhoneInput de 2026-05-01).
+
+## Usage local
+
+Prérequis : avoir buildé les deux Storybooks au préalable.
+
+```bash
+# Build des packages, puis des deux Storybooks
+pnpm -r --filter "./packages/*" build
+pnpm --filter @govpf/ori-storybook-react build
+pnpm --filter @govpf/ori-storybook-angular build
+
+# Servir les deux storybooks (terminaux distincts ou en arrière-plan)
+npx http-server apps/storybook-react/storybook-static -p 6006 -s &
+npx http-server apps/storybook-angular/storybook-static -p 6008 -s &
+
+# Installer les deps de l'outil et exécuter
+pnpm --filter @govpf/ori-tools-visual-parity install
+pnpm exec playwright install chromium
+node tools/visual-parity/compare.mjs
+```
+
+Sortie dans `tools/visual-parity/output/` :
+
+- `report.html` : rapport visuel (ouvrir directement dans un navigateur)
+- `results.json` : résultats bruts pour usage CI
+- `images/<story-id>/{react,angular,diff}.png` : captures et diff par story
+
+## Variables d'env
+
+| Var               | Default                           | Effet                                                           |
+| ----------------- | --------------------------------- | --------------------------------------------------------------- |
+| `REACT_URL`       | `http://localhost:6006`           | URL du Storybook React                                          |
+| `ANGULAR_URL`     | `http://localhost:6008`           | URL du Storybook Angular                                        |
+| `THRESHOLD`       | `0.01`                            | Tolérance globale (1 % de pixels divergents par story)          |
+| `PIXEL_THRESHOLD` | `0.1`                             | Sensibilité de pixelmatch par pixel (0 = strict, 1 = permissif) |
+| `VIEWPORT_WIDTH`  | `1280`                            | Largeur du viewport                                             |
+| `VIEWPORT_HEIGHT` | `800`                             | Hauteur du viewport                                             |
+| `SETTLE_MS`       | `500`                             | Attente après render avant capture                              |
+| `SKIP_TAGS`       | `skip-visual,docs-only,test-only` | Tags Storybook à exclure                                        |
+
+## Comment exclure une story
+
+Ajouter le tag `skip-visual` dans le `meta.tags` de la story concernée :
+
+```ts
+const meta = {
+  title: 'Primitives/...',
+  component: ...,
+  tags: ['autodocs', 'skip-visual'],
+};
+```
+
+À justifier par un commentaire (animations qui ne stabilisent pas, snapshot non déterministe, etc.).
+
+## Codes de sortie
+
+- `0` : toutes les paires sont en parité
+- `1` : au moins une story diverge ou erreur d'exécution
+
+## Usage CI
+
+Workflow déclenché à la demande, non bloquant pour l'instant. Voir `.github/workflows/visual-parity.yml`.
+
+Triggers :
+
+- `workflow_dispatch` : bouton "Run workflow" dans l'UI Actions, ou `gh workflow run visual-parity.yml --ref ma-branche`
+- Label `visual-test` posé sur une PR : déclenche automatiquement le job
+
+Le rapport HTML + les images sont uploadés en artifact CI (rétention 14 jours).
+
+## Roadmap
+
+1. **Phase d'observation** (actuelle) : déclenchement à la demande, ajustement des thresholds, identification des stories instables.
+2. **Phase de stabilisation** : tournage automatique sur toutes les PR avec `continue-on-error: true`.
+3. **Phase de gating** : retrait de `continue-on-error` + ajout du check à la branch protection.
+
+Chaque transition se fait en modifiant `.github/workflows/visual-parity.yml`.

--- a/tools/visual-parity/compare.mjs
+++ b/tools/visual-parity/compare.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Test de parité visuelle entre les Storybook React et Angular d'Ori.
+ *
+ * Pour chaque story qui existe dans les deux frameworks (clé : `title +
+ * name`), prend un screenshot du `#storybook-root` côté React et côté
+ * Angular, puis compare les deux pixels-à-pixel via pixelmatch.
+ *
+ * Sortie :
+ *   - `output/images/<story-id>/{react,angular,diff}.png` : captures + diff
+ *   - `output/report.html` : rapport HTML lisible (ouverture directe dans
+ *     un navigateur, pas besoin d'host)
+ *   - `output/results.json` : résultats bruts (pour l'usage CI)
+ *
+ * Codes de sortie :
+ *   - 0 : toutes les stories communes sont en parité (diff < THRESHOLD)
+ *   - 1 : au moins une story diverge ou erreur d'exécution
+ *
+ * Variables d'env :
+ *   - REACT_URL (default http://localhost:6006)
+ *   - ANGULAR_URL (default http://localhost:6008)
+ *   - THRESHOLD (default 0.01 = 1% de pixels différents toléré)
+ *   - PIXEL_THRESHOLD (default 0.1 = sensibilité de pixelmatch par pixel)
+ *   - VIEWPORT_WIDTH / VIEWPORT_HEIGHT (default 1280 / 800)
+ *   - SETTLE_MS (default 500 = ms d'attente après render avant capture)
+ *   - SKIP_TAGS (default 'skip-visual,docs-only,test-only')
+ *
+ * Le test n'échoue jamais sur les stories absentes d'un framework. La
+ * couverture comparable est limitée aux paires existantes.
+ */
+
+import { chromium } from 'playwright';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const REACT_URL = process.env.REACT_URL || 'http://localhost:6006';
+const ANGULAR_URL = process.env.ANGULAR_URL || 'http://localhost:6008';
+const THRESHOLD = Number(process.env.THRESHOLD || '0.01');
+const PIXEL_THRESHOLD = Number(process.env.PIXEL_THRESHOLD || '0.1');
+const VIEWPORT_WIDTH = Number(process.env.VIEWPORT_WIDTH || '1280');
+const VIEWPORT_HEIGHT = Number(process.env.VIEWPORT_HEIGHT || '800');
+const SETTLE_MS = Number(process.env.SETTLE_MS || '500');
+const SKIP_TAGS = (process.env.SKIP_TAGS || 'skip-visual,docs-only,test-only')
+  .split(',')
+  .map((t) => t.trim());
+
+const OUT = path.join(__dirname, 'output');
+const IMG_DIR = path.join(OUT, 'images');
+
+function log(...args) {
+  // eslint-disable-next-line no-console
+  console.log('[visual-parity]', ...args);
+}
+
+function err(...args) {
+  // eslint-disable-next-line no-console
+  console.error('[visual-parity]', ...args);
+}
+
+async function fetchIndex(baseUrl) {
+  const res = await fetch(`${baseUrl}/index.json`);
+  if (!res.ok) throw new Error(`Failed to fetch ${baseUrl}/index.json (${res.status})`);
+  return res.json();
+}
+
+function commonStories(reactIndex, angularIndex) {
+  const reactStories = Object.values(reactIndex.entries).filter(
+    (e) => e.type === 'story' && !(e.tags || []).some((t) => SKIP_TAGS.includes(t)),
+  );
+  const angularStories = Object.values(angularIndex.entries).filter(
+    (e) => e.type === 'story' && !(e.tags || []).some((t) => SKIP_TAGS.includes(t)),
+  );
+  const angularByKey = new Map();
+  for (const s of angularStories) angularByKey.set(`${s.title}::${s.name}`, s);
+
+  const pairs = [];
+  for (const r of reactStories) {
+    const key = `${r.title}::${r.name}`;
+    const a = angularByKey.get(key);
+    if (a) pairs.push({ key, title: r.title, name: r.name, react: r, angular: a });
+  }
+  // Stories qui existent côté React mais pas Angular (et vice-versa) :
+  // utile pour le rapport mais ne fait pas échouer le test.
+  const onlyReact = reactStories
+    .filter((r) => !angularByKey.has(`${r.title}::${r.name}`))
+    .map((s) => ({ key: `${s.title}::${s.name}`, title: s.title, name: s.name }));
+  const reactKeys = new Set(reactStories.map((r) => `${r.title}::${r.name}`));
+  const onlyAngular = angularStories
+    .filter((a) => !reactKeys.has(`${a.title}::${a.name}`))
+    .map((s) => ({ key: `${s.title}::${s.name}`, title: s.title, name: s.name }));
+
+  return { pairs, onlyReact, onlyAngular };
+}
+
+async function captureStory(page, baseUrl, storyId) {
+  const url = `${baseUrl}/iframe.html?id=${encodeURIComponent(storyId)}&viewMode=story`;
+  await page.goto(url, { waitUntil: 'networkidle' });
+  // Attente du root storybook (présent dès que le composant est monté).
+  await page.waitForSelector('#storybook-root', { timeout: 15000 });
+  // Stabilisation : laisser le temps aux animations / fonts de se poser.
+  await page.waitForTimeout(SETTLE_MS);
+  return page.locator('#storybook-root').screenshot({ type: 'png' });
+}
+
+function padToSameSize(a, b) {
+  const w = Math.max(a.width, b.width);
+  const h = Math.max(a.height, b.height);
+  if (a.width === w && a.height === h && b.width === w && b.height === h) {
+    return [a, b, w, h];
+  }
+  const padded = (src) => {
+    const out = new PNG({ width: w, height: h });
+    out.data.fill(255); // fond blanc, plus parlant que noir dans le diff
+    PNG.bitblt(src, out, 0, 0, src.width, src.height, 0, 0);
+    return out;
+  };
+  return [padded(a), padded(b), w, h];
+}
+
+function comparePngs(reactBuf, angularBuf) {
+  const a = PNG.sync.read(reactBuf);
+  const b = PNG.sync.read(angularBuf);
+  const [pa, pb, w, h] = padToSameSize(a, b);
+  const diff = new PNG({ width: w, height: h });
+  const diffPixels = pixelmatch(pa.data, pb.data, diff.data, w, h, {
+    threshold: PIXEL_THRESHOLD,
+  });
+  const total = w * h;
+  const ratio = total === 0 ? 0 : diffPixels / total;
+  return { reactPng: pa, angularPng: pb, diffPng: diff, diffPixels, total, ratio };
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function generateReport({ pairs, onlyReact, onlyAngular, results }) {
+  const failed = results.filter((r) => !r.passed);
+  const passed = results.filter((r) => r.passed);
+  const errored = results.filter((r) => r.error);
+
+  const rows = results
+    .slice()
+    .sort((a, b) => (b.ratio || 0) - (a.ratio || 0))
+    .map((r) => {
+      const id = r.react?.id || r.key;
+      const dir = `images/${id}`;
+      const status = r.error ? 'error' : r.passed ? 'pass' : 'fail';
+      const ratioPct = r.ratio !== undefined ? (r.ratio * 100).toFixed(3) + '%' : '-';
+      const imgs = r.error
+        ? `<td colspan="3" class="error-cell">${escapeHtml(r.error)}</td>`
+        : `
+        <td><img loading="lazy" src="${dir}/react.png" alt="React" /></td>
+        <td><img loading="lazy" src="${dir}/angular.png" alt="Angular" /></td>
+        <td><img loading="lazy" src="${dir}/diff.png" alt="Diff" /></td>`;
+      return `
+      <tr class="row-${status}">
+        <td><span class="badge badge-${status}">${status.toUpperCase()}</span></td>
+        <td>${escapeHtml(r.title)}<br><small>${escapeHtml(r.name)}</small></td>
+        <td class="num">${ratioPct}</td>
+        ${imgs}
+      </tr>`;
+    })
+    .join('\n');
+
+  const onlyList = (arr, framework) =>
+    arr.length === 0
+      ? `<p class="muted">Aucune story uniquement côté ${framework}.</p>`
+      : `<ul>${arr
+          .map((s) => `<li>${escapeHtml(s.title)} - ${escapeHtml(s.name)}</li>`)
+          .join('')}</ul>`;
+
+  return `<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Visual parity React ↔ Angular - Ori</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; color: #1a1a1a; background: #f7f7f7; }
+  header { background: #073ca5; color: #fff; padding: 1.5rem 2rem; }
+  h1 { margin: 0 0 0.25rem 0; font-size: 1.25rem; }
+  .summary { display: flex; gap: 2rem; margin-top: 1rem; flex-wrap: wrap; }
+  .summary div { background: rgba(255,255,255,0.12); padding: 0.5rem 1rem; border-radius: 6px; }
+  .summary strong { display: block; font-size: 1.5rem; }
+  main { padding: 1.5rem 2rem; max-width: 1600px; margin: 0 auto; }
+  table { width: 100%; border-collapse: collapse; background: #fff; }
+  th, td { padding: 0.5rem 0.75rem; text-align: left; vertical-align: top; border-bottom: 1px solid #e5e5e5; font-size: 0.875rem; }
+  th { background: #f0f0f0; position: sticky; top: 0; }
+  td.num { font-variant-numeric: tabular-nums; white-space: nowrap; }
+  td img { max-width: 100%; max-height: 220px; border: 1px solid #e0e0e0; }
+  .row-pass { background: #fafffa; }
+  .row-fail { background: #fff5f5; }
+  .row-error { background: #fffaf0; }
+  .badge { padding: 0.125rem 0.5rem; border-radius: 999px; font-size: 0.75rem; font-weight: 600; }
+  .badge-pass { background: #e0f8e0; color: #1a7f1a; }
+  .badge-fail { background: #fde0e0; color: #b40000; }
+  .badge-error { background: #fde6c0; color: #8a4a00; }
+  .error-cell { color: #8a4a00; font-family: ui-monospace, monospace; font-size: 0.8125rem; }
+  details { margin-top: 1.5rem; background: #fff; padding: 0.75rem 1rem; border-radius: 6px; }
+  summary { cursor: pointer; font-weight: 600; }
+  .muted { color: #666; }
+  .config { background: #fff; padding: 0.75rem 1rem; border-radius: 6px; font-size: 0.8125rem; color: #444; }
+  .config code { background: #f0f0f0; padding: 0.0625rem 0.25rem; border-radius: 3px; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Visual parity Storybook React ↔ Angular - Ori</h1>
+  <div class="summary">
+    <div><strong>${pairs.length}</strong> paires comparées</div>
+    <div><strong>${passed.length}</strong> en parité</div>
+    <div><strong>${failed.length}</strong> divergences</div>
+    <div><strong>${errored.length}</strong> erreurs</div>
+  </div>
+</header>
+<main>
+  <p class="config">
+    Threshold global : <code>${(THRESHOLD * 100).toFixed(2)}%</code> de pixels divergents par story.
+    Sensibilité pixel : <code>${PIXEL_THRESHOLD}</code>. Viewport : <code>${VIEWPORT_WIDTH}×${VIEWPORT_HEIGHT}</code>.
+    Tags exclus : <code>${SKIP_TAGS.join(', ')}</code>.
+  </p>
+  <table>
+    <thead>
+      <tr><th>Statut</th><th>Story</th><th>Diff</th><th>React</th><th>Angular</th><th>Diff visuel</th></tr>
+    </thead>
+    <tbody>${rows}</tbody>
+  </table>
+
+  <details>
+    <summary>Stories uniquement côté React (${onlyReact.length})</summary>
+    ${onlyList(onlyReact, 'React')}
+  </details>
+  <details>
+    <summary>Stories uniquement côté Angular (${onlyAngular.length})</summary>
+    ${onlyList(onlyAngular, 'Angular')}
+  </details>
+</main>
+</body>
+</html>`;
+}
+
+async function main() {
+  log('Threshold', THRESHOLD, '· pixel threshold', PIXEL_THRESHOLD);
+  log('React URL', REACT_URL);
+  log('Angular URL', ANGULAR_URL);
+
+  mkdirSync(OUT, { recursive: true });
+  mkdirSync(IMG_DIR, { recursive: true });
+
+  log('Récupération des index.json…');
+  const [reactIndex, angularIndex] = await Promise.all([
+    fetchIndex(REACT_URL),
+    fetchIndex(ANGULAR_URL),
+  ]);
+
+  const { pairs, onlyReact, onlyAngular } = commonStories(reactIndex, angularIndex);
+  log(`${pairs.length} paires de stories communes (skip ${SKIP_TAGS.join(', ')}).`);
+  log(`Uniquement React : ${onlyReact.length} · uniquement Angular : ${onlyAngular.length}`);
+
+  if (pairs.length === 0) {
+    err('Aucune paire de stories à comparer. Vérifier les Storybooks et les SKIP_TAGS.');
+    process.exit(1);
+  }
+
+  const browser = await chromium.launch();
+  const reactCtx = await browser.newContext({
+    viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
+    deviceScaleFactor: 1,
+  });
+  const angularCtx = await browser.newContext({
+    viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
+    deviceScaleFactor: 1,
+  });
+  const reactPage = await reactCtx.newPage();
+  const angularPage = await angularCtx.newPage();
+
+  const results = [];
+  let i = 0;
+  for (const pair of pairs) {
+    i += 1;
+    process.stdout.write(`\r[${i}/${pairs.length}] ${pair.key.padEnd(60).slice(0, 60)}`);
+    try {
+      const [reactBuf, angularBuf] = await Promise.all([
+        captureStory(reactPage, REACT_URL, pair.react.id),
+        captureStory(angularPage, ANGULAR_URL, pair.angular.id),
+      ]);
+      const cmp = comparePngs(reactBuf, angularBuf);
+
+      const dir = path.join(IMG_DIR, pair.react.id);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, 'react.png'), PNG.sync.write(cmp.reactPng));
+      writeFileSync(path.join(dir, 'angular.png'), PNG.sync.write(cmp.angularPng));
+      writeFileSync(path.join(dir, 'diff.png'), PNG.sync.write(cmp.diffPng));
+
+      const passed = cmp.ratio <= THRESHOLD;
+      results.push({
+        key: pair.key,
+        title: pair.title,
+        name: pair.name,
+        react: pair.react,
+        angular: pair.angular,
+        passed,
+        diffPixels: cmp.diffPixels,
+        total: cmp.total,
+        ratio: cmp.ratio,
+      });
+    } catch (e) {
+      results.push({
+        key: pair.key,
+        title: pair.title,
+        name: pair.name,
+        react: pair.react,
+        angular: pair.angular,
+        passed: false,
+        error: e.message,
+      });
+    }
+  }
+  process.stdout.write('\n');
+
+  await browser.close();
+
+  // Persistance des résultats.
+  const failed = results.filter((r) => !r.passed && !r.error);
+  const errored = results.filter((r) => r.error);
+  const summary = {
+    threshold: THRESHOLD,
+    pixelThreshold: PIXEL_THRESHOLD,
+    viewport: { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT },
+    pairs: pairs.length,
+    passed: results.filter((r) => r.passed).length,
+    failed: failed.length,
+    errored: errored.length,
+    onlyReact: onlyReact.length,
+    onlyAngular: onlyAngular.length,
+    results: results.map((r) => ({
+      key: r.key,
+      title: r.title,
+      name: r.name,
+      reactId: r.react?.id,
+      angularId: r.angular?.id,
+      passed: r.passed,
+      ratio: r.ratio,
+      diffPixels: r.diffPixels,
+      total: r.total,
+      error: r.error || null,
+    })),
+  };
+  writeFileSync(path.join(OUT, 'results.json'), JSON.stringify(summary, null, 2));
+  writeFileSync(
+    path.join(OUT, 'report.html'),
+    generateReport({ pairs, onlyReact, onlyAngular, results }),
+  );
+
+  log(`Résumé : ${summary.passed} pass · ${summary.failed} fail · ${summary.errored} error`);
+  log(`Rapport HTML : ${path.relative(REPO_ROOT, path.join(OUT, 'report.html'))}`);
+
+  if (failed.length > 0 || errored.length > 0) {
+    err(
+      `${failed.length} story(s) divergent et ${errored.length} en erreur. ` +
+        'Voir output/report.html pour le détail.',
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  err(e);
+  process.exit(1);
+});

--- a/tools/visual-parity/package.json
+++ b/tools/visual-parity/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@govpf/ori-tools-visual-parity",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Outil interne de test de parité visuelle entre les Storybook React et Angular d'Ori",
+  "type": "module",
+  "scripts": {
+    "compare": "node compare.mjs"
+  },
+  "dependencies": {
+    "http-server": "^14.1.1",
+    "pixelmatch": "^7.1.0",
+    "playwright": "^1.59.1",
+    "pngjs": "^7.0.0",
+    "wait-on": "^9.0.1"
+  }
+}


### PR DESCRIPTION
## Contexte

La cohérence visuelle entre les composants React et Angular reposait jusqu'ici uniquement sur la **discipline de revue manuelle**. On a vu cette discipline échouer plusieurs fois sur la vague 1 (SearchBar et PhoneInput rendaient différemment, drift découvert post-déploiement seulement).

Cette PR ajoute un test de parité visuelle automatisable. Pour chaque story qui existe dans les deux Storybooks, on capture `#storybook-root` côté React et côté Angular et on compare pixel-à-pixel via `pixelmatch`. Si la divergence dépasse un seuil (1 % par défaut), le job remonte un fail avec un rapport HTML détaillé en artifact.

## Phase d'observation - non bloquant

Le job est en place mais **ne tourne que sur demande explicite** :

- bouton **`Run workflow`** dans l'UI GitHub Actions
- CLI : `gh workflow run visual-parity.yml --ref ma-branche`
- label **`visual-test`** posé sur une PR

Tant qu'il ne fait pas partie des checks requis dans la branch protection, son échec ne bloque jamais un merge. La promotion vers `automatique non bloquant` puis `automatique bloquant` est documentée dans la roadmap.

## Architecture

- **`tools/visual-parity/compare.mjs`** : script principal (Playwright + pixelmatch + pngjs). Lit les `index.json` des deux Storybooks, apparie les stories par `(title, name)`, capture les deux côtés, écrit `react.png` / `angular.png` / `diff.png` dans un dossier par story, génère un `report.html` navigable et un `results.json` pour l'usage CI.
- **`tools/visual-parity/package.json`** : workspace pnpm interne (non publié). Embarque `playwright`, `pixelmatch`, `pngjs`, `http-server`, `wait-on`. Ajout de `tools/*` à `pnpm-workspace.yaml`.
- **`.github/workflows/visual-parity.yml`** : workflow on-demand. Build packages + 2 Storybooks, lance http-server en background, run `compare.mjs`, upload l'output en artifact (rétention 14 jours), commente la PR avec le top 10 des divergences.

## Documentation

- **`packages/docs/src/Validation-Parite-Visuelle.mdx`** : nouvelle fiche `Fondations / Validation parité visuelle` du Storybook. Explique pourquoi, comment, statut courant, roadmap, config, limites assumées.
- **`CONTRIBUTING.md`** : section dédiée dans le chapitre `Tests` du process de contribution.
- **`tools/visual-parity/README.md`** : doc technique d'usage local.
- **`apps/ori-site/public/llms.txt`** : référence le nouveau MDX et la fonctionnalité dans le positionnement du DS.

## Test plan

- [ ] CI standard verte (build, format, A11y, tests)
- [ ] Vérifier que le job `Visual parity React ↔ Angular` n'apparaît **pas** dans les checks PR par défaut.
- [ ] Poser le label `visual-test` sur cette PR pour déclencher le job (ou attendre que la PR soit mergée puis lancer manuellement via `gh workflow run`).
- [ ] Vérifier l'artifact `visual-parity-report` : `report.html` ouvrable hors serveur, listant les paires de stories avec leur statut et le triptyque React | Angular | Diff.
- [ ] Vérifier que le commentaire automatique sur la PR liste le top 10 des divergences.

## Pas de changeset

Aucun package publishable n'est touché. C'est un outil interne de CI uniquement.