### PR TITLE
fix(ci): visual-parity invoque http-server et wait-on via les bin locaux

### DIFF
--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -57,11 +57,16 @@ jobs:
 
       - name: Run visual parity test
         run: |
-          npx http-server apps/storybook-react/storybook-static -p 6006 -s -c-1 &
+          # http-server et wait-on sont déclarés en dépendances du package
+          # interne @govpf/ori-tools-visual-parity. On invoque les binaires
+          # via le `node_modules/.bin` local pour ne pas dépendre du
+          # PATH global du runner ni du cache `npx` qui reste flaky en CI.
+          BIN=tools/visual-parity/node_modules/.bin
+          "$BIN/http-server" apps/storybook-react/storybook-static -p 6006 -s -c-1 &
           REACT_PID=$!
-          npx http-server apps/storybook-angular/storybook-static -p 6008 -s -c-1 &
+          "$BIN/http-server" apps/storybook-angular/storybook-static -p 6008 -s -c-1 &
           ANGULAR_PID=$!
-          npx wait-on tcp:6006 tcp:6008 --timeout 60000
+          "$BIN/wait-on" tcp:6006 tcp:6008 --timeout 60000
           set +e
           node tools/visual-parity/compare.mjs
           STATUS=$?


### PR DESCRIPTION
## Bug

Premier essai du workflow `Visual parity React ↔ Angular` lancé sur main : échec avec `sh: 1: http-server: not found` puis `Timed out waiting for: tcp:6006, tcp:6008`.

## Cause

Le workflow utilisait `npx http-server` et `npx wait-on` directement à la racine du repo. Sur le runner GitHub Actions :

- ces binaires ne sont pas dans le PATH global ;
- le cache npx ne les a pas pré-installés ;
- `npx` tente de les télécharger via le registre, ce qui échoue silencieusement (le `&` background masque l'erreur) ou prend assez de temps pour faire timeout `wait-on` à 60 s.

## Fix

`http-server` et `wait-on` sont déjà déclarés en dépendances directes du package interne `@govpf/ori-tools-visual-parity`. On les invoque via leur path explicite dans `tools/visual-parity/node_modules/.bin/`.

```bash
BIN=tools/visual-parity/node_modules/.bin
"$BIN/http-server" apps/storybook-react/storybook-static -p 6006 -s -c-1 &
"$BIN/http-server" apps/storybook-angular/storybook-static -p 6008 -s -c-1 &
"$BIN/wait-on" tcp:6006 tcp:6008 --timeout 60000
```

Plus de dépendance au PATH ni au cache npx. Pas de changeset, c'est un fix de workflow CI.

## Test plan

- [ ] CI standard verte (la build du workflow lui-même n'est pas testé par cette PR ; il sera relancé manuellement après merge)
- [ ] Lancer `gh workflow run visual-parity.yml --ref main` après merge pour vérifier que ça progresse au-delà de l'étape `wait-on`.