### PR TITLE
fix(visual-parity): calibrer le pixel threshold et skip toc/empty

### DIFF
--- a/packages/angular/docs/toc/toc.stories.ts
+++ b/packages/angular/docs/toc/toc.stories.ts
@@ -45,4 +45,9 @@ export const NoSubLevels: Story = {
 
 export const Empty: Story = {
   args: { headings: [] },
+  // Tag `skip-visual` : la story ne rend rien (pas de heading), donc le
+  // `#storybook-root` reste hidden et le test de parité visuelle plante
+  // sur le timeout du `waitForSelector`. Pas pertinent à comparer puisque
+  // par construction il n'y a rien à voir.
+  tags: ['skip-visual'],
 };

--- a/packages/docs/src/Validation-Parite-Visuelle.mdx
+++ b/packages/docs/src/Validation-Parite-Visuelle.mdx
@@ -72,7 +72,7 @@ Le test est paramétrable par variables d'environnement :
 | Variable | Défaut | Effet |
 |---|---|---|
 | `THRESHOLD` | `0.01` | Tolérance globale (1 % de pixels divergents par story). |
-| `PIXEL_THRESHOLD` | `0.1` | Sensibilité de pixelmatch par pixel (`0` = strict, `1` = permissif). |
+| `PIXEL_THRESHOLD` | `0.2` | Sensibilité de pixelmatch par pixel (`0` = strict, `1` = permissif). `0.2` absorbe le bruit de sub-pixel font rendering différent entre React et Angular. |
 | `VIEWPORT_WIDTH` / `VIEWPORT_HEIGHT` | `1280` / `800` | Taille du viewport pour la capture. |
 | `SETTLE_MS` | `500` | Attente après render avant la capture (laisse les animations se poser). |
 | `SKIP_TAGS` | `skip-visual,docs-only,test-only` | Tags Storybook exclus du test. |

--- a/packages/react/src/docs/Toc/Toc.stories.tsx
+++ b/packages/react/src/docs/Toc/Toc.stories.tsx
@@ -54,4 +54,9 @@ export const NoSubLevels: Story = {
 
 export const Empty: Story = {
   args: { headings: [] },
+  // Tag `skip-visual` : la story ne rend rien (pas de heading), donc le
+  // `#storybook-root` reste hidden et le test de parité visuelle plante
+  // sur le timeout du `waitForSelector`. Pas pertinent à comparer puisque
+  // par construction il n'y a rien à voir.
+  tags: ['skip-visual'],
 };

--- a/tools/visual-parity/README.md
+++ b/tools/visual-parity/README.md
@@ -34,16 +34,16 @@ Sortie dans `tools/visual-parity/output/` :
 
 ## Variables d'env
 
-| Var               | Default                           | Effet                                                           |
-| ----------------- | --------------------------------- | --------------------------------------------------------------- |
-| `REACT_URL`       | `http://localhost:6006`           | URL du Storybook React                                          |
-| `ANGULAR_URL`     | `http://localhost:6008`           | URL du Storybook Angular                                        |
-| `THRESHOLD`       | `0.01`                            | Tolérance globale (1 % de pixels divergents par story)          |
-| `PIXEL_THRESHOLD` | `0.1`                             | Sensibilité de pixelmatch par pixel (0 = strict, 1 = permissif) |
-| `VIEWPORT_WIDTH`  | `1280`                            | Largeur du viewport                                             |
-| `VIEWPORT_HEIGHT` | `800`                             | Hauteur du viewport                                             |
-| `SETTLE_MS`       | `500`                             | Attente après render avant capture                              |
-| `SKIP_TAGS`       | `skip-visual,docs-only,test-only` | Tags Storybook à exclure                                        |
+| Var               | Default                           | Effet                                                                                                                                               |
+| ----------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REACT_URL`       | `http://localhost:6006`           | URL du Storybook React                                                                                                                              |
+| `ANGULAR_URL`     | `http://localhost:6008`           | URL du Storybook Angular                                                                                                                            |
+| `THRESHOLD`       | `0.01`                            | Tolérance globale (1 % de pixels divergents par story)                                                                                              |
+| `PIXEL_THRESHOLD` | `0.2`                             | Sensibilité de pixelmatch par pixel (0 = strict, 1 = permissif). 0.2 absorbe le bruit de sub-pixel font rendering différent entre React et Angular. |
+| `VIEWPORT_WIDTH`  | `1280`                            | Largeur du viewport                                                                                                                                 |
+| `VIEWPORT_HEIGHT` | `800`                             | Hauteur du viewport                                                                                                                                 |
+| `SETTLE_MS`       | `500`                             | Attente après render avant capture                                                                                                                  |
+| `SKIP_TAGS`       | `skip-visual,docs-only,test-only` | Tags Storybook à exclure                                                                                                                            |
 
 ## Comment exclure une story
 

--- a/tools/visual-parity/compare.mjs
+++ b/tools/visual-parity/compare.mjs
@@ -42,7 +42,12 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const REACT_URL = process.env.REACT_URL || 'http://localhost:6006';
 const ANGULAR_URL = process.env.ANGULAR_URL || 'http://localhost:6008';
 const THRESHOLD = Number(process.env.THRESHOLD || '0.01');
-const PIXEL_THRESHOLD = Number(process.env.PIXEL_THRESHOLD || '0.1');
+// Calibration post run #2 (2026-05-01) : avec 0.1, beaucoup de stories
+// dont le rendu est visuellement identique entre React et Angular
+// remontaient comme divergentes à ~10 % à cause du sub-pixel font
+// rendering différent entre les deux. 0.2 absorbe ce bruit sans masquer
+// les vrais drifts (ex: layouts cassés, classes manquantes).
+const PIXEL_THRESHOLD = Number(process.env.PIXEL_THRESHOLD || '0.2');
 const VIEWPORT_WIDTH = Number(process.env.VIEWPORT_WIDTH || '1280');
 const VIEWPORT_HEIGHT = Number(process.env.VIEWPORT_HEIGHT || '800');
 const SETTLE_MS = Number(process.env.SETTLE_MS || '500');


### PR DESCRIPTION
## Contexte

Premier run de calibration du test de parité visuelle sur `main` ([run 25214842761](https://github.com/govpf/ori/actions/runs/25214842761)) :

- **232 paires testées** · **172 pass** · **59 fail** · **1 error**.

Après inspection des diffs, deux problèmes structurels identifiés.

## Fix 1 - PIXEL_THRESHOLD : 0.1 → 0.2

Beaucoup de stories visuellement **identiques** entre React et Angular remontaient comme divergentes à 5-10 % à cause du **sub-pixel font rendering différent** entre les deux navigateurs (le moteur de rendering Angular et React produit des micro-différences sur l'antialiasing).

Exemple : `Primitives/Affichage/Tag/Variants` ressort à 10.7 % alors que les deux rendus sont visuellement indistinguables.

`PIXEL_THRESHOLD` passe de `0.1` à `0.2` par défaut. Ça absorbe le bruit antialiasing sans masquer les vrais drifts (layouts cassés, classes manquantes, contenu différent).

## Fix 2 - Skip-visual sur Toc/Empty

`Patterns/Documentation/Toc / Empty` est volontairement vide (`headings: []`). Du coup, le `#storybook-root` reste hidden et le `waitForSelector` du test plante après 15 s. La story n'a rien à comparer puisqu'elle est vide par construction.

Tag `skip-visual` ajouté côté React et Angular avec un commentaire.

## Doc mise à jour

- `tools/visual-parity/README.md` : nouveau défaut documenté.
- `packages/docs/src/Validation-Parite-Visuelle.mdx` : idem.

## Test plan

- [ ] CI standard verte
- [ ] Après merge, relancer `gh workflow run visual-parity.yml --ref main`
- [ ] Vérifier que :
  - le ratio fail/pass baisse significativement (cible : sous 30 fails)
  - l'erreur sur Toc/Empty disparaît
  - les vrais drifts (Header, MainNavigation In Header, Switch/Checkbox Groupe) restent flaggés

Si la cible 30 fails est atteinte, on peut passer à la PR 2 (audit des stories pédagogiques framework-specific).