### PR TITLE
docs(counts): synchroniser les compteurs composants, stories et tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,9 +257,9 @@ incompatibilités ESM / TypeScript de l'écosystème Angular 20 + pnpm.
 Karma reste fonctionnel mais en EOL annoncé.
 
 La couverture des composants Angular repose pour l'instant sur les
-tests a11y axe-core (193 stories) et sur le fait que la logique est
-miroir de la version React (71 tests Vitest). À ré-évaluer à chaque
-release Angular ou Vitest majeure.
+tests a11y axe-core (snapshot 2026-05-01 : 255 stories Angular) et sur
+le fait que la logique est miroir de la version React (198 tests
+Vitest). À ré-évaluer à chaque release Angular ou Vitest majeure.
 
 #### Tests de parité visuelle React ↔ Angular (à la demande)
 

--- a/apps/ori-site/public/llms.txt
+++ b/apps/ori-site/public/llms.txt
@@ -19,7 +19,7 @@ Tous publiés sous le scope `@govpf/`.
 
 - [@govpf/ori-react](https://www.npmjs.com/package/@govpf/ori-react) : composants React / Next.js
 - [@govpf/ori-angular](https://www.npmjs.com/package/@govpf/ori-angular) : composants Angular standalone (≥ 20)
-- [@govpf/ori-tailwind-preset](https://www.npmjs.com/package/@govpf/ori-tailwind-preset) : preset Tailwind + classes sémantiques `.ori-*`
+- [@govpf/ori-tailwind-preset](https://www.npmjs.com/package/@govpf/ori-tailwind-preset) : preset Tailwind + classes sémantiques `.ori-*` (convention de nommage : voir section Conventions)
 - [@govpf/ori-css](https://www.npmjs.com/package/@govpf/ori-css) : bundle CSS drop-in (intégrations GLPI, emails)
 - [@govpf/ori-tokens](https://www.npmjs.com/package/@govpf/ori-tokens) : design tokens W3C DTCG (CSS variables, JS, SCSS)
 
@@ -30,27 +30,33 @@ Pour explorer le design system programmatiquement sans exécuter le JavaScript d
 - [https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json) : index complet des entrées React (format Storybook v5, ~100 ko, JSON). Contient pour chaque entrée : `id`, `title`, `name`, `importPath`, `tags`, `type`.
 - [https://ori.gov.pf/storybook/angular/index.json](https://ori.gov.pf/storybook/angular/index.json) : équivalent Angular.
 
-L'index contient deux types d'entrées (champ `type`) à filtrer selon l'usage : `type === "story"` pour les stories interactives (~200 entrées), `type === "docs"` pour les fiches autodocs et MDX rattachés (~200 entrées). Pour explorer les composants disponibles, filtrer sur `type === "story"`. Pour lire la documentation rédigée, filtrer sur `type === "docs"`.
-- [https://github.com/govpf/ori](https://github.com/govpf/ori) : code source (sources React/Angular dans `packages/`, MDX docs dans `packages/docs/src/`)
-- [Roadmap publique](https://github.com/orgs/govpf/projects/3) : board GitHub Projects (Backlog, Up next, In progress, Done)
+L'index contient deux types d'entrées (champ `type`) à filtrer selon l'usage : `type === "story"` pour les stories interactives, `type === "docs"` pour les fiches autodocs et MDX rattachés. Pour explorer les composants disponibles, filtrer sur `type === "story"`. Pour lire la documentation rédigée, filtrer sur `type === "docs"`.
 
 Pour récupérer le contenu d'une story spécifique (HTML rendu) : `https://ori.gov.pf/storybook/react/iframe.html?id={story-id}` ou la fiche docs `https://ori.gov.pf/storybook/react/?path=/docs/{story-id}`.
 
+Sources annexes : [code source GitHub](https://github.com/govpf/ori) (sources React/Angular dans `packages/`, MDX dans `packages/docs/src/`) et [roadmap publique](https://github.com/orgs/govpf/projects/3) (Backlog, Up next, In progress, Done).
+
 ## Composants livrés
 
-Inventaire snapshot avril 2026, classés en 3 niveaux (cf. [décision B.0](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux)). L'inventaire à jour vit dans le repo et l'index Storybook ([https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json)).
+**54 composants au total** (à ne pas confondre avec les 54 services administratifs PF mentionnés en intro - simple coïncidence numérique). Inventaire snapshot avril 2026, classés en 3 niveaux selon la [décision B.0](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx#b0--classification-des-composants-en-3-niveaux) :
 
-### Primitives (≈ 39)
+- **Primitives** : 39 composants
+- **Compositions** : 12 composants
+- **Templates** : 3 composants
+
+L'inventaire à jour vit dans le repo et l'index Storybook ([https://ori.gov.pf/storybook/react/index.json](https://ori.gov.pf/storybook/react/index.json)).
+
+### Primitives (39)
 
 Briques atomiques, API agnostique du domaine, présentes dans tous les DS de référence.
 
-Inputs : Button, Input, Textarea, Select, Combobox, MultiSelect, Checkbox, Radio, RichRadio, Switch, DatePicker, PhoneInput, SearchBar
-Feedback : Dialog, AlertDialog, Tooltip, Toast, Notification, Alert, Spinner, Progress, Skeleton
-Navigation : DropdownMenu, Tabs, Accordion, Breadcrumb, Pagination, Steps, Link
-Actions : DownloadButton
-Data : Table, Tag, Avatar, Highlight, Statistic, Timeline, LanguageSwitcher, Logo
+- Actions : Button, Link, LanguageSwitcher, DownloadButton (4)
+- Saisie : Input, Textarea, Select, Combobox, MultiSelect, Checkbox, Radio, RichRadio, Switch, DatePicker, PhoneInput, SearchBar (12)
+- Feedback : Alert, AlertDialog, Dialog, Notification, Toast, Tooltip, Spinner, Progress, Skeleton (9)
+- Navigation : Breadcrumb, Tabs, Steps, Pagination, DropdownMenu, Accordion (6)
+- Affichage : Card, Tag, Avatar, Logo, Highlight, Statistic, Table, Timeline (8)
 
-### Compositions (≈ 11)
+### Compositions (12)
 
 Assemblages de primitives, paramétrables mais génériques.
 
@@ -77,7 +83,7 @@ Documentées en MDX dans le repo, source de vérité publique :
 - [packages/docs/src/Decisions-A-Prendre.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Decisions-A-Prendre.mdx) : décisions architecturales tranchées
 - [packages/docs/src/Validation-Accessibilite.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Accessibilite.mdx) : méthode et couverture a11y
 - [packages/docs/src/Validation-Parite-Visuelle.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Validation-Parite-Visuelle.mdx) : test de parité visuelle React ↔ Angular (à la demande, non bloquant en phase d'observation)
-- [packages/docs/src/Convention-Nommage.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Convention-Nommage.mdx) : convention React PascalCase ↔ CSS kebab-case + tableau de correspondance des 53 composants → classes CSS
+- [packages/docs/src/Convention-Nommage.mdx](https://github.com/govpf/ori/blob/main/packages/docs/src/Convention-Nommage.mdx) : convention React PascalCase ↔ CSS kebab-case + tableau de correspondance des 54 composants → classes CSS
 
 ## Conventions
 

--- a/packages/docs/src/Convention-Nommage.mdx
+++ b/packages/docs/src/Convention-Nommage.mdx
@@ -63,7 +63,7 @@ Toutes les variantes ont été renommées en bloc :
 
 ## Tableau de correspondance complet
 
-Les 53 composants Ori et leurs classes CSS principales.
+Les 54 composants Ori et leurs classes CSS principales (Primitives 39 + Compositions 12 + Templates 3).
 
 ### Primitives - Actions
 

--- a/packages/docs/src/Decisions-A-Prendre.mdx
+++ b/packages/docs/src/Decisions-A-Prendre.mdx
@@ -306,17 +306,20 @@ Cette grille évite trois ambiguïtés récurrentes :
 | **Composition** | Assemble plusieurs primitives, paramétrable mais générique                          | Décrit un pattern UI standard (table paginée, formulaire en étapes), pas un domaine  |
 | **Template**    | Orienté un cas d'usage spécifique (souvent administratif ou régalien)               | Le nom porte un domaine ("error page", "legal layout", "audit log") ; pas dans Radix |
 
-**Ori actuel par niveau** (snapshot 2026-04-28) :
+**Ori actuel par niveau** (snapshot 2026-05-01, 54 composants au total) :
 
-- **Primitives** (≈ 30) : `Button`, `Input`, `Select`, `Textarea`, `Checkbox`,
-  `Radio`, `Switch`, `Dialog`, `Tooltip`, `Toast`, `Tabs`, `Accordion`,
-  `Card`, `Tag`, `Avatar`, `Skeleton`, `Spinner`, `Progress`, `Pagination`,
-  `Breadcrumb`, `Link`, `Logo`, `Highlight`, `Steps`, `Statistic`,
-  `Notification`, `Alert`, `Timeline`, `DatePicker`, `Table`,
-  `LanguageSwitcher`.
-- **Compositions** (≈ 5) : `Header`, `Footer`, `MainNavigation`, `SideMenu`,
-  `FileUpload`, `FileCard`.
-- **Templates** (≈ 3) : `ErrorPage`, `LegalLayout`, `AuthButton`.
+- **Primitives** (39) : `Button`, `Link`, `LanguageSwitcher`, `DownloadButton` (Actions) ;
+  `Input`, `Textarea`, `Select`, `Combobox`, `MultiSelect`, `Checkbox`, `Radio`, `RichRadio`,
+  `Switch`, `DatePicker`, `PhoneInput`, `SearchBar` (Saisie) ;
+  `Alert`, `AlertDialog`, `Dialog`, `Notification`, `Toast`, `Tooltip`, `Spinner`,
+  `Progress`, `Skeleton` (Feedback) ;
+  `Breadcrumb`, `Tabs`, `Steps`, `Pagination`, `DropdownMenu`, `Accordion` (Navigation) ;
+  `Card`, `Tag`, `Avatar`, `Logo`, `Highlight`, `Statistic`, `Table`, `Timeline` (Affichage).
+- **Compositions** (12) : `AppShell`, `Form`, `LoginLayout`, `Wizard`, `Header`, `Footer`,
+  `MainNavigation`, `SideMenu`, `FileUpload`, `FileCard`, `DataTable`, `EmptyState`.
+- **Templates** (3) : `ErrorPage`, `LegalLayout`, `AuthButton`.
+
+L'inventaire à jour vit dans le repo (`packages/react/src/components/`) et l'index Storybook (`https://ori.gov.pf/storybook/react/index.json`).
 
 **Roadmap par niveau** (items taggés sur le board) :
 
@@ -540,7 +543,7 @@ peut être ajouté sans changer la chaîne principale.
 
 - **CI** sur chaque PR : Format Prettier, Build packages, Build des 4
   apps (storybook React, storybook Angular, demo-portail, ori-site),
-  A11y axe-core sur les 406 stories (React + Angular), Security audit
+  A11y axe-core sur l'ensemble des stories (React + Angular), Security audit
   global, Security audit ciblé sur les packages publiés (tolérance
   zéro).
 - **Release** sur push main : pattern Changesets bot officiel. Ouvre /
@@ -569,10 +572,10 @@ pnpm workspace, ou retour à un setup Karma maintenu
 Angular du DS, en miroir du setup Vitest+@testing-library/react côté
 React (cf. PR #37) ?
 
-**État au 2026-04-28** : aucun runner branché côté `packages/angular`.
+**État au 2026-05-01** : aucun runner branché côté `packages/angular`.
 Les composants Angular sont couverts par les tests a11y axe-core
-(193 stories) et la galerie visuelle Storybook, mais pas par une
-couche de tests unitaires.
+(255 stories au dernier snapshot) et la galerie visuelle Storybook,
+mais pas par une couche de tests unitaires.
 
 **Options évaluées** :
 
@@ -602,8 +605,8 @@ l'option 3 est de la dette anticipée.
   Angular restent en place et constituent la couche de défense
   principale contre les régressions visibles côté DOM.
 - La logique métier des composants Angular est miroir de la version
-  React, dont la couverture unitaire en Vitest (71 tests sur 5
-  composants) sert de référence comportementale documentée. Une
+  React, dont la couverture unitaire en Vitest (198 tests, snapshot
+  2026-05-01) sert de référence comportementale documentée. Une
   divergence cross-framework remonterait en revue de PR (cf. mémoire
   feedback "sync cross-framework").
 - À chaque release Angular ou Vitest majeure, ré-évaluer si l'un des

--- a/packages/docs/src/Validation-Accessibilite.mdx
+++ b/packages/docs/src/Validation-Accessibilite.mdx
@@ -23,7 +23,7 @@ vérifiée, et les limites assumées de la garantie automatisée.
     fontWeight: 600,
   }}
 >
-  ✓ 406 / 406 stories validées WCAG 2.0 AA, 0 violation
+  ✓ 536 / 536 stories validées WCAG 2.0 AA, 0 violation
 </div>
 
 Dernière mesure obtenue par le job CI **A11y Storybook React** et
@@ -78,11 +78,11 @@ story par variante visuelle**, et chaque story est testée. Voir
 l'arbre Storybook par section "Composants" (Actions, Saisie,
 Affichage, Feedback, Navigation, Données, Mise en page).
 
-**Métriques courantes** :
+**Métriques courantes** (snapshot 2026-05-01, le compte exact vit dans [`index.json`](https://ori.gov.pf/storybook/react/index.json)) :
 
-- 213 stories React testées
-- 193 stories Angular testées
-- Total : **406 stories**, 0 violation `serious` ou `critical`
+- 281 stories React testées
+- 255 stories Angular testées
+- Total : **536 stories**, 0 violation `serious` ou `critical`
 
 ## Limites assumées de la couverture automatique
 


### PR DESCRIPTION
## Contexte

Retour qualité : plusieurs documents donnaient des chiffres divergents et obsolètes.

| Document | Avant | Réel actuel |
|---|---|---|
| `llms.txt` | Compositions ≈ 11 | 12 |
| `llms.txt` | Convention-Nommage : 53 composants | 54 |
| `llms.txt` | Coïncidence non explicite avec « 54 services administratifs » | Mention ajoutée |
| `Convention-Nommage.mdx` | « 53 composants » | 54 |
| `Decisions-A-Prendre.mdx` | Snapshot 2026-04-28, Primitives ≈ 30, Compositions ≈ 5 | 2026-05-01, 39, 12 |
| `Decisions-A-Prendre.mdx` | « 406 stories » | « ensemble des stories » (`index.json` source) |
| `Decisions-A-Prendre.mdx` | 193 stories Angular, 71 tests Vitest | 255, 198 |
| `Validation-Accessibilite.mdx` | Badge 406/406, 213 React, 193 Angular | 536/536, 281, 255 |
| `CONTRIBUTING.md` | 193 stories Angular, 71 tests Vitest | 255, 198 |

## Nouveau snapshot

Validé via :

- `ls packages/react/src/components/ \| wc -l` → 54
- `index.json` Storybook React + Angular en prod → 281 + 255 = 536 stories
- `pnpm --filter @govpf/ori-react test` → 198 tests passing

## Améliorations de fluidité du `llms.txt`

Sur ces ajustements de chiffres, j'en profite pour deux retouches structurelles remontées dans le même feedback :

1. **Pointeur ligne 22** : la mention `.ori-*` dans la liste des packages npm pointe désormais vers la section Conventions (qui décrit la convention de nommage). Évite à un lecteur LLM/humain de devoir attendre la ligne 80 pour comprendre comment se forment les classes.

2. **Section Endpoints machine-readable nettoyée** : le repo GitHub et la roadmap publique étaient mentionnés deux fois (en milieu et fin de section). Ils sont consolidés en un seul paragraphe en fin de section. La phrase qui mentionnait `~200 entrées` a été retirée parce que le compte exact vit dans `index.json`.

## Origine de la coquille

Le commit body de la PR #85 mentionnait erronnément « 53 composants ». Pas grave : la fiche `Convention-Nommage.mdx` publiée sur prod listait 54 entrées dans son tableau (les 54 sont bien dans le texte du tableau côté composants listés). C'est uniquement la phrase qui introduisait le tableau qui disait « 53 ». Corrigé ici.

## Pas de changeset

Modifs documentaires uniquement, aucun package publishable touché.