### PR TITLE
feat(site): rendre le site documentaire mobile-friendly

### DIFF
--- a/apps/ori-site/src/components/Sidebar.astro
+++ b/apps/ori-site/src/components/Sidebar.astro
@@ -1,10 +1,20 @@
 ---
 interface Props {
   current: string;
+  /** Section principale active (home/components/tokens/examples). Sert
+   *  à mettre l'item actif dans la nav top-mobile du drawer. */
+  headerCurrent?: string;
 }
 
-const { current } = Astro.props;
+const { current, headerCurrent } = Astro.props;
 const base = import.meta.env.BASE_URL;
+
+const topNavItems: { label: string; section: string; href: string }[] = [
+  { label: 'Accueil', section: 'home', href: base },
+  { label: 'Composants', section: 'components', href: `${base}composants/` },
+  { label: 'Fondations', section: 'tokens', href: `${base}fondations/palette/` },
+  { label: 'Exemples', section: 'examples', href: `${base}exemples/` },
+];
 
 interface NavSection {
   title: string;
@@ -129,7 +139,34 @@ const sections: NavSection[] = [
 ];
 ---
 
-<aside class="ori-side-menu site-aside" aria-label="Navigation de la documentation">
+<aside id="site-drawer" class="ori-side-menu site-aside" aria-label="Navigation de la documentation">
+  <nav class="site-aside__top" aria-label="Sections principales (mobile)">
+    <ul class="site-aside__top-list" role="list">
+      {topNavItems.map((item) => (
+        <li>
+          <a
+            class="site-aside__top-link"
+            href={item.href}
+            aria-current={headerCurrent === item.section ? 'page' : undefined}
+          >
+            {item.label}
+          </a>
+        </li>
+      ))}
+      <li>
+        <a
+          class="site-aside__top-link"
+          href="https://github.com/govpf/ori"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+          <span class="site-aside__top-external" aria-hidden="true">↗</span>
+        </a>
+      </li>
+    </ul>
+    <hr class="site-aside__top-divider" />
+  </nav>
   {
     sections.map((section) => (
       <div class="ori-side-menu__section">

--- a/apps/ori-site/src/layouts/BaseLayout.astro
+++ b/apps/ori-site/src/layouts/BaseLayout.astro
@@ -30,6 +30,31 @@ const base = import.meta.env.BASE_URL;
     <div class="site-shell">
       <header class="ori-header site-header">
         <div class="site-header__inner">
+          {variant === 'doc' && (
+            <button
+              type="button"
+              class="site-burger"
+              aria-label="Ouvrir le sommaire de la documentation"
+              aria-controls="site-drawer"
+              aria-expanded="false"
+              data-site-burger
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="3" y1="6" x2="21" y2="6" />
+                <line x1="3" y1="12" x2="21" y2="12" />
+                <line x1="3" y1="18" x2="21" y2="18" />
+              </svg>
+            </button>
+          )}
           <a href={base} class="ori-header__brand site-header__brand">
             <img src={`${base}assets/logo-pf.svg`} alt="" class="site-header__logo" />
             <span>Ori</span>
@@ -106,6 +131,35 @@ const base = import.meta.env.BASE_URL;
           </div>
         </div>
       </footer>
+      {variant === 'doc' && <div class="site-scrim" data-site-scrim hidden></div>}
     </div>
+
+    {variant === 'doc' && (
+      <script is:inline>
+        // Toggle du drawer mobile sur les pages doc. Pilote l'attribut
+        // data-site-drawer="open" sur <body> ; le CSS s'occupe du reste.
+        // Ferme sur clic dans la sidebar (pour ne pas piéger l'utilisateur
+        // après navigation), sur clic du scrim, et sur Escape.
+        (function () {
+          const burger = document.querySelector('[data-site-burger]');
+          const scrim = document.querySelector('[data-site-scrim]');
+          const aside = document.querySelector('.site-aside');
+          if (!burger || !scrim || !aside) return;
+          const setOpen = (open) => {
+            document.body.dataset.siteDrawer = open ? 'open' : '';
+            burger.setAttribute('aria-expanded', String(open));
+            scrim.hidden = !open;
+          };
+          burger.addEventListener('click', () => setOpen(document.body.dataset.siteDrawer !== 'open'));
+          scrim.addEventListener('click', () => setOpen(false));
+          aside.addEventListener('click', (e) => {
+            if (e.target instanceof HTMLAnchorElement) setOpen(false);
+          });
+          document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') setOpen(false);
+          });
+        })();
+      </script>
+    )}
   </body>
 </html>

--- a/apps/ori-site/src/layouts/DocLayout.astro
+++ b/apps/ori-site/src/layouts/DocLayout.astro
@@ -42,7 +42,7 @@ const hasToc = headings.some((h) => h.depth === 2 || h.depth === 3);
 ---
 
 <BaseLayout title={title} description={description} current={headerCurrent ?? 'components'}>
-  <Sidebar current={current} />
+  <Sidebar current={current} headerCurrent={headerCurrent ?? 'components'} />
   <article class="site-content">
     <slot />
   </article>

--- a/apps/ori-site/src/styles/global.css
+++ b/apps/ori-site/src/styles/global.css
@@ -10,6 +10,13 @@
 
 /* ─── Layout du site ─────────────────────────────────────────────────── */
 
+html,
+body {
+  margin: 0;
+  background-color: var(--color-surface-base);
+  color: var(--color-text-primary);
+}
+
 .site-shell {
   min-height: 100vh;
   display: flex;
@@ -85,6 +92,163 @@
   align-self: start;
   max-height: calc(100vh - 6rem);
   overflow-y: auto;
+}
+
+/* ─── Mobile : burger + drawer + grille mono-colonne ─────────────────────
+   Sur < lg (992px) : la TOC est masquée pour donner toute la place au
+   contenu. La sidebar reste visible.
+   Sur < md (768px) : la sidebar bascule en drawer overlay piloté par le
+   burger du header. Le contenu prend toute la largeur. */
+.site-burger {
+  display: none;
+}
+.site-scrim {
+  display: none;
+}
+
+@media (max-width: 991.98px) {
+  .site-toc {
+    display: none;
+  }
+  .site-main--doc:has(.site-toc) {
+    grid-template-columns: 16rem minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 767.98px) {
+  .site-header__inner {
+    gap: 0.75rem;
+    padding-inline: 1rem;
+    justify-content: flex-start;
+  }
+  /* Sur mobile, on masque la nav principale et les actions du header.
+     Les liens correspondants sont relayés en haut du drawer (cf. la
+     section .site-aside__top dans Sidebar.astro). */
+  .site-header__inner > .ori-header__nav,
+  .site-header__inner > .ori-header__actions {
+    display: none;
+  }
+  .site-burger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    background: transparent;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md, 0.375rem);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    flex: 0 0 auto;
+  }
+  .site-burger:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--color-brand-primary-subtle);
+  }
+  .site-burger svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .site-main--doc {
+    display: block;
+    padding: 1rem 1rem 3rem;
+  }
+
+  /* Sidebar en drawer overlay */
+  .site-aside {
+    position: fixed;
+    inset-block: 0;
+    inset-inline-start: 0;
+    z-index: 30;
+    width: min(85%, 20rem);
+    max-width: 100vw;
+    overflow-y: auto;
+    background: var(--color-surface-base);
+    border-inline-end: 1px solid var(--color-border-subtle);
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.12);
+    padding: 1rem 1rem 2rem;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+  }
+  body[data-site-drawer='open'] .site-aside {
+    transform: translateX(0);
+  }
+  body[data-site-drawer='open'] .site-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 25;
+    background: rgba(0, 0, 0, 0.45);
+  }
+
+  /* Empêche le scroll du body quand le drawer est ouvert */
+  body[data-site-drawer='open'] {
+    overflow: hidden;
+  }
+
+  /* Le contenu doc ne doit jamais déborder horizontalement sous la
+     sidebar fermée. */
+  .site-content {
+    max-width: 100%;
+  }
+}
+
+/* ─── Top du drawer mobile : nav principale dupliquée ────────────────────
+   Sur mobile, le burger ouvre le drawer qui doit contenir la fois la
+   navigation principale (Accueil / Composants / Fondations / Exemples)
+   et la sidebar de doc. .site-aside__top n'est rendu que sur les pages
+   variant=doc (cf. Sidebar.astro). On le masque sur desktop pour ne pas
+   dupliquer la nav du header. */
+.site-aside__top {
+  display: none;
+}
+.site-aside__top-list {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.site-aside__top-link {
+  display: flex;
+  align-items: center;
+  min-block-size: 2.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  text-decoration: none;
+  border-radius: var(--radius-md, 0.375rem);
+}
+.site-aside__top-link:hover {
+  background-color: var(--color-surface-muted);
+}
+.site-aside__top-link[aria-current='page'] {
+  background-color: var(--color-brand-primary-subtle);
+  color: var(--color-brand-primary);
+  font-weight: 600;
+}
+.site-aside__top-divider {
+  margin: 0 0 1rem;
+  border: 0;
+  border-top: 1px solid var(--color-border-subtle);
+}
+.site-aside__top-external {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-inline-start: auto;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+@media (max-width: 767.98px) {
+  .site-aside__top {
+    display: block;
+  }
 }
 
 .site-main--landing {
@@ -293,10 +457,14 @@
 
 /* Tableaux markdown alignés sur le visuel .ori-table.
    Le markdown ne peut pas porter de classe - on style donc les éléments
-   nus dans .site-content avec les mêmes choix que le composant Ori. */
+   nus dans .site-content avec les mêmes choix que le composant Ori.
+   `display: block` + `overflow-x: auto` permettent au tableau de scroller
+   horizontalement si ses colonnes débordent du viewport mobile. */
 .site-content table {
+  display: block;
   width: 100%;
   margin: 1rem 0 1.75rem;
+  overflow-x: auto;
   border-collapse: collapse;
   font-size: 0.875rem;
   color: var(--color-text-primary);


### PR DESCRIPTION
## Summary

Avant cette PR, le site `ori.gov.pf` était inutilisable sous 768px : la grille `.site-main--doc` imposait `grid-template-columns: 16rem minmax(0, 1fr)` sans media query, ce qui laissait moins de 110px pour le contenu sur un viewport mobile classique de 360px. Avec une TOC active, c'était pire (480px réservés à la chrome avant même le contenu).

Approche : ajouter le minimum vital de comportement responsif sans refondre la structure du site. Reuse maximum des classes `.ori-*` déjà en place (`.ori-header`, `.ori-side-menu`, `.ori-footer`). Pas de nouveau composant DS.

## Changements

### `BaseLayout.astro`

- Bouton burger SVG inline ajouté dans le header pour le variant `doc` uniquement, à gauche du brand. `aria-controls` vers le drawer, `aria-expanded` toggle.
- Scrim cliquable rendu après le footer (variant `doc` uniquement), `hidden` par défaut.
- Script `is:inline` ~25 lignes qui pilote l'attribut `data-site-drawer` sur le `body`. Toggle au clic burger, fermeture au clic scrim, à `Escape`, et au clic d'un lien dans la sidebar (pour ne pas piéger l'utilisateur après navigation).

### `Sidebar.astro`

- `id="site-drawer"` ajouté pour `aria-controls`.
- Nouvelle section `.site-aside__top` en tête : 4 items principaux (Accueil, Composants, Fondations, Exemples) + lien GitHub. Visible uniquement sur mobile via media query, masquée sur desktop pour ne pas dupliquer la nav du header.
- Nouvelle prop `headerCurrent` pour marquer `aria-current="page"` sur l'item actif.

### `DocLayout.astro`

Passe `headerCurrent` à `Sidebar`.

### `styles/global.css`

- Background explicite sur `html` et `body` (défense en profondeur, `surface-base` blanc).
- **Sous `lg` (992px)** : TOC masquée, grille passe à 2 colonnes au lieu de 3.
- **Sous `md` (768px)** :
  - Sidebar bascule en drawer overlay (`position: fixed`, `width: min(85%, 20rem)`, `translateX(-100%)` par défaut, transition 250ms ease).
  - Scrim noir 45% sur le body pendant l'ouverture. Body scroll bloqué.
  - Grille passe en mono-colonne, padding réduit à 1rem.
  - Nav header et actions GitHub masquées, relayées dans le drawer.
- Tableaux markdown : `display: block` + `overflow-x: auto` pour scroll horizontal sur mobile.
- Burger : 40x40px, focus-visible avec shadow `brand-primary-subtle`, border `default`.

## Test plan

- [x] Validation visuelle locale en viewport 360px (header propre, drawer fonctionnel)
- [x] Build Astro local OK (29 pages)
- [ ] CI verte
- [ ] Validation post-déploiement Pages

## Limitations connues à traiter en PR séparées si besoin

- Sur la home (variant `landing`), pas de burger ni drawer. La nav header reste visible et wrap en flex sous 360px. Acceptable mais améliorable.
- Pas de transition smooth quand on bascule du desktop vers le mobile en redimensionnant la fenêtre (la transition fonctionne uniquement au clic du burger).
