### PR TITLE
feat(examples): bandeau DÉMO sur les 3 exemples (parité demo-portail)

### DIFF
--- a/apps/example-agent/src/app/app.component.html
+++ b/apps/example-agent/src/app/app.component.html
@@ -5,6 +5,16 @@
   (sidebarOpenChange)="sidebarOpen.set($event)"
 >
   <header slot="header">
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <ori-header>
       <ori-logo
         brand

--- a/apps/example-agent/src/styles.css
+++ b/apps/example-agent/src/styles.css
@@ -72,3 +72,50 @@ body {
   font-size: 1.25rem;
   line-height: 1;
 }
+
+/* Bandeau "DÉMO" permanent en haut de la page. Volontairement voyant
+   et non-fermable (aucun bouton dismiss) : un usager ne doit jamais
+   confondre cette démo avec un service réel. Couleurs feedback warning
+   pour signaler le caractère non officiel. */
+.demo-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-feedback-warning);
+  color: var(--color-neutral-900);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  border-bottom: 2px solid var(--color-feedback-warning-strong);
+}
+.demo-banner strong {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-neutral-900);
+  color: var(--color-feedback-warning);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.demo-banner__link {
+  flex: 0 0 auto;
+  color: var(--color-neutral-900);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.demo-banner__link:hover {
+  text-decoration-thickness: 2px;
+}
+.demo-banner__link:focus-visible {
+  outline: 2px solid var(--color-neutral-900);
+  outline-offset: 2px;
+  border-radius: 0.125rem;
+}

--- a/apps/example-keycloak/auth.css
+++ b/apps/example-keycloak/auth.css
@@ -179,3 +179,50 @@ body {
   font-size: 0.75rem;
   color: var(--color-text-secondary);
 }
+
+/* Bandeau "DÉMO" permanent en haut de la page. Volontairement voyant
+   et non-fermable (aucun bouton dismiss) : un usager ne doit jamais
+   confondre cette démo avec un service réel. Couleurs feedback warning
+   pour signaler le caractère non officiel. */
+.demo-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-feedback-warning);
+  color: var(--color-neutral-900);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  border-bottom: 2px solid var(--color-feedback-warning-strong);
+}
+.demo-banner strong {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-neutral-900);
+  color: var(--color-feedback-warning);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.demo-banner__link {
+  flex: 0 0 auto;
+  color: var(--color-neutral-900);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.demo-banner__link:hover {
+  text-decoration-thickness: 2px;
+}
+.demo-banner__link:focus-visible {
+  outline: 2px solid var(--color-neutral-900);
+  outline-offset: 2px;
+  border-radius: 0.125rem;
+}

--- a/apps/example-keycloak/error.html
+++ b/apps/example-keycloak/error.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/index.html
+++ b/apps/example-keycloak/index.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <main class="index-page">
       <header class="index-page__header">
         <h1 class="index-page__title">Mires d'authentification Keycloak</h1>

--- a/apps/example-keycloak/login.html
+++ b/apps/example-keycloak/login.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/otp.html
+++ b/apps/example-keycloak/otp.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/register.html
+++ b/apps/example-keycloak/register.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/reset-password.html
+++ b/apps/example-keycloak/reset-password.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/session-expired.html
+++ b/apps/example-keycloak/session-expired.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-keycloak/update-password.html
+++ b/apps/example-keycloak/update-password.html
@@ -8,6 +8,16 @@
     <link rel="stylesheet" href="./auth.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <div class="back-bar"><a href="./index.html">← Retour à l'index</a></div>
 
     <div class="pf-auth-page">

--- a/apps/example-landing/index.html
+++ b/apps/example-landing/index.html
@@ -12,6 +12,16 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <a href="#main" class="visually-hidden-focusable">Aller au contenu principal</a>
 
     <!--

--- a/apps/example-landing/legal.html
+++ b/apps/example-landing/legal.html
@@ -12,6 +12,16 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <a href="#main" class="visually-hidden-focusable">Aller au contenu principal</a>
 
     <header class="page-header">

--- a/apps/example-landing/recrutement.html
+++ b/apps/example-landing/recrutement.html
@@ -12,6 +12,16 @@
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
+    <div class="demo-banner" role="region" aria-label="Avertissement de démonstration">
+      <strong>DÉMO</strong>
+      <span
+        >Cette page illustre le design system Ori avec des données fictives. Aucune information
+        saisie ici n'est transmise à un service réel.</span
+      >
+      <a class="demo-banner__link" href="https://ori.gov.pf" target="_blank" rel="noreferrer"
+        >Voir la documentation Ori →</a
+      >
+    </div>
     <a href="#main" class="visually-hidden-focusable">Aller au contenu principal</a>
 
     <header class="page-header">

--- a/apps/example-landing/style.css
+++ b/apps/example-landing/style.css
@@ -591,3 +591,50 @@ body {
   color: var(--color-text-muted);
   text-align: center;
 }
+
+/* Bandeau "DÉMO" permanent en haut de la page. Volontairement voyant
+   et non-fermable (aucun bouton dismiss) : un usager ne doit jamais
+   confondre cette démo avec un service réel. Couleurs feedback warning
+   pour signaler le caractère non officiel. */
+.demo-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-feedback-warning);
+  color: var(--color-neutral-900);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  border-bottom: 2px solid var(--color-feedback-warning-strong);
+}
+.demo-banner strong {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--color-neutral-900);
+  color: var(--color-feedback-warning);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.demo-banner__link {
+  flex: 0 0 auto;
+  color: var(--color-neutral-900);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.demo-banner__link:hover {
+  text-decoration-thickness: 2px;
+}
+.demo-banner__link:focus-visible {
+  outline: 2px solid var(--color-neutral-900);
+  outline-offset: 2px;
+  border-radius: 0.125rem;
+}


### PR DESCRIPTION
## Summary

Le `demo-portail` affiche un bandeau jaune fixe « DÉMO » en tête de page pour qu'un usager ne confonde pas la démo avec un service réel. Les 3 exemples ajoutés en #87 (landing, keycloak, agent) n'avaient pas ce bandeau, ce qui aurait pu prêter à confusion une fois exposés sur `ori.gov.pf/exemples/`.

Markup et CSS strictement identiques au `demo-portail` (texte, couleurs feedback warning, lien d'évasion vers https://ori.gov.pf).

## Insertion

- **3 pages HTML** de `example-landing` (index, legal, recrutement) - injection après `<body>`
- **8 pages HTML** de `example-keycloak` (index + 7 mires) - injection après `<body>`
- **Slot header de l'AppShell Angular** dans `example-agent` - bandeau au-dessus du `<ori-header>`, en dehors de la sidebar

Le CSS `.demo-banner` est dupliqué dans les 3 stylesheets locales (`style.css`, `auth.css`, `src/styles.css`) plutôt que centralisé : c'est du contenu éditorial spécifique aux démos, pas un composant DS, on évite de polluer `@govpf/ori-css` avec une classe non publique.

## Test plan

- [x] Les 3 exemples buildent localement
- [x] Bannière visuellement identique à celle du demo-portail
- [ ] CI verte
- [ ] Validation visuelle après déploiement Pages