### PR TITLE
fix(ci): pinner pnpm/action-setup sur v6.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
@@ -66,7 +66,7 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -87,7 +87,7 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -121,7 +121,7 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -141,7 +141,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -160,7 +160,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -185,7 +185,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -208,7 +208,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -231,7 +231,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -250,7 +250,7 @@ jobs:
     needs: build-packages
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -273,7 +273,7 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
@@ -302,7 +302,7 @@ jobs:
     needs: install
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           # les CHANGELOG (sinon les notes des commits anciens manquent).
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/visual-parity.yml
+++ b/.github/workflows/visual-parity.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.5
         with:
           version: ${{ env.PNPM_VERSION }}
 


### PR DESCRIPTION
## Symptôme

Tous les jobs CI sortent dès `Set up job` :

```
Unable to resolve action `pnpm/action-setup@v6`, unable to find version `v6`
```

Le pipeline CI, Deploy, Release et Visual parity sont tous bloqués depuis le merge de #84 (Dependabot bump) qui a passé l'action de `@v5` à `@v6`.

## Diagnostic

Le tag git `v6` du repo `pnpm/action-setup` existe pourtant (`refs/tags/v6` pointe vers un sha valide), mais le résolveur d'actions GitHub ne le trouve pas dans la liste des releases. Les releases publiées sont `v6.0.0` à `v6.0.5`, sans alias majeur `v6` exposé comme release. Dependabot a fait un bump trop optimiste sur le tag majeur.

## Fix

Pin direct sur la version exacte `v6.0.5` (la plus récente). Plus stable et plus sécurisé qu'un tag mouvant.

15 occurrences remplacées dans 4 workflows :

- `.github/workflows/ci.yml` (12 occurrences)
- `.github/workflows/deploy.yml`
- `.github/workflows/release.yml`
- `.github/workflows/visual-parity.yml`

## Suite

Une fois cette PR mergée, les PR #96 (touch targets) et #97 (MobileTabBar) doivent être rebasées sur main. Avec auto-merge actif sur les deux, GitHub déclenchera le rebase tout seul.

## Test plan

- [ ] CI verte sur cette PR (preuve que `@v6.0.5` se résout bien)
- [ ] Après merge, #96 et #97 rebasent et passent leur CI