### PR TITLE
feat(mobile-tab-bar): nouveau composant React + Angular

### DIFF
--- a/.changeset/mobile-tab-bar.md
+++ b/.changeset/mobile-tab-bar.md
@@ -1,0 +1,53 @@
+---
+'@govpf/ori-react': minor
+'@govpf/ori-angular': minor
+'@govpf/ori-tailwind-preset': minor
+'@govpf/ori-css': minor
+---
+
+Nouveau composant `MobileTabBar` (React) / `<ori-mobile-tab-bar>` (Angular).
+
+Barre de navigation fixée en bas d'écran sur mobile, pattern UX standard
+(Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône
+au-dessus d'un label court. Items rendus en `<a>` ou `<button>` selon
+qu'un `href` est fourni.
+
+API React :
+
+```tsx
+<MobileTabBar
+  items={[
+    { id: 'home', label: 'Accueil', icon: <Home size={20} />, current: true },
+    { id: 'demarches', label: 'Démarches', icon: <FileText size={20} />, badge: 2 },
+    { id: 'profil', label: 'Profil', icon: <User size={20} /> },
+  ]}
+  onSelect={(item) => router.push(`/${item.id}`)}
+/>
+```
+
+API Angular :
+
+```html
+<ori-mobile-tab-bar
+  [items]="[
+    { id: 'home', label: 'Accueil', icon: HomeIcon, current: true },
+    { id: 'demarches', label: 'Démarches', icon: FileTextIcon, badge: 2 },
+    { id: 'profil', label: 'Profil', icon: UserIcon }
+  ]"
+  (select)="onSelect($event)"
+></ori-mobile-tab-bar>
+```
+
+Caractéristiques :
+
+- Masquée par défaut au-dessus du breakpoint `md` (768px) ; `alwaysVisible`
+  pour forcer l'affichage sur desktop.
+- Touch target 56px sur chaque item (au-delà du minimum WCAG 2.5.5).
+- Respecte `env(safe-area-inset-bottom)` pour l'iPhone home indicator.
+- Support des pastilles de notification (`badge`).
+- Items désactivables (`disabled`).
+- ARIA : `<nav aria-label>`, `aria-current="page"` sur l'item courant,
+  `aria-disabled` sur les items désactivés.
+
+Acquis fonctionnel repris de PF-UI, première action structurelle de la
+roadmap mobile (issue #94).

--- a/packages/angular/src/components/mobile-tab-bar/index.ts
+++ b/packages/angular/src/components/mobile-tab-bar/index.ts
@@ -1,0 +1,1 @@
+export { OriMobileTabBarComponent, type OriMobileTabBarItem } from './mobile-tab-bar.component';

--- a/packages/angular/src/components/mobile-tab-bar/mobile-tab-bar.component.ts
+++ b/packages/angular/src/components/mobile-tab-bar/mobile-tab-bar.component.ts
@@ -1,0 +1,137 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewEncapsulation,
+} from '@angular/core';
+import { LucideAngularModule, Edit } from 'lucide-angular';
+
+type LucideIconData = typeof Edit;
+
+/**
+ * Item d'une `<ori-mobile-tab-bar>`.
+ *
+ * - `href` rend l'item en `<a>`, sinon en `<button>` qui émet l'event `(select)`.
+ * - `icon` accepte une icône Lucide (cohérent avec `<ori-dropdown-menu>`).
+ * - `badge` est une chaîne ou un nombre affichés en pastille (notification).
+ */
+export interface OriMobileTabBarItem {
+  /** Identifiant stable, utile si plusieurs items ont le même libellé. */
+  id?: string;
+  /** Libellé court (idéalement 1 à 2 mots). */
+  label: string;
+  /** URL cible. Si fournie, l'item est rendu en `<a>`. */
+  href?: string;
+  /** Marque l'item comme courant. Pose `aria-current="page"` et le style actif. */
+  current?: boolean;
+  /** Icône Lucide (taille 24px), affichée au-dessus du label. */
+  icon?: LucideIconData;
+  /** Pastille optionnelle affichée en débordement de l'icône. */
+  badge?: string | number;
+  /** Désactive l'item (apparence grisée, non cliquable). */
+  disabled?: boolean;
+}
+
+/**
+ * Barre de navigation fixée en bas d'écran sur mobile, pattern UX standard
+ * (Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône
+ * au-dessus d'un label court.
+ *
+ * Masquée par défaut au-dessus du breakpoint `md` (768px), où la navigation
+ * principale passe par le `<ori-header>` + `<ori-side-menu>`. La prop
+ * `alwaysVisible` permet de forcer l'affichage si l'app le justifie.
+ *
+ * Touch target de 56px minimum sur chaque item, indépendamment de la règle
+ * globale `@media (pointer: coarse)`, parce que la barre est intrinsèquement
+ * destinée au tactile.
+ *
+ * Sécurité iOS : le conteneur respecte `env(safe-area-inset-bottom)` pour
+ * ne pas s'afficher sous le home indicator des iPhone récents.
+ */
+@Component({
+  selector: 'ori-mobile-tab-bar',
+  standalone: true,
+  imports: [LucideAngularModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <nav
+      class="ori-mobile-tab-bar"
+      [class.ori-mobile-tab-bar--always-visible]="alwaysVisible"
+      [attr.aria-label]="ariaLabel"
+    >
+      <ul class="ori-mobile-tab-bar__list">
+        @for (item of items; track item.id ?? item.label; let i = $index) {
+          <li class="ori-mobile-tab-bar__item">
+            @if (item.href) {
+              <a
+                [href]="item.disabled ? null : item.href"
+                class="ori-mobile-tab-bar__link"
+                [attr.aria-current]="item.current ? 'page' : null"
+                [attr.aria-disabled]="item.disabled ? true : null"
+                (click)="onLinkClick($event, item)"
+              >
+                @if (item.icon) {
+                  <span class="ori-mobile-tab-bar__icon" aria-hidden="true">
+                    <lucide-icon [img]="item.icon" [size]="20"></lucide-icon>
+                  </span>
+                }
+                @if (item.badge !== undefined && item.badge !== null) {
+                  <span class="ori-mobile-tab-bar__badge" aria-hidden="true">{{ item.badge }}</span>
+                }
+                <span class="ori-mobile-tab-bar__label">{{ item.label }}</span>
+              </a>
+            } @else {
+              <button
+                type="button"
+                class="ori-mobile-tab-bar__link"
+                [attr.aria-current]="item.current ? 'page' : null"
+                [disabled]="item.disabled"
+                (click)="select.emit(item)"
+              >
+                @if (item.icon) {
+                  <span class="ori-mobile-tab-bar__icon" aria-hidden="true">
+                    <lucide-icon [img]="item.icon" [size]="20"></lucide-icon>
+                  </span>
+                }
+                @if (item.badge !== undefined && item.badge !== null) {
+                  <span class="ori-mobile-tab-bar__badge" aria-hidden="true">{{ item.badge }}</span>
+                }
+                <span class="ori-mobile-tab-bar__label">{{ item.label }}</span>
+              </button>
+            }
+          </li>
+        }
+      </ul>
+    </nav>
+  `,
+})
+export class OriMobileTabBarComponent {
+  /** Items à afficher. 3 à 5 items recommandés (Material / iOS HIG). */
+  @Input() items: OriMobileTabBarItem[] = [];
+
+  /** Étiquette ARIA du `<nav>`. */
+  @Input() ariaLabel: string = 'Navigation mobile';
+
+  /**
+   * Si `true`, la barre reste visible au-dessus du breakpoint `md` (768px).
+   * Par défaut elle est masquée sur desktop.
+   */
+  @Input() alwaysVisible: boolean = false;
+
+  /**
+   * Émis au clic sur un item dépourvu de `href` (mode bouton). Permet à l'app
+   * de gérer le routing via Angular Router ou tout autre mécanisme.
+   */
+  @Output() select = new EventEmitter<OriMobileTabBarItem>();
+
+  onLinkClick(event: MouseEvent, item: OriMobileTabBarItem): void {
+    if (item.disabled) {
+      event.preventDefault();
+      return;
+    }
+    this.select.emit(item);
+  }
+}

--- a/packages/angular/src/components/mobile-tab-bar/mobile-tab-bar.stories.ts
+++ b/packages/angular/src/components/mobile-tab-bar/mobile-tab-bar.stories.ts
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj, Args } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+import { Home, FileText, MessageCircle, User, Search } from 'lucide-angular';
+import { OriMobileTabBarComponent, type OriMobileTabBarItem } from './mobile-tab-bar.component';
+
+const baseItems: OriMobileTabBarItem[] = [
+  { id: 'home', label: 'Accueil', icon: Home, current: true },
+  { id: 'demarches', label: 'Démarches', icon: FileText },
+  { id: 'messages', label: 'Messages', icon: MessageCircle },
+  { id: 'profil', label: 'Profil', icon: User },
+];
+
+const meta: Meta<OriMobileTabBarComponent> = {
+  title: 'Compositions/Navigation/MobileTabBar',
+  component: OriMobileTabBarComponent,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Barre de navigation fixée en bas d'écran sur mobile, pattern UX standard (Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône au-dessus d'un label court. Masquée par défaut au-dessus du breakpoint `md` (768px).",
+      },
+    },
+    viewport: { defaultViewport: 'mobile360' },
+    layout: 'fullscreen',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [OriMobileTabBarComponent],
+    }),
+  ],
+  render: (args: Args) => ({
+    props: args,
+    template: `<ori-mobile-tab-bar [items]="items" [alwaysVisible]="alwaysVisible"></ori-mobile-tab-bar>`,
+  }),
+};
+
+export default meta;
+type Story = StoryObj<OriMobileTabBarComponent>;
+
+export const Default: Story = {
+  name: 'Par défaut (4 items)',
+  args: {
+    items: baseItems,
+  },
+};
+
+export const ThreeItems: Story = {
+  name: '3 items',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: Home, current: true },
+      { id: 'demarches', label: 'Démarches', icon: FileText },
+      { id: 'profil', label: 'Profil', icon: User },
+    ],
+  },
+};
+
+export const FiveItems: Story = {
+  name: '5 items (max recommandé)',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: Home, current: true },
+      { id: 'search', label: 'Rechercher', icon: Search },
+      { id: 'demarches', label: 'Démarches', icon: FileText },
+      { id: 'messages', label: 'Messages', icon: MessageCircle },
+      { id: 'profil', label: 'Profil', icon: User },
+    ],
+  },
+};
+
+export const WithBadges: Story = {
+  name: 'Avec pastilles de notification',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: Home, current: true },
+      { id: 'demarches', label: 'Démarches', icon: FileText, badge: 2 },
+      { id: 'messages', label: 'Messages', icon: MessageCircle, badge: '12' },
+      { id: 'profil', label: 'Profil', icon: User },
+    ],
+  },
+};
+
+export const WithDisabledItem: Story = {
+  name: 'Item désactivé',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: Home, current: true },
+      { id: 'demarches', label: 'Démarches', icon: FileText },
+      { id: 'messages', label: 'Messages', icon: MessageCircle, disabled: true },
+      { id: 'profil', label: 'Profil', icon: User },
+    ],
+  },
+};
+
+export const ButtonsWithCallback: Story = {
+  name: 'Boutons (sans href, événement (select))',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Sans `href`, l'item est rendu en `<button>` et l'événement `(select)` permet de gérer la navigation côté app (Angular Router, signal, etc.).",
+      },
+    },
+  },
+  render: () => ({
+    props: {
+      items: baseItems.map((item) => ({ ...item, href: undefined })),
+      onSelect: (item: OriMobileTabBarItem) => console.log('selected', item.id),
+    },
+    template: `
+      <ori-mobile-tab-bar
+        [items]="items"
+        (select)="onSelect($event)"
+      ></ori-mobile-tab-bar>
+    `,
+  }),
+};
+
+export const AlwaysVisible: Story = {
+  name: 'Toujours visible (alwaysVisible=true)',
+  args: {
+    items: baseItems,
+    alwaysVisible: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Par défaut la barre est masquée au-dessus du breakpoint `md` (768px). `alwaysVisible` la conserve sur desktop, à utiliser uniquement si l'app n'a pas de header avec navigation horizontale.",
+      },
+    },
+  },
+};

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -43,6 +43,7 @@ export * from './components/logo';
 export * from './components/header';
 export * from './components/footer';
 export * from './components/main-navigation';
+export * from './components/mobile-tab-bar';
 export * from './components/side-menu';
 export * from './components/language-switcher';
 export * from './components/error-page';

--- a/packages/react/src/components/MobileTabBar/MobileTabBar.stories.tsx
+++ b/packages/react/src/components/MobileTabBar/MobileTabBar.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Home, FileText, MessageCircle, User, Search } from 'lucide-react';
+import { MobileTabBar, type MobileTabBarItem } from './MobileTabBar.js';
+
+const meta = {
+  title: 'Compositions/Navigation/MobileTabBar',
+  component: MobileTabBar,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Barre de navigation fixée en bas d'écran sur mobile, pattern UX standard (Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône au-dessus d'un label court. Masquée par défaut au-dessus du breakpoint `md` (768px).",
+      },
+    },
+    viewport: { defaultViewport: 'mobile360' },
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof MobileTabBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseItems: MobileTabBarItem[] = [
+  { id: 'home', label: 'Accueil', icon: <Home size={20} aria-hidden="true" />, current: true },
+  { id: 'demarches', label: 'Démarches', icon: <FileText size={20} aria-hidden="true" /> },
+  { id: 'messages', label: 'Messages', icon: <MessageCircle size={20} aria-hidden="true" /> },
+  { id: 'profil', label: 'Profil', icon: <User size={20} aria-hidden="true" /> },
+];
+
+export const Default: Story = {
+  name: 'Par défaut (4 items)',
+  args: {
+    items: baseItems,
+  },
+};
+
+export const ThreeItems: Story = {
+  name: '3 items',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: <Home size={20} aria-hidden="true" />, current: true },
+      { id: 'demarches', label: 'Démarches', icon: <FileText size={20} aria-hidden="true" /> },
+      { id: 'profil', label: 'Profil', icon: <User size={20} aria-hidden="true" /> },
+    ],
+  },
+};
+
+export const FiveItems: Story = {
+  name: '5 items (max recommandé)',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: <Home size={20} aria-hidden="true" />, current: true },
+      { id: 'search', label: 'Rechercher', icon: <Search size={20} aria-hidden="true" /> },
+      { id: 'demarches', label: 'Démarches', icon: <FileText size={20} aria-hidden="true" /> },
+      { id: 'messages', label: 'Messages', icon: <MessageCircle size={20} aria-hidden="true" /> },
+      { id: 'profil', label: 'Profil', icon: <User size={20} aria-hidden="true" /> },
+    ],
+  },
+};
+
+export const WithBadges: Story = {
+  name: 'Avec pastilles de notification',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: <Home size={20} aria-hidden="true" />, current: true },
+      {
+        id: 'demarches',
+        label: 'Démarches',
+        icon: <FileText size={20} aria-hidden="true" />,
+        badge: 2,
+      },
+      {
+        id: 'messages',
+        label: 'Messages',
+        icon: <MessageCircle size={20} aria-hidden="true" />,
+        badge: '12',
+      },
+      { id: 'profil', label: 'Profil', icon: <User size={20} aria-hidden="true" /> },
+    ],
+  },
+};
+
+export const WithDisabledItem: Story = {
+  name: 'Item désactivé',
+  args: {
+    items: [
+      { id: 'home', label: 'Accueil', icon: <Home size={20} aria-hidden="true" />, current: true },
+      { id: 'demarches', label: 'Démarches', icon: <FileText size={20} aria-hidden="true" /> },
+      {
+        id: 'messages',
+        label: 'Messages',
+        icon: <MessageCircle size={20} aria-hidden="true" />,
+        disabled: true,
+      },
+      { id: 'profil', label: 'Profil', icon: <User size={20} aria-hidden="true" /> },
+    ],
+  },
+};
+
+export const ButtonsWithCallback: Story = {
+  name: 'Boutons (sans href, callback `onSelect`)',
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [active, setActive] = useState<string>('home');
+    const items: MobileTabBarItem[] = baseItems.map((item) => ({
+      ...item,
+      href: undefined,
+      current: item.id === active,
+    }));
+    return (
+      <MobileTabBar
+        items={items}
+        onSelect={(item) => {
+          if (item.id) setActive(item.id);
+        }}
+      />
+    );
+  },
+};
+
+export const AlwaysVisible: Story = {
+  name: 'Toujours visible (alwaysVisible=true)',
+  args: {
+    items: baseItems,
+    alwaysVisible: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Par défaut la barre est masquée au-dessus du breakpoint `md` (768px). `alwaysVisible` la conserve sur desktop, à utiliser uniquement si l'app n'a pas de Header avec navigation horizontale.",
+      },
+    },
+  },
+};

--- a/packages/react/src/components/MobileTabBar/MobileTabBar.tsx
+++ b/packages/react/src/components/MobileTabBar/MobileTabBar.tsx
@@ -1,0 +1,129 @@
+import type { HTMLAttributes, MouseEvent, ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+export interface MobileTabBarItem {
+  /** Identifiant stable, utile si plusieurs items ont le même libellé. */
+  id?: string;
+  /** Libellé court (idéalement 1 mot, 2 max). */
+  label: ReactNode;
+  /** URL cible. Si fournie, l'item est rendu en `<a>`, sinon en `<button>`. */
+  href?: string;
+  /** Marque l'item comme courant. Pose `aria-current="page"` et le style actif. */
+  current?: boolean;
+  /** Icône (idéalement 24x24px) rendue au-dessus du label. */
+  icon?: ReactNode;
+  /** Pastille optionnelle affichée en débordement de l'icône (notification, compteur). */
+  badge?: ReactNode;
+  /** Désactive l'item (apparence grisée, non cliquable). */
+  disabled?: boolean;
+}
+
+export interface MobileTabBarProps extends Omit<HTMLAttributes<HTMLElement>, 'onSelect'> {
+  /** Items à afficher. 3 à 5 items recommandés (Material / iOS HIG). */
+  items: MobileTabBarItem[];
+  /** Étiquette ARIA du `<nav>`. */
+  'aria-label'?: string;
+  /**
+   * Si `true`, la barre reste visible au-dessus du breakpoint `md` (768px).
+   * Par défaut elle est masquée sur desktop, où la navigation est censée
+   * passer par le `Header` + `SideMenu`.
+   */
+  alwaysVisible?: boolean;
+  /**
+   * Callback appelé au clic sur un item dépourvu de `href`. L'événement
+   * natif est passé en second argument pour permettre un `preventDefault`.
+   */
+  onSelect?: (item: MobileTabBarItem, event: MouseEvent<HTMLElement>) => void;
+}
+
+/**
+ * Barre de navigation fixée en bas d'écran sur mobile, pattern UX standard
+ * (Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône
+ * au-dessus d'un label court.
+ *
+ * Masquée par défaut au-dessus du breakpoint `md` (768px), où la navigation
+ * principale passe par le `Header` + `SideMenu`. La prop `alwaysVisible`
+ * permet de forcer l'affichage si l'app le justifie.
+ *
+ * Touch target de 56px minimum sur chaque item, indépendamment de la règle
+ * globale `@media (pointer: coarse)`, parce que la barre est intrinsèquement
+ * destinée au tactile.
+ *
+ * Sécurité iOS : le conteneur respecte `env(safe-area-inset-bottom)` pour
+ * ne pas s'afficher sous le home indicator des iPhone récents.
+ */
+export function MobileTabBar({
+  items,
+  'aria-label': ariaLabel = 'Navigation mobile',
+  alwaysVisible = false,
+  onSelect,
+  className,
+  ...rest
+}: MobileTabBarProps) {
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={clsx(
+        'ori-mobile-tab-bar',
+        alwaysVisible && 'ori-mobile-tab-bar--always-visible',
+        className,
+      )}
+      {...rest}
+    >
+      <ul className="ori-mobile-tab-bar__list">
+        {items.map((item, i) => {
+          const key = item.id ?? `${i}-${typeof item.label === 'string' ? item.label : ''}`;
+          const ariaCurrent = item.current ? 'page' : undefined;
+          const ariaDisabled = item.disabled ? true : undefined;
+          const content = (
+            <>
+              {item.icon !== undefined && (
+                <span className="ori-mobile-tab-bar__icon" aria-hidden="true">
+                  {item.icon}
+                </span>
+              )}
+              {item.badge !== undefined && (
+                <span className="ori-mobile-tab-bar__badge" aria-hidden="true">
+                  {item.badge}
+                </span>
+              )}
+              <span className="ori-mobile-tab-bar__label">{item.label}</span>
+            </>
+          );
+          return (
+            <li key={key} className="ori-mobile-tab-bar__item">
+              {item.href ? (
+                <a
+                  href={item.disabled ? undefined : item.href}
+                  className="ori-mobile-tab-bar__link"
+                  aria-current={ariaCurrent}
+                  aria-disabled={ariaDisabled}
+                  onClick={(event) => {
+                    if (item.disabled) {
+                      event.preventDefault();
+                      return;
+                    }
+                    onSelect?.(item, event);
+                  }}
+                >
+                  {content}
+                </a>
+              ) : (
+                <button
+                  type="button"
+                  className="ori-mobile-tab-bar__link"
+                  aria-current={ariaCurrent}
+                  aria-disabled={ariaDisabled}
+                  disabled={item.disabled}
+                  onClick={(event) => onSelect?.(item, event)}
+                >
+                  {content}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/packages/react/src/components/MobileTabBar/index.ts
+++ b/packages/react/src/components/MobileTabBar/index.ts
@@ -1,0 +1,2 @@
+export { MobileTabBar } from './MobileTabBar.js';
+export type { MobileTabBarProps, MobileTabBarItem } from './MobileTabBar.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -43,6 +43,7 @@ export * from './components/Logo/index.js';
 export * from './components/Header/index.js';
 export * from './components/Footer/index.js';
 export * from './components/MainNavigation/index.js';
+export * from './components/MobileTabBar/index.js';
 export * from './components/SideMenu/index.js';
 export * from './components/LanguageSwitcher/index.js';
 export * from './components/ErrorPage/index.js';

--- a/packages/tailwind-preset/src/plugin-components.js
+++ b/packages/tailwind-preset/src/plugin-components.js
@@ -4082,6 +4082,121 @@ export function componentsPlugin({ addComponents, addBase, theme }) {
       color: v('text-secondary'),
       lineHeight: theme('lineHeight.normal'),
     },
+
+    // ─── MobileTabBar (issue #94) ──────────────────────────────────────────
+    // Barre de navigation fixée en bas d'écran, pattern UX mobile standard
+    // (Material BottomNavigation, iOS TabBar). 3 à 5 items, chacun = icône
+    // au-dessus du label, layout flex équi-réparti. Masquée par défaut au
+    // dessus du breakpoint md (768px) : sur desktop, c'est le Header +
+    // SideMenu qui assument la navigation.
+    '.ori-mobile-tab-bar': {
+      position: 'fixed',
+      insetBlockEnd: '0',
+      insetInline: '0',
+      zIndex: '20',
+      backgroundColor: v('surface-base'),
+      borderBlockStartWidth: '1px',
+      borderBlockStartStyle: 'solid',
+      borderBlockStartColor: v('border-subtle'),
+      // Respecte le safe-area iOS (notch / home indicator).
+      paddingBlockEnd: 'env(safe-area-inset-bottom, 0)',
+      // Masquage automatique au-dessus du breakpoint md. La classe
+      // .ori-mobile-tab-bar--always-visible permet de forcer l'affichage
+      // si l'app le justifie.
+      '@media (min-width: 768px)': {
+        display: 'none',
+      },
+    },
+    '.ori-mobile-tab-bar--always-visible': {
+      '@media (min-width: 768px)': {
+        display: 'block',
+      },
+    },
+    '.ori-mobile-tab-bar__list': {
+      display: 'flex',
+      flexDirection: 'row',
+      margin: '0',
+      padding: '0',
+      listStyle: 'none',
+    },
+    '.ori-mobile-tab-bar__item': {
+      flex: '1 1 0',
+      display: 'flex',
+    },
+    '.ori-mobile-tab-bar__link': {
+      flex: '1 1 0',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: theme('spacing.1'),
+      paddingBlock: theme('spacing.2'),
+      paddingInline: theme('spacing.1'),
+      // 56px minimum pour respecter le touch target sur la cible tactile,
+      // sans dépendre uniquement de la règle @media (pointer: coarse).
+      minBlockSize: '3.5rem',
+      fontFamily: theme('fontFamily.sans'),
+      fontSize: theme('fontSize.xs'),
+      fontWeight: theme('fontWeight.medium'),
+      lineHeight: theme('lineHeight.tight'),
+      color: v('text-secondary'),
+      backgroundColor: 'transparent',
+      borderWidth: '0',
+      textDecoration: 'none',
+      cursor: 'pointer',
+      position: 'relative',
+      transitionProperty: 'color, background-color',
+      transitionDuration: theme('transitionDuration.fast'),
+      transitionTimingFunction: theme('transitionTimingFunction.standard'),
+      '&:hover:not([aria-current="page"])': {
+        color: v('text-primary'),
+        backgroundColor: v('surface-subtle'),
+      },
+      '&:focus-visible': {
+        outline: 'none',
+        boxShadow: `inset 0 0 0 2px ${v('border-focus')}`,
+      },
+      '&[aria-current="page"]': {
+        color: v('brand-primary'),
+        fontWeight: theme('fontWeight.semibold'),
+      },
+      '&[aria-disabled="true"]': {
+        opacity: '0.5',
+        cursor: 'not-allowed',
+      },
+    },
+    '.ori-mobile-tab-bar__icon': {
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '1.5rem',
+      height: '1.5rem',
+      flex: '0 0 auto',
+    },
+    '.ori-mobile-tab-bar__label': {
+      flex: '0 0 auto',
+      // Empêche un libellé long de casser la mise en page : ellipsis.
+      maxWidth: '100%',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    },
+    '.ori-mobile-tab-bar__badge': {
+      position: 'absolute',
+      insetBlockStart: theme('spacing.1'),
+      // Décalage horizontal à droite du centre, en débordement de l'icône.
+      insetInlineStart: 'calc(50% + 0.25rem)',
+      minWidth: '1.125rem',
+      height: '1.125rem',
+      paddingInline: theme('spacing.1'),
+      backgroundColor: v('feedback-danger'),
+      color: v('brand-on-primary'),
+      borderRadius: '9999px',
+      fontSize: '0.6875rem',
+      fontWeight: theme('fontWeight.semibold'),
+      lineHeight: '1.125rem',
+      textAlign: 'center',
+    },
   });
 
   // ─── Touch targets (issue #94) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Troisième et dernière action court terme de l'issue #94. Composant explicitement mobile : barre de navigation fixée en bas d'écran, pattern UX standard Material BottomNavigation / iOS TabBar.

3 à 5 items, chacun = icône au-dessus d'un label court. Items rendus en `<a>` ou `<button>` selon qu'un `href` est fourni. **Acquis fonctionnel repris de PF-UI**, premier composant explicitement mobile dans Ori.

## API

React :

```tsx
<MobileTabBar
  items={[
    { id: 'home', label: 'Accueil', icon: <Home size={20} />, current: true },
    { id: 'demarches', label: 'Démarches', icon: <FileText size={20} />, badge: 2 },
    { id: 'profil', label: 'Profil', icon: <User size={20} /> },
  ]}
  onSelect={(item) => router.push(`/${item.id}`)}
/>
```

Angular :

```html
<ori-mobile-tab-bar
  [items]="[
    { id: 'home', label: 'Accueil', icon: HomeIcon, current: true },
    { id: 'demarches', label: 'Démarches', icon: FileTextIcon, badge: 2 },
    { id: 'profil', label: 'Profil', icon: UserIcon }
  ]"
  (select)="onSelect($event)"
></ori-mobile-tab-bar>
```

## Changements

### `packages/tailwind-preset/src/plugin-components.js`

Nouvelles classes : `.ori-mobile-tab-bar` (container fixed bottom), `__list`, `__item`, `__link`, `__icon`, `__label`, `__badge`. Container masqué par défaut au-dessus de 768px (modificateur `--always-visible` pour forcer). Respecte `env(safe-area-inset-bottom)` pour iPhone home indicator. Touch target 56px sur chaque item.

### `packages/react/src/components/MobileTabBar/`

`MobileTabBar.tsx`, `MobileTabBar.stories.tsx`, `index.ts`. Props : `items` (id, label, href, current, icon, badge, disabled), `alwaysVisible`, `onSelect`. 7 stories. Viewport `mobile360` par défaut, layout fullscreen. Export ajouté à `packages/react/src/index.ts`.

### `packages/angular/src/components/mobile-tab-bar/`

`mobile-tab-bar.component.ts`, `.stories.ts`, `index.ts`. Composant standalone, OnPush, ViewEncapsulation.None. Inputs : `items`, `ariaLabel`, `alwaysVisible`. Output : `(select)`. Icône via `lucide-angular` (LucideIconData), cohérent avec `ori-dropdown-menu`. 7 stories miroir parité React. Export ajouté à `packages/angular/src/public-api.ts`.

## Stories

7 stories par framework :

- Default (4 items, item courant marqué)
- ThreeItems (3 items)
- FiveItems (5 items, max recommandé)
- WithBadges (pastilles de notification)
- WithDisabledItem (item désactivé)
- ButtonsWithCallback (sans href, callback `onSelect` / event `(select)`)
- AlwaysVisible (forcer l'affichage desktop)

## Caractéristiques accessibilité

- `<nav aria-label>` configurable
- `aria-current="page"` sur l'item actif
- `aria-disabled="true"` sur les items désactivés
- `<a href>` pour les items navigables, `<button>` pour les actions
- Focus visible : ombre brand-primary insérée

## Test plan

- [x] Build local des 3 packages CSS / React / Angular OK
- [x] 13 occurrences de `ori-mobile-tab-bar` dans `dist/ori.css`
- [x] `OriMobileTabBarComponent` exporté en Angular
- [x] `MobileTabBar` exporté en React
- [ ] CI verte (Storybook builds React + Angular, a11y, etc.)
- [ ] Validation visuelle dans les 2 Storybooks en viewport mobile360

## Suite de #94

Avec cette PR, les 4 actions court terme de la roadmap mobile sont expédiées :

1. Storybook viewports + page responsive + README à jour (#95)
2. Touch target 44x44 en pointer coarse (#96)
3. MobileTabBar (cette PR)
4. Page `fondations/responsive.mdx` (livrée dans #95)

Bump minor sur `@govpf/ori-react`, `@govpf/ori-angular`, `@govpf/ori-tailwind-preset`, `@govpf/ori-css`. Issue #94 à fermer une fois cette PR mergée.
