### PR TITLE
feat(tokens,tailwind): touch target 44x44 en pointer coarse

### DIFF
--- a/.changeset/touch-targets-44px-coarse-pointer.md
+++ b/.changeset/touch-targets-44px-coarse-pointer.md
@@ -1,0 +1,30 @@
+---
+'@govpf/ori-tokens': minor
+'@govpf/ori-tailwind-preset': minor
+'@govpf/ori-css': minor
+---
+
+Ajout du token `size.touchTarget` (valeur `44px`) et application
+automatique sur les composants interactifs principaux en contexte
+tactile.
+
+Concrètement :
+
+- Nouveau token DTCG `size.touchTarget`. Disponible côté CSS via
+  `var(--size-touch-target)`, côté JS via `SizeTouchTarget`, côté
+  SCSS via `$size-touch-target`.
+- Nouveau bloc `@media (pointer: coarse)` dans le preset Tailwind qui
+  applique `min-block-size: var(--size-touch-target)` à `.ori-button`,
+  `.ori-input`, `.ori-select`, `.ori-tabs__tab`, et `.ori-choice`
+  (wrapper checkbox / radio / switch).
+
+L'objectif : conformité WCAG 2.5.5 niveau AAA (cibles tactiles ≥
+44×44 CSS pixels) sans dégrader la densité desktop. Sur souris /
+trackpad (`pointer: fine`), les composants conservent leur dimension
+actuelle. Sur mobile et tablette tactile, ils s'étendent au minimum
+de 44px en hauteur.
+
+Non breaking : le défaut desktop est inchangé. Les apps qui forcent
+déjà des tailles supérieures à 44px voient la règle absorbée sans
+effet (le `min-block-size` ne diminue jamais une hauteur déjà plus
+grande).

--- a/apps/ori-site/src/pages/fondations/responsive.mdx
+++ b/apps/ori-site/src/pages/fondations/responsive.mdx
@@ -72,10 +72,32 @@ partir de `768px`, sans rien défaire sur mobile.
 
 ## Touch targets
 
-La règle WAI-ARIA recommande des cibles tactiles d'au moins **44x44px**.
-Le travail est en cours pour appliquer cette règle systématiquement aux
-composants interactifs. Voir la
-[roadmap mobile](https://github.com/govpf/ori/issues/94) pour le suivi.
+WCAG 2.5.5 niveau AAA recommande des cibles tactiles d'au moins
+**44x44px**. Ori expose le token `--size-touch-target` (valeur 44px) et
+l'applique automatiquement aux composants interactifs principaux
+**en contexte tactile uniquement**, via `@media (pointer: coarse)` :
+
+| Élément | Hit-area en `pointer: coarse` |
+|---------|-------------------------------|
+| `.ori-button` (toutes variantes) | `min-block-size: 44px` |
+| `.ori-input` | idem |
+| `.ori-select` | idem |
+| `.ori-tabs__tab` | idem |
+| `.ori-choice` (wrapper checkbox / radio / switch) | idem, padding vertical pour étendre la rangée cliquable autour du visuel 18x18 |
+
+Sur souris ou trackpad (`pointer: fine`), la densité actuelle est
+conservée pour ne pas surcharger les interfaces denses (back-office,
+tableaux d'instruction).
+
+Pour un composant custom qui a besoin de la même règle :
+
+```css
+@media (pointer: coarse) {
+  .mon-bouton-custom {
+    min-block-size: var(--size-touch-target);
+  }
+}
+```
 
 ## Tester en viewport mobile
 

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -4084,6 +4084,29 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
     },
   });
 
+  // ─── Touch targets (issue #94) ──────────────────────────────────────────
+  // Sur appareil tactile (pointer: coarse), on garantit 44x44 CSS pixels
+  // sur les éléments interactifs principaux, conforme WCAG 2.5.5 niveau AAA.
+  // Sur souris/trackpad (pointer: fine), on conserve la densité actuelle pour
+  // ne pas surcharger les interfaces denses (back-office, tableaux). La
+  // variable --size-touch-target est définie par @govpf/ori-tokens (44px),
+  // surchargeable par un consommateur si besoin.
+  addComponents({
+    '@media (pointer: coarse)': {
+      '.ori-button, .ori-input, .ori-select, .ori-tabs__tab': {
+        minBlockSize: 'var(--size-touch-target)',
+      },
+      // Pour les form-rows checkbox / radio / switch, c'est le wrapper
+      // .ori-choice (le <label> cliquable qui contient l'input + le texte) qui
+      // fournit la hit-area, via un padding vertical qui amène la rangée au
+      // minimum tactile. Le visuel 18x18 du checkbox/radio reste compact.
+      '.ori-choice': {
+        minBlockSize: 'var(--size-touch-target)',
+        paddingBlock: theme('spacing.2'),
+      },
+    },
+  });
+
   addBase({
     '@keyframes ori-fade-in': {
       from: { opacity: '0' },

--- a/packages/tokens/src/core.json
+++ b/packages/tokens/src/core.json
@@ -70,6 +70,13 @@
       "600": { "$value": "#062f88", "$type": "color" }
     }
   },
+  "size": {
+    "$description": "Tailles minimales d'interaction. Cible WAI-ARIA Target Size (Enhanced) 2.5.5 : 44x44 CSS pixels recommandés sur les éléments interactifs en contexte tactile. Appliqué via @media (pointer: coarse) pour ne pas dégrader la densité desktop.",
+    "touchTarget": {
+      "$value": "44px",
+      "$type": "dimension"
+    }
+  },
   "spacing": {
     "0": { "$value": "0", "$type": "dimension" },
     "1": { "$value": "0.25rem", "$type": "dimension" },


### PR DESCRIPTION
## Summary

Deuxième lot d'actions de l'issue #94 (mobile maturity P1). Conformité **WCAG 2.5.5 niveau AAA** sur les cibles tactiles, sans dégrader la densité desktop.

## Changements

### `packages/tokens/src/core.json`

Nouvelle section `size` avec un seul token pour l'instant : `touchTarget` à `44px`. Génère :

- `--size-touch-target: 44px;` en CSS
- `SizeTouchTarget = "44px"` en JS / TS
- `$size-touch-target: 44px;` en SCSS

### `packages/tailwind-preset/src/plugin-components.js`

Nouveau bloc `@media (pointer: coarse)` ajouté en fin de plugin qui applique `min-block-size: var(--size-touch-target)` sur les composants interactifs principaux :

- `.ori-button` (toutes variantes, y compris `--sm` qui fait aujourd'hui ~24px en density desktop)
- `.ori-input`, `.ori-select`, `.ori-tabs__tab`
- `.ori-choice` (wrapper label de checkbox / radio / switch). Le visuel 18x18 du checkbox/radio reste compact, c'est le label qui fournit la hit-area via padding vertical.

### Documentation

`apps/ori-site/src/pages/fondations/responsive.mdx` : section *Touch targets* mise à jour. Table des composants visés, exemple d'application sur un composant custom.

## Pourquoi `@media (pointer: coarse)` plutôt qu'inconditionnel

Le `pointer: coarse` matche les périphériques de pointage imprécis (doigt sur écran tactile). Sur souris ou trackpad (`pointer: fine`), Ori conserve la densité actuelle pour ne pas surcharger les interfaces denses (back-office d'instruction de dossiers, tableaux). Sur mobile et tablette tactile, les composants interactifs s'étendent au minimum 44px en hauteur.

C'est un compromis pragmatique : on respecte WCAG AAA en mobile (cible la plus exigeante) sans imposer un dimensionnement géant aux UI desktop denses.

## Non breaking

- Le défaut desktop est inchangé.
- `min-block-size` ne diminue jamais une hauteur déjà plus grande, donc les composants qui sont déjà au-dessus de 44px (ex. `.ori-button--lg`) ne bougent pas.
- Aucune classe ni API renommée ou supprimée.

Bump minor sur `@govpf/ori-tokens`, `@govpf/ori-tailwind-preset`, `@govpf/ori-css` (changeset inclus).

## Test plan

- [x] Build local des tokens : `--size-touch-target: 44px` présent dans `tokens.css`
- [x] Build local du preset Tailwind : `@media (pointer: coarse) { .ori-button, .ori-input, ... }` présent dans `dist/ori.css`
- [ ] CI verte
- [ ] Smoke test visuel : storybook React + Angular en viewport mobile, vérifier qu'un button `--sm` fait bien 44px de haut
- [ ] Validation visuelle des 3 exemples publics (landing, keycloak, agent) sur mobile

## Suite de #94

- **MobileTabBar** : composant complet React + Angular avec stories. Dernière action court terme à expédier.
