### PR TITLE
feat(mobile): viewports Storybook + page responsive + README a jour

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ ori/
     ├── ori-site/            # Site documentaire public (Astro)
     ├── storybook-react/     # Storybook test interactif React
     ├── storybook-angular/   # Storybook test interactif Angular
-    ├── playground-static/   # Démo HTML pur (intégration GLPI, emails)
-    ├── playground-react/    # Démo Vite + React
-    ├── playground-angular/  # Démo Angular CLI
-    └── demo-portail/        # Démo end-to-end portail usager
+    ├── demo-portail/        # Démo end-to-end portail citoyen (React)
+    ├── example-landing/     # Exemple : landing institutionnelle (HTML pur + ori-css)
+    ├── example-keycloak/    # Exemple : 7 mires d'authentification (HTML pur)
+    └── example-agent/       # Exemple : back-office agent (Angular standalone)
 ```
 
 ### Chaîne de production
@@ -119,6 +119,29 @@ just storybook-angular     # Storybook Angular, http://localhost:6008
 just demo-portail          # Demo portail end-to-end, http://localhost:5174
 just site                  # Site Astro, http://localhost:4321
 ```
+
+Les 3 exemples publics, qui démontrent la consommation de chaque livrable
+en conditions réelles (HTML pur, mires d'authentification, back-office
+Angular) :
+
+```bash
+pnpm example:landing       # Landing institutionnelle, http://localhost:4173
+pnpm example:keycloak      # Mires d'authentification, http://localhost:4174
+pnpm example:agent         # Back-office agent (Angular), http://localhost:5173
+```
+
+Tout en parallèle, deux modes au choix :
+
+```bash
+pnpm dev:all               # Orchestrateur natif : 8 apps + dashboard sur :3000
+pnpm dev:docker            # Conteneur Docker reproductible (premier boot 3-5 min,
+                           # ensuite ~30 s, kill global propre via compose down)
+```
+
+Détail dans [tools/dev-all/README.md](./tools/dev-all/README.md).
+
+Les démos sont aussi exposées publiquement sur le portail :
+<https://ori.gov.pf/exemples/>.
 
 ## Commandes
 

--- a/apps/ori-site/src/components/Sidebar.astro
+++ b/apps/ori-site/src/components/Sidebar.astro
@@ -45,6 +45,11 @@ const sections: NavSection[] = [
       { label: 'Rayons', slug: 'rayons', href: `${base}fondations/rayons/` },
       { label: 'Ombres', slug: 'ombres', href: `${base}fondations/ombres/` },
       {
+        label: 'Responsive design',
+        slug: 'responsive',
+        href: `${base}fondations/responsive/`,
+      },
+      {
         label: 'Validation accessibilité',
         slug: 'accessibilite',
         href: `${base}fondations/accessibilite/`,

--- a/apps/ori-site/src/pages/fondations/responsive.mdx
+++ b/apps/ori-site/src/pages/fondations/responsive.mdx
@@ -1,0 +1,102 @@
+---
+layout: ../../layouts/DocLayout.astro
+title: "Responsive design"
+current: "responsive"
+headerCurrent: "tokens"
+---
+
+# Responsive design
+
+Ori expose 4 breakpoints alignés Tailwind, repris de PF-UI pour rester
+cohérent avec les apps existantes. Le DS suit une logique mobile-first :
+on écrit le style mobile d'abord, puis on l'enrichit aux paliers
+supérieurs avec `min-width`.
+
+## Breakpoints
+
+Les breakpoints sont publiés dans `@govpf/ori-tokens` et exposés en CSS
+via les variables `--breakpoint-*`, en JavaScript via les exports
+`Breakpoint*`, en Tailwind via les screens du preset.
+
+| Token | Valeur | Cible | Quand l'utiliser |
+|-------|--------|-------|------------------|
+| `--breakpoint-sm` | `500px` | Smartphone XL en paysage, petite tablette | Faire passer une grille de 1 à 2 colonnes |
+| `--breakpoint-md` | `768px` | Tablette en portrait | Bascule sidebar drawer vers persistent, header passe en mode complet |
+| `--breakpoint-lg` | `992px` | Tablette en paysage, petit laptop | Apparition d'une troisième colonne, padding plus généreux |
+| `--breakpoint-xl` | `1200px` | Desktop standard | Largeur max conteneur, affichage tableau riche |
+
+## Règle mobile-first
+
+Toujours écrire le style mobile par défaut, puis enrichir avec
+`min-width`. Ne pas utiliser `max-width` sauf cas justifié (masquage
+d'un élément qui n'a pas de sens en grand écran).
+
+```css
+/* OK : mobile-first */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+@media (min-width: 768px) {
+  .kpi-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+  }
+}
+
+/* À éviter : desktop-first */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+@media (max-width: 767px) {
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+Avec Tailwind, les utilitaires sont mobile-first par construction :
+`md:grid-cols-4` applique `grid-template-columns: repeat(4, 1fr)` à
+partir de `768px`, sans rien défaire sur mobile.
+
+## Composants déjà responsive
+
+| Composant | Comportement |
+|-----------|--------------|
+| `AppShell` | Sidebar in-flow desktop, drawer overlay sous 768px piloté par la prop `sidebarOpen`. |
+| `SideMenu` | Variant explicite `persistent` (desktop) ou `drawer` (mobile), pas d'auto-bascule. |
+| `Header` | Layout 3 colonnes (brand, nav, actions) qui wrap en mobile. La nav doit être pilotée par l'app si on veut un burger menu. |
+| `Table` / `DataTable` | Pas d'adaptation native pour l'instant. Sur mobile, prévoir un wrapper avec `overflow-x: auto` ou un layout alternatif (cf. roadmap mobile). |
+
+## Touch targets
+
+La règle WAI-ARIA recommande des cibles tactiles d'au moins **44x44px**.
+Le travail est en cours pour appliquer cette règle systématiquement aux
+composants interactifs. Voir la
+[roadmap mobile](https://github.com/govpf/ori/issues/94) pour le suivi.
+
+## Tester en viewport mobile
+
+Les deux Storybooks (React et Angular) exposent 5 viewports prédéfinis
+dans la barre d'outils :
+
+- **Mobile S (360x640)** : smartphone Android entrée de gamme, plus
+  petit dénominateur commun à viser.
+- **Mobile L (414x896)** : iPhone Pro Max et grands smartphones.
+- **Tablet (768x1024)** : iPad mini.
+- **Desktop (1280x800)** et **Desktop L (1440x900)** : écrans laptop
+  courants.
+
+Pour activer un viewport, cliquer sur l'icône loupe dans la barre
+d'outils Storybook puis choisir un format. La story rend dans une
+iframe à la taille demandée, ce qui permet de valider le comportement
+sans redimensionner manuellement la fenêtre.
+
+## Voir aussi
+
+- [Issue #94 - Mobile maturity P1](https://github.com/govpf/ori/issues/94) :
+  les actions court terme sur la dimension mobile.
+- [Tokens](/tokens/) : la liste complète des variables, dont les
+  `--breakpoint-*`.

--- a/apps/storybook-angular/.storybook/preview.ts
+++ b/apps/storybook-angular/.storybook/preview.ts
@@ -40,6 +40,38 @@ const preview: Preview = {
     },
     backgrounds: { disable: true },
     layout: 'centered',
+    // Viewports calés sur les BreakpointSm/Md/Lg/Xl du DS (500/768/992/1200)
+    // plus 360 et 414 pour cadrer les usages mobiles réels. Synchronisé avec
+    // le preview du Storybook React.
+    viewport: {
+      viewports: {
+        mobile360: {
+          name: 'Mobile S (360x640)',
+          styles: { width: '360px', height: '640px' },
+          type: 'mobile',
+        },
+        mobile414: {
+          name: 'Mobile L (414x896)',
+          styles: { width: '414px', height: '896px' },
+          type: 'mobile',
+        },
+        tablet768: {
+          name: 'Tablet (768x1024)',
+          styles: { width: '768px', height: '1024px' },
+          type: 'tablet',
+        },
+        desktop1280: {
+          name: 'Desktop (1280x800)',
+          styles: { width: '1280px', height: '800px' },
+          type: 'desktop',
+        },
+        desktop1440: {
+          name: 'Desktop L (1440x900)',
+          styles: { width: '1440px', height: '900px' },
+          type: 'desktop',
+        },
+      },
+    },
     options: {
       // Ordre de la sidebar. Doit être inline (Storybook 8 ne suit pas les
       // imports dans cette config). Synchronisé avec le preview React.

--- a/apps/storybook-react/.storybook/preview.ts
+++ b/apps/storybook-react/.storybook/preview.ts
@@ -43,6 +43,37 @@ const preview: Preview = {
     },
     backgrounds: { disable: true },
     layout: 'centered',
+    // Viewports calés sur les BreakpointSm/Md/Lg/Xl du DS (500/768/992/1200)
+    // plus 360 et 414 pour cadrer les usages mobiles réels.
+    viewport: {
+      viewports: {
+        mobile360: {
+          name: 'Mobile S (360x640)',
+          styles: { width: '360px', height: '640px' },
+          type: 'mobile',
+        },
+        mobile414: {
+          name: 'Mobile L (414x896)',
+          styles: { width: '414px', height: '896px' },
+          type: 'mobile',
+        },
+        tablet768: {
+          name: 'Tablet (768x1024)',
+          styles: { width: '768px', height: '1024px' },
+          type: 'tablet',
+        },
+        desktop1280: {
+          name: 'Desktop (1280x800)',
+          styles: { width: '1280px', height: '800px' },
+          type: 'desktop',
+        },
+        desktop1440: {
+          name: 'Desktop L (1440x900)',
+          styles: { width: '1440px', height: '900px' },
+          type: 'desktop',
+        },
+      },
+    },
     options: {
       // Ordre de la sidebar. Doit être inline (Storybook 8 ne suit pas les
       // imports dans cette config). Synchronisé avec le preview Angular.


### PR DESCRIPTION
## Summary

Premier lot d'actions de l'issue #94 (mobile maturity P1). Trois changements de visibilité sans toucher au comportement des composants. Aucun risque de régression.

## Changements

### Storybook viewports (`apps/storybook-{react,angular}/.storybook/preview.ts`)

5 viewports prédéfinis dans la barre d'outils Storybook, calibrés sur les `BreakpointSm/Md/Lg/Xl` du DS plus 2 tailles mobiles :

- Mobile S (360x640)
- Mobile L (414x896)
- Tablet (768x1024)
- Desktop (1280x800)
- Desktop L (1440x900)

Activation depuis l'icône loupe dans la toolbar Storybook. Permet aux contributeurs et reviewers de valider le comportement mobile sans redimensionner manuellement la fenêtre.

### Page `fondations/responsive.mdx` (`apps/ori-site`)

Nouvelle page documentaire :

- Table des 4 breakpoints CSS exposés via les tokens `--breakpoint-sm/md/lg/xl` (500/768/992/1200), avec leur cible et leur usage type.
- Règle mobile-first systématique avec exemple CSS et exemple Tailwind.
- Table des composants déjà responsive : `AppShell` (drawer < 768px), `SideMenu` (variant `persistent` / `drawer`), `Header` (layout 3 colonnes), `Table` / `DataTable` (pas d'adaptation native pour l'instant, lien vers la roadmap).
- Note sur les touch targets 44x44px à venir, lien vers issue #94.
- Mode d'emploi des viewports Storybook.

Ajoutée à la sidebar Astro section `Fondations`.

### `README.md`

- Section **Architecture** : remplace les 3 playgrounds supprimés (PR #87) par les 3 nouveaux exemples.
- Section **Lancer les apps** : ajout des commandes `pnpm example:*` et des modes `pnpm dev:all` (natif) / `pnpm dev:docker` (conteneur). Lien vers `tools/dev-all/README.md`.
- Mention de l'exposition publique des démos sous `https://ori.gov.pf/exemples/`.

## Suite de #94

PRs suivantes à venir :

- **Touch targets 44x44px** : tokens `--size-touch-target` + application sur `.ori-button`, `.ori-input`, `.ori-tab`, wrappers checkbox/radio. Non breaking en théorie, à valider sur les variants `sm`.
- **MobileTabBar** : composant complet React + Angular avec stories, sortie de la pause vague 4.

## Test plan

- [x] Build local du site Astro : 29 pages générées (+1), `dist/fondations/responsive/index.html` présent
- [x] Pas de changement de comportement composant
- [ ] CI verte
- [ ] Validation visuelle après déploiement Pages
