### PR TITLE
fix(site): CTA hero et footer pointent vers /exemples/

### DIFF
--- a/apps/ori-site/src/layouts/BaseLayout.astro
+++ b/apps/ori-site/src/layouts/BaseLayout.astro
@@ -78,7 +78,7 @@ const base = import.meta.env.BASE_URL;
                 <a class="ori-link ori-link--quiet" href={`${base}decouvrir/pourquoi/`}>Pourquoi Ori</a>
                 <a class="ori-link ori-link--quiet" href={`${base}composants/`}>Composants</a>
                 <a class="ori-link ori-link--quiet" href={`${base}fondations/palette/`}>Fondations</a>
-                <a class="ori-link ori-link--quiet" href={`${base}demo/`}>Portail démo</a>
+                <a class="ori-link ori-link--quiet" href={`${base}exemples/`}>Exemples et démos</a>
               </nav>
 
               <nav class="ori-footer__column" aria-label="Ressources">

--- a/apps/ori-site/src/pages/index.astro
+++ b/apps/ori-site/src/pages/index.astro
@@ -48,8 +48,8 @@ const base = import.meta.env.BASE_URL;
     <a class="ori-button ori-button--primary" href={`${base}decouvrir/pourquoi/`}>
       Démarrer avec Ori
     </a>
-    <a class="ori-button ori-button--secondary" href={`${base}demo/`}>
-      Voir le portail démo
+    <a class="ori-button ori-button--secondary" href={`${base}exemples/`}>
+      Voir les exemples
     </a>
     <a class="ori-button ori-button--ghost" href="https://github.com/govpf/ori" target="_blank" rel="noreferrer">
       Voir sur GitHub


### PR DESCRIPTION
## Summary

Cohérence avec la PR #90 : le CTA secondaire du hero de la home pointait encore vers `/demo/` (« Voir le portail démo »), qui n'expose qu'une seule des 4 démos. Idem pour le lien Documentation -> Portail démo du footer.

Renommé en « Voir les exemples » / « Exemples et démos » -> `/exemples/` pour rediriger vers le hub.

L'URL `/demo/` reste valide (préservée pour les liens externes), elle n'est juste plus le point d'entrée mis en avant.

## Test plan

- [x] Build local OK
- [ ] CI verte