### PR TITLE
feat(deploy): exposer les 3 exemples via /exemples/ sur le portail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ name: Deploy to GitHub Pages
 #   /                       -> site Astro (apps/ori-site/)
 #   /storybook/react/       -> Storybook React (test interactif)
 #   /storybook/angular/     -> Storybook Angular (test interactif)
+#   /demo/                  -> demo-portail (parcours usager bout en bout)
+#   /exemples/landing/      -> example-landing (HTML pur + ori-css)
+#   /exemples/keycloak/     -> example-keycloak (mires d'authentification)
+#   /exemples/agent/        -> example-agent (back-office Angular)
 
 on:
   push:
@@ -62,15 +66,29 @@ jobs:
       - name: Build demo-portail
         run: pnpm --filter @govpf/ori-demo-portail build
 
+      - name: Build example-landing
+        run: pnpm --filter @govpf/ori-example-landing build
+
+      - name: Build example-keycloak
+        run: pnpm --filter @govpf/ori-example-keycloak build
+
+      - name: Build example-agent
+        run: pnpm --filter @govpf/ori-example-agent build
+
       - name: Compose dist composé
         run: |
           set -euo pipefail
           mkdir -p dist
           cp -r apps/ori-site/dist/. dist/
           mkdir -p dist/storybook/react dist/storybook/angular dist/demo
+          mkdir -p dist/exemples/landing dist/exemples/keycloak dist/exemples/agent
           cp -r apps/storybook-react/storybook-static/. dist/storybook/react/
           cp -r apps/storybook-angular/storybook-static/. dist/storybook/angular/
           cp -r apps/demo-portail/dist/. dist/demo/
+          cp -r apps/example-landing/dist/. dist/exemples/landing/
+          cp -r apps/example-keycloak/dist/. dist/exemples/keycloak/
+          # Angular CLI (application builder) produit dist/<projet>/browser/
+          cp -r apps/example-agent/dist/example-agent/browser/. dist/exemples/agent/
           # .nojekyll obligatoire pour servir _astro/, _next/, etc.
           touch dist/.nojekyll
           # CNAME pour le custom domain (Astro le copie déjà depuis public/
@@ -79,7 +97,7 @@ jobs:
           echo "=== dist content ==="
           ls -la dist
           echo "=== sizes ==="
-          du -sh dist dist/storybook/react dist/storybook/angular dist/demo dist/_astro 2>/dev/null || true
+          du -sh dist dist/storybook/react dist/storybook/angular dist/demo dist/exemples 2>/dev/null || true
 
       - uses: actions/configure-pages@v6
 

--- a/apps/example-agent/angular.json
+++ b/apps/example-agent/angular.json
@@ -24,13 +24,12 @@
           },
           "configurations": {
             "production": {
+              "baseHref": "/exemples/agent/",
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true
+              "extractLicenses": true
             },
             "development": {
               "optimization": false,

--- a/apps/example-agent/package.json
+++ b/apps/example-agent/package.json
@@ -6,7 +6,7 @@
   "description": "Exemple Angular : back-office agent administratif (instruction de dossiers). Démontre la consommation de @govpf/ori-angular en conditions réelles : AppShell, Table avec sélection multiple, DropdownMenu, AlertDialog, Notification, SearchBar, Statistic.",
   "scripts": {
     "dev": "ng serve --host 0.0.0.0 --port 5173",
-    "build": "ng build",
+    "build": "ng build --configuration production",
     "preview": "ng serve --host 0.0.0.0 --port 5173 --configuration production"
   },
   "dependencies": {

--- a/apps/example-keycloak/build.mjs
+++ b/apps/example-keycloak/build.mjs
@@ -1,0 +1,26 @@
+// Build statique : produit dist/ avec les 7 mires HTML + CSS + assets.
+// Lancé après copy-css.mjs (qui copie ds.css + crest officiel) via le
+// hook prebuild.
+
+import { copyFileSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(__dirname, 'dist');
+
+rmSync(distDir, { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+
+const exts = new Set(['.html', '.css', '.svg', '.png', '.jpg', '.webp', '.ttf']);
+let count = 0;
+for (const file of readdirSync(__dirname)) {
+  if (file === 'dist' || file === 'node_modules') continue;
+  const src = path.join(__dirname, file);
+  if (!statSync(src).isFile()) continue;
+  if (!exts.has(path.extname(file).toLowerCase())) continue;
+  copyFileSync(src, path.join(distDir, file));
+  count++;
+}
+
+console.log(`[build] ${count} fichier(s) copié(s) vers dist/`);

--- a/apps/example-keycloak/package.json
+++ b/apps/example-keycloak/package.json
@@ -8,7 +8,7 @@
     "predev": "pnpm copy-css",
     "dev": "npx http-server . -p 4174 -c-1",
     "prebuild": "pnpm copy-css",
-    "build": "echo 'page HTML statique - copy-css fait le job'"
+    "build": "node build.mjs"
   },
   "dependencies": {
     "@govpf/ori-css": "workspace:*"

--- a/apps/example-landing/build.mjs
+++ b/apps/example-landing/build.mjs
@@ -1,0 +1,26 @@
+// Build statique : produit dist/ avec HTML, CSS, SVG, PNG. Lancé après
+// copy-css.mjs (qui copie le ds.css depuis packages/css/dist) via le
+// hook prebuild.
+
+import { copyFileSync, mkdirSync, readdirSync, rmSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(__dirname, 'dist');
+
+rmSync(distDir, { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+
+const exts = new Set(['.html', '.css', '.svg', '.png', '.jpg', '.webp', '.ttf']);
+let count = 0;
+for (const file of readdirSync(__dirname)) {
+  if (file === 'dist' || file === 'node_modules') continue;
+  const src = path.join(__dirname, file);
+  if (!statSync(src).isFile()) continue;
+  if (!exts.has(path.extname(file).toLowerCase())) continue;
+  copyFileSync(src, path.join(distDir, file));
+  count++;
+}
+
+console.log(`[build] ${count} fichier(s) copié(s) vers dist/`);

--- a/apps/example-landing/package.json
+++ b/apps/example-landing/package.json
@@ -8,7 +8,7 @@
     "predev": "pnpm copy-css",
     "dev": "npx http-server . -p 4173 -c-1",
     "prebuild": "pnpm copy-css",
-    "build": "echo 'page HTML statique - copy-css fait le job'"
+    "build": "node build.mjs"
   },
   "dependencies": {
     "@govpf/ori-css": "workspace:*"

--- a/apps/ori-site/src/layouts/BaseLayout.astro
+++ b/apps/ori-site/src/layouts/BaseLayout.astro
@@ -46,7 +46,7 @@ const base = import.meta.env.BASE_URL;
                 <a class="ori-main-nav__link" href={`${base}fondations/palette/`} aria-current={current === 'tokens' ? 'page' : undefined}>Fondations</a>
               </li>
               <li class="ori-main-nav__item">
-                <a class="ori-main-nav__link" href={`${base}demo/`}>Démo</a>
+                <a class="ori-main-nav__link" href={`${base}exemples/`} aria-current={current === 'examples' ? 'page' : undefined}>Exemples</a>
               </li>
             </ul>
           </nav>

--- a/apps/ori-site/src/pages/exemples/index.astro
+++ b/apps/ori-site/src/pages/exemples/index.astro
@@ -1,0 +1,208 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const base = import.meta.env.BASE_URL;
+
+const examples = [
+  {
+    title: 'Portail usager (parcours bout en bout)',
+    description:
+      'Démo end-to-end du portail PF : authentification fédérée, page d accueil personnalisée, dépôt et suivi de démarches, espace messages. Pendant usager du back-office agent ci-dessous.',
+    href: `${base}demo/`,
+    badge: 'React + Vite',
+    badgeVariant: 'info',
+    surface: 'Tous les composants Ori React, ChatBot d aide intégré',
+  },
+  {
+    title: 'Landing institutionnelle',
+    description:
+      'Site institutionnel d un service administratif (Direction du Patrimoine) en HTML pur, consommant @govpf/ori-css en drop-in. Hero avec motif polynésien, sections trust strip, chiffres clés, actualités, missions. Inclut une page Mentions légales et une page Recrutement.',
+    href: `${base}exemples/landing/`,
+    badge: 'HTML statique',
+    badgeVariant: 'success',
+    surface: 'ori-card, ori-tag, ori-statistic, ori-link, ori-breadcrumb, ori-button',
+  },
+  {
+    title: 'Mires d authentification Keycloak',
+    description:
+      '7 mires HTML pur servant de référence visuelle pour les équipes qui développent un thème Keycloak (login, register, reset-password, update-password, OTP, session-expired, error). Identité Ori cohérente sur l ensemble du parcours d auth.',
+    href: `${base}exemples/keycloak/`,
+    badge: 'HTML statique',
+    badgeVariant: 'success',
+    surface: 'ori-card--elevated, ori-input, ori-button, ori-alert, ori-link',
+  },
+  {
+    title: 'Back-office agent (instruction de dossiers)',
+    description:
+      'Espace agent administratif construit en Angular 20 standalone, démontrant la consommation de @govpf/ori-angular en conditions réelles : sélection multiple, tri, cellTemplate, dropdown contextuel, dialog de confirmation, notifications, recherche et filtres. Pendant agent du portail usager.',
+    href: `${base}exemples/agent/`,
+    badge: 'Angular 20 standalone',
+    badgeVariant: 'warning',
+    surface:
+      'ori-app-shell, ori-table (sélection + tri + cellTemplate), ori-dropdown-menu, ori-alert-dialog, ori-notification, ori-search-bar, ori-statistic',
+  },
+];
+
+const tools = [
+  {
+    title: 'Storybook React',
+    description:
+      'Catalogue interactif de tous les composants @govpf/ori-react, avec variantes, contrôles et documentation autogénérée depuis les types TypeScript.',
+    href: `${base}storybook/react/`,
+  },
+  {
+    title: 'Storybook Angular',
+    description:
+      'Catalogue interactif de tous les composants @govpf/ori-angular, miroir parité du Storybook React.',
+    href: `${base}storybook/angular/`,
+  },
+];
+---
+
+<BaseLayout
+  title="Exemples et démos"
+  current="examples"
+  description="Démos exécutables d Ori : portail usager, landing institutionnelle, mires Keycloak, back-office agent Angular."
+  variant="landing"
+>
+  <section class="page-intro">
+    <div class="page-intro__inner">
+      <p class="page-intro__eyebrow">Exemples et démos</p>
+      <h1 class="page-intro__title">Voir Ori en action</h1>
+      <p class="page-intro__lead">
+        Quatre démos exécutables couvrant les principaux cas d usage des
+        services administratifs PF : portail usager, site institutionnel,
+        authentification fédérée, back-office agent. Toutes consomment les
+        packages publiés <code>@govpf/ori-*</code> sans patch.
+      </p>
+    </div>
+  </section>
+
+  <section class="examples-section">
+    <div class="examples-section__inner">
+      <ul class="examples-grid" role="list">
+        {
+          examples.map((ex) => (
+            <li>
+              <article class="ori-card example-card">
+                <div class="ori-card__body">
+                  <span class={`ori-tag ori-tag--${ex.badgeVariant}`}>{ex.badge}</span>
+                  <h2 class="ori-card__title">{ex.title}</h2>
+                  <p>{ex.description}</p>
+                  <p class="example-card__surface">
+                    <strong>Composants démontrés :</strong> {ex.surface}
+                  </p>
+                </div>
+                <div class="ori-card__footer">
+                  <a class="ori-button ori-button--primary" href={ex.href}>
+                    Ouvrir la démo →
+                  </a>
+                </div>
+              </article>
+            </li>
+          ))
+        }
+      </ul>
+
+      <h2 class="examples-section__sub">Outils interactifs</h2>
+      <ul class="examples-grid examples-grid--tools" role="list">
+        {
+          tools.map((tool) => (
+            <li>
+              <article class="ori-card example-card">
+                <div class="ori-card__body">
+                  <h3 class="ori-card__title">{tool.title}</h3>
+                  <p>{tool.description}</p>
+                </div>
+                <div class="ori-card__footer">
+                  <a class="ori-link" href={tool.href}>
+                    Ouvrir →
+                  </a>
+                </div>
+              </article>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .page-intro {
+    background: var(--color-brand-primary-subtle);
+    border-bottom: 1px solid var(--color-border-subtle);
+    padding: 4rem 1.5rem 3rem;
+  }
+  .page-intro__inner {
+    max-width: 60rem;
+    margin: 0 auto;
+  }
+  .page-intro__eyebrow {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-brand-primary);
+    font-weight: 600;
+  }
+  .page-intro__title {
+    margin: 0 0 1rem 0;
+    font-size: clamp(1.875rem, 1rem + 3vw, 2.75rem);
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.15;
+    color: var(--color-text-primary);
+  }
+  .page-intro__lead {
+    margin: 0;
+    font-size: 1.0625rem;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+  }
+
+  .examples-section {
+    padding: 3rem 1.5rem 4rem;
+  }
+  .examples-section__inner {
+    max-width: 80rem;
+    margin: 0 auto;
+  }
+  .examples-section__sub {
+    margin: 3rem 0 1.5rem 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-text-primary);
+  }
+
+  .examples-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1rem;
+  }
+  .examples-grid--tools {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  .example-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .example-card .ori-card__body {
+    flex: 1 1 auto;
+  }
+  .example-card__surface {
+    margin-top: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+  .example-card__surface strong {
+    color: var(--color-text-primary);
+    font-weight: 600;
+  }
+</style>


### PR DESCRIPTION
## Summary

Le workflow `deploy.yml` ne composait que `/`, `/storybook/{react,angular}/` et `/demo/`. Les 3 exemples ajoutés en #87 (landing, keycloak, agent Angular) n'étaient accessibles que via `pnpm dev`. Cette PR les expose publiquement sous `ori.gov.pf/exemples/`.

Structure servie après ce changement :

```
/                     -> site Astro
/storybook/react/     -> Storybook React
/storybook/angular/   -> Storybook Angular
/demo/                -> demo-portail (inchangé, lien externe préservé)
/exemples/            -> hub Astro listant toutes les démos (nouveau)
/exemples/landing/    -> example-landing (HTML statique)
/exemples/keycloak/   -> example-keycloak (mires HTML)
/exemples/agent/      -> example-agent (Angular SPA)
```

## Changements

- **`apps/example-landing` + `apps/example-keycloak`** : nouveau `build.mjs` qui copie les fichiers statiques (HTML, CSS, SVG, PNG, fonts) dans `dist/`, lancé après `copy-css.mjs` via le hook `prebuild`.
- **`apps/example-agent`** : `angular.json` configuration production complétée avec `"baseHref": "/exemples/agent/"`. Le builder Angular 20 application injecte `<base href>` en conséquence dans `index.html`. Suppression de `vendorChunk` et `buildOptimizer` (non supportés par le builder application). Build prod : 459 kB initial, 113 kB transferé compressé. `package.json` force `--configuration production` pour `pnpm build`.
- **`.github/workflows/deploy.yml`** : 3 nouveaux build steps (landing, keycloak, agent), copie des dists vers `dist/exemples/{name}/`. Pour l'agent on copie le sous-dossier `browser/` produit par le builder application Angular.
- **`apps/ori-site/src/pages/exemples/index.astro`** : nouvelle page hub qui liste les 4 démos avec description, badge framework, surface de composants démontrés et CTA. Suivie d'une section « Outils interactifs » pour les 2 Storybooks.
- **`apps/ori-site/src/layouts/BaseLayout.astro`** : item de navigation `Démo` renommé en `Exemples` pointant vers `/exemples/`. Lien footer `Portail démo` -> `/demo/` conservé.

## Test plan

- [x] `pnpm --filter @govpf/ori-example-landing build` produit `dist/` avec 9 fichiers
- [x] `pnpm --filter @govpf/ori-example-keycloak build` produit `dist/` avec 13 fichiers
- [x] `pnpm --filter @govpf/ori-example-agent build` produit `dist/example-agent/browser/` avec `<base href="/exemples/agent/">` injecté
- [x] `pnpm --filter @govpf/ori-site build` génère bien `/exemples/index.html`, nav avec « Exemples »
- [ ] CI verte sur le merge
- [ ] Déploiement Pages OK : navigation depuis ori.gov.pf vers les 4 démos opérationnelle
